### PR TITLE
readme fixes and appname toggle

### DIFF
--- a/README
+++ b/README
@@ -45,6 +45,8 @@ OPTIONS
               expands over the whole screen (dmenu-like). If width is 0, the window expands to the longest message displayed. A positive x is measured from the left, a negative from  the  right
               side of the screen. Y is measured from the top and down respectevly. see also EXAMPLES show the notification on monitor n.
 
+       -appname 0/1
+              toggle whether to display app name that sent message (e.g. notify-send)  
 
 EXAMPLES
        dunst -geometry x2 Displays a maximum of two lines across the top of the screen.

--- a/dunst.c
+++ b/dunst.c
@@ -57,6 +57,7 @@ static KeySym mask = 0;
 static screen_info scr;
 static dimension_t geometry;
 static int font_h;
+static int display_appname = True;
 
 /* list functions */
 msg_queue_t *append(msg_queue_t *queue, char *msg);
@@ -398,6 +399,8 @@ main(int argc, char *argv[]) {
             }
             i++;
         }
+        else if(!strcmp(argv[i], "-appname"))
+          display_appname = atoi(argv[++i]);
         else
             usage(EXIT_FAILURE);
     }

--- a/dunst_dbus.c
+++ b/dunst_dbus.c
@@ -181,22 +181,29 @@ notify(DBusMessage *dmsg) {
     dbus_message_iter_next( &args );
     dbus_message_iter_get_basic(&args, &expires);
 
-
     if(strlen(body) > 0) {
         msg = malloc(
-                  strlen(appname)
+                  display_appname ? strlen(appname) : 0
                  +strlen(summary)
                  +strlen(body)
                  +strlen(":  -- ")
                  +5);
-        sprintf(msg, "%s: %s -- %s", appname, summary, body);
+        if (display_appname) {
+            sprintf(msg, "%s: %s -- %s", appname, summary, body);
+        } else {
+          sprintf(msg, "%s -- %s", summary, body);
+        }
     } else {
         msg = malloc(
-                  strlen(appname)
+                  (display_appname ? strlen(appname) : 0)
                  +strlen(summary)
                  +strlen(": ")
                  +5);
-        sprintf(msg, "%s: %s", appname, summary);
+   if (display_appname) {
+          sprintf(msg, "%s: %s", appname, summary);
+      } else {
+          sprintf(msg, "%s", summary);
+      }
     }
 
     msgqueue = append(msgqueue, msg);


### PR DESCRIPTION
Very cool app!

I fixed a couple mistakes in README and added a toggle for the appname. The problem is 99% of the time, for me at least, it shows notify-send which isn't very interesting. 

I don't know C so sorry if there are mistakes. Wasn't sure about option convention including naming (-appname or --disable-appname or --appname=x), or how to write options (0/1). Feel free to change.

Probably the only thing I'm missing with this is icons. If you stick with all text might still be nice to allow displaying the name of the icon. With notify-send I use -i info and -i alert and -i appname a lot. Maybe display it with the same syntax as appname currently.
