### PR TITLE
Implemented bouncing text

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -18,6 +18,7 @@ int indicate_hidden = True;     /* show count of hidden messages */
 int idle_threshold = 0;         /* don't timeout notifications when idle for x seconds */
 int show_age_threshold = -1;    /* show age of notification, when notification is older than x seconds */
 enum alignment align = left;    /* text alignment [left/center/right] */
+float bounce_freq = 1;          /* determines the bounce frequency (if activated) */
 int sticky_history = True;
 int verbosity = 0;
 int word_wrap = False;

--- a/config.mk
+++ b/config.mk
@@ -23,7 +23,7 @@ INIFLAGS = -DINI_ALLOW_MULTILINE=0
 
 # includes and libs
 INCS = -I${X11INC} $(shell pkg-config --cflags dbus-1 libxdg-basedir) ${XFTINC}
-LIBS = -L${X11LIB} -lX11 -lXss ${XFTLIBS} ${XINERAMALIBS} $(shell pkg-config --libs dbus-1 libxdg-basedir)
+LIBS = -lm -L${X11LIB} -lX11 -lXss ${XFTLIBS} ${XINERAMALIBS} $(shell pkg-config --libs dbus-1 libxdg-basedir)
 
 # flags
 CPPFLAGS += -D_BSD_SOURCE -DVERSION=\"${VERSION}\" ${XINERAMAFLAGS} ${INIFLAGS}

--- a/dunstrc
+++ b/dunstrc
@@ -19,6 +19,9 @@
     # Possible values are "left", "center" and "right"
     alignment = left
 
+    # determines the bounce frequency (in hz, 0 to disable)
+    bounce_freq = 0
+
     # show age of message if message is older than show_age_threshold seconds.
     # set to -1 to disable
     show_age_threshold = 60;


### PR DESCRIPTION
In this patch I implemented a feature I called "bouncing text".
When the text is too long and no wrap is enabled, the text can bounce from one side to another in order to enable a full visualization.

A new parameter was added to the config, called "bounce_freq", determining the speed of the text.
The motion of the text is controlled using a sin function.
