### PR TITLE
Add "show_indicators" option

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -22,6 +22,7 @@ int show_age_threshold = -1;    /* show age of notification, when notification i
 enum alignment align = left;    /* text alignment [left/center/right] */
 float bounce_freq = 1;          /* determines the bounce frequency (if activated) */
 int sticky_history = True;
+int show_indicators = True;
 int verbosity = 0;
 int word_wrap = False;
 int ignore_newline = False;

--- a/dunstrc
+++ b/dunstrc
@@ -92,6 +92,9 @@
     # timeout as if it would normally do.
     sticky_history = yes
 
+    # Display indicators for URLs (U) and actions (A)
+    show_indicators = yes
+
     # The height of a single line. If the height is smaller than the font height,
     # it will get raised to the font height.
     # This adds empty space above and under the text.

--- a/notification.c
+++ b/notification.c
@@ -501,12 +501,13 @@ void notification_update_text_to_render(notification *n)
         char *msg = g_strstrip(n->msg);
 
         /* print dup_count and msg */
-        if (n->dup_count > 0 && (n->actions || n->urls)) {
+        if (n->dup_count > 0 && (n->actions || n->urls)
+            && settings.show_indicators) {
                 buf = g_strdup_printf("(%d%s%s) %s",
                                       n->dup_count,
                                       n->actions ? "A" : "",
                                       n->urls ? "U" : "", msg);
-        } else if (n->actions || n->urls) {
+        } else if ((n->actions || n->urls) && settings.show_indicators) {
                 buf = g_strdup_printf("(%s%s) %s",
                                       n->actions ? "A" : "",
                                       n->urls ? "U" : "", msg);

--- a/settings.c
+++ b/settings.c
@@ -138,6 +138,10 @@ void load_settings(char *cmdline_config_path)
             option_get_bool("global", "sticky_history", "-sticky_history",
                             sticky_history,
                             "Don't timeout notifications popped up from history");
+        settings.show_indicators =
+            option_get_bool("global", "show_indicators", "-show_indicators",
+			    show_indicators,
+			    "Show indicators for actions \"(A)\" and URLs \"(U)\"");
         settings.separator_height =
             option_get_int("global", "separator_height",
                            "-sep_height/-separator_height", separator_height,

--- a/settings.h
+++ b/settings.h
@@ -23,6 +23,7 @@ typedef struct _settings {
         enum alignment align;
         float bounce_freq;
         int sticky_history;
+	int show_indicators;
         int verbosity;
         int word_wrap;
         int ignore_newline;


### PR DESCRIPTION
Add an option for disabling marking messages containing URLs or actions.
This means that messages will not be displayed with "(U)" or "(A)"
before them, but you can still use the context menu on them.
