### PR TITLE
change index for null-termination of dmenu output

### DIFF
--- a/dunst.c
+++ b/dunst.c
@@ -217,7 +217,7 @@ void context_menu(void) {
         size_t len = read(parent_io[0], buf, 1023);
         if (len == 0)
             return;
-        buf[len - 1] = '\0';
+        buf[len] = '\0';
 
         int status;
         waitpid(pid, &status, 0);


### PR DESCRIPTION
The index used to null-terminate the buffer containing the output of
dmenu has been changed from len-1 to len: before this change the last
character of the url had been ripped off. The access to this character
is legitimate because the buffer is preallocate to 1024 and data from
read are truncated at 1023.
