### PR TITLE
Fix unreliable timeouts

### DIFF
--- a/dunst.c
+++ b/dunst.c
@@ -193,7 +193,7 @@ static int get_sleep_time(void)
 
                 max_age = MAX(max_age, notification_get_age(n));
                 int ttl = notification_get_ttl(n);
-                if (ttl > 0) {
+                if (ttl >= 0) {
                         if (have_ttl) {
                                 min_ttl = MIN(min_ttl, ttl);
                         } else {

--- a/notification.c
+++ b/notification.c
@@ -520,7 +520,7 @@ void notification_update_text_to_render(notification *n)
 
 int notification_get_ttl(notification *n) {
         if (n->timeout == 0) {
-                return 0;
+                return -1;
         } else {
                 return n->timeout - (time(NULL) - n->start);
         }


### PR DESCRIPTION
These commits should fix unreliable timeouts and window updates

I also changed the timer resoultion to seconds instead of milliseconds. It is not important whether a notification is shown for 9.5 or 10.5 seconds.
