### PR TITLE
Remove unnecessary dependencies

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -7,7 +7,7 @@ X11LIB = /usr/X11R6/lib
 
 # Xft, comment if you don't want it
 XFTINC = -I/usr/include/freetype2
-XFTLIBS  = -lXft -lXrender -lfreetype -lz -lfontconfig
+XFTLIBS  = -lXft
 
 # Xinerama, comment if you don't want it
 XINERAMALIBS  = -lXinerama
@@ -18,7 +18,7 @@ INIFLAGS = -DINI_ALLOW_MULTILINE=0
 
 # includes and libs
 INCS = -I${X11INC} -I/usr/lib/dbus-1.0/include -I/usr/include/dbus-1.0 ${XFTINC}
-LIBS = -L${X11LIB} -lX11 -lXext -lXss -ldbus-1 ${XFTLIBS} -lpthread -lrt ${XINERAMALIBS}
+LIBS = -L${X11LIB} -lX11 -lXss -ldbus-1 ${XFTLIBS} ${XINERAMALIBS}
 
 # flags
 CPPFLAGS = -D_BSD_SOURCE -DVERSION=\"${VERSION}\" ${XINERAMAFLAGS} ${INIFLAGS}


### PR DESCRIPTION
I’m not entirely sure about this (maybe I’m missing something), but when building the debian package, our QA tools complain that you link against these libraries without ever using any of their symbols.

And in fact, after removing them, dunst still compiles and works fine.
