### PR TITLE
Remove config.h with `make clean`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ debug: ${OBJ}
 clean:
 	@echo cleaning
 	rm -f ${OBJ}
+	rm -f config.h
 	rm -f dunst
 	rm -f dunst.1
 	rm -f org.knopwob.dunst.service


### PR DESCRIPTION
I got a compilation error after pulling the changes merged in #117:

```
settings.c: In function `load_settings`:
settings.c:143:8: error: `show_indicators` undeclared (first use in this function)
        show_indicators,
        ^
settings.c:143:8: note: each undeclared identifier is reported only once for each function it appears in
```

Turns out that a new variable has been declared in `config.def.h` but I already had a `config.h` generated from it before and the Makefile doesn't regenerates it when it already exists.

I think it is appropriate to remove `config.h` with `make clean` since it's a byproduct of the make process and depends on `config.def.h`.
