### PR TITLE
Feature: Support backslash escapes in format to embed quotes (and tabs, etc)

### DIFF
--- a/dunstify.c
+++ b/dunstify.c
@@ -199,7 +199,7 @@ void closed(NotifyNotification *n, gpointer foo)
 void add_action(NotifyNotification *n, char *str)
 {
     char *action = str;
-    char *label = strstr(str, ",");
+    char *label = strchr(str, ',');
 
     if (!label || *(label+1) == '\0') {
         g_printerr("Malformed action. Excpected \"action,label\", got \"%s\"", str);
@@ -215,14 +215,14 @@ void add_action(NotifyNotification *n, char *str)
 void add_hint(NotifyNotification *n, char *str)
 {
     char *type = str;
-    char *name = strstr(str, ":");
+    char *name = strchr(str, ':');
     if (!name || *(name+1) == '\0') {
         g_printerr("Malformed hint. Expected \"type:name:value\", got \"%s\"", str);
         return;
     }
     *name = '\0';
     name++;
-    char *value = strstr(name, ":");
+    char *value = strchr(name, ':');
     if (!value || *(value+1) == '\0') {
         g_printerr("Malformed hint. Expected \"type:name:value\", got \"%s\"", str);
         return;

--- a/notification.c
+++ b/notification.c
@@ -281,7 +281,8 @@ int notification_init(notification * n, int id)
 
         n->urls = notification_extract_markup_urls(&(n->body));
 
-        n->msg = string_replace("%a", n->appname, g_strdup(n->format));
+        n->msg = string_replace_all("\\n", "\n", g_strdup(n->format));
+        n->msg = string_replace("%a", n->appname, n->msg);
         n->msg = string_replace("%s", n->summary, n->msg);
         if (n->icon) {
                 n->msg = string_replace("%I", basename(n->icon), n->msg);
@@ -302,9 +303,6 @@ int notification_init(notification * n, int id)
                 n->msg = string_replace("<br>", "\n", n->msg);
                 n->msg = string_replace("<br />", "\n", n->msg);
         }
-
-        while (strstr(n->msg, "\\n") != NULL)
-                n->msg = string_replace("\\n", "\n", n->msg);
 
         if (settings.ignore_newline)
                 while (strstr(n->msg, "\n") != NULL)

--- a/notification.c
+++ b/notification.c
@@ -305,8 +305,7 @@ int notification_init(notification * n, int id)
         }
 
         if (settings.ignore_newline)
-                while (strstr(n->msg, "\n") != NULL)
-                        n->msg = string_replace("\n", " ", n->msg);
+                n->msg = string_replace_char('\n', ' ', n->msg);
 
         n->msg = g_strstrip(n->msg);
 

--- a/notification.c
+++ b/notification.c
@@ -281,7 +281,7 @@ int notification_init(notification * n, int id)
 
         n->urls = notification_extract_markup_urls(&(n->body));
 
-        n->msg = string_replace_all("\\n", "\n", g_strdup(n->format));
+        n->msg = g_strdup(n->format);
         n->msg = string_replace("%a", n->appname, n->msg);
         n->msg = string_replace("%s", n->summary, n->msg);
         if (n->icon) {

--- a/option_parser.c
+++ b/option_parser.c
@@ -208,7 +208,7 @@ int load_ini_file(FILE * fp)
                         continue;
 
                 if (*start == '[') {
-                        char *end = strstr(start + 1, "]");
+                        char *end = strchr(start + 1, ']');
                         if (!end) {
                                 printf
                                     ("Warning: invalid config file at line %d\n",
@@ -226,7 +226,7 @@ int load_ini_file(FILE * fp)
                         continue;
                 }
 
-                char *equal = strstr(start + 1, "=");
+                char *equal = strchr(start + 1, '=');
                 if (!equal) {
                         printf("Warning: invalid config file at line %d\n",
                                line_num);
@@ -238,9 +238,9 @@ int load_ini_file(FILE * fp)
                 char *key = g_strstrip(start);
                 char *value = g_strstrip(equal + 1);
 
-                char *quote = strstr(value, "\"");
+                char *quote = strchr(value, '"');
                 if (quote) {
-                        char *closing_quote = strstr(quote + 1, "\"");
+                        char *closing_quote = strchr(quote + 1, '"');
                         if (!closing_quote) {
                                 printf
                                     ("Warning: invalid config file at line %d\n",
@@ -251,9 +251,7 @@ int load_ini_file(FILE * fp)
 
                         closing_quote = '\0';
                 } else {
-                        char *comment = strstr(value, "#");
-                        if (!comment)
-                                comment = strstr(value, ";");
+                        char *comment = strpbrk(value, "#;");
                         if (comment)
                                 comment = '\0';
                 }
@@ -285,7 +283,7 @@ int cmdline_find_option(char *key)
                 return -1;
         }
         char *key1 = g_strdup(key);
-        char *key2 = strstr(key1, "/");
+        char *key2 = strchr(key1, '/');
 
         if (key2) {
                 *key2 = '\0';

--- a/option_parser.c
+++ b/option_parser.c
@@ -240,11 +240,24 @@ int load_ini_file(FILE * fp)
 
                 gboolean in_quote = 0;
                 char *unparsed = value;
-                while ((unparsed = strpbrk(unparsed, "\"#;")) != NULL) {
+                while ((unparsed = strpbrk(unparsed, "\"\\#;")) != NULL) {
                         switch (*unparsed) {
                         case '"':
                                 g_memmove(unparsed, unparsed + 1, strlen(unparsed));
                                 in_quote = !in_quote;
+                                break;
+                        case '\\':
+                                g_memmove(unparsed, unparsed + 1, strlen(unparsed));
+                                switch (*unparsed) {
+                                case 'n': *unparsed = '\n'; break;
+                                case 't': *unparsed = '\t'; break;
+                                case '"': break;
+                                case '\\': break;
+                                default:
+                                        printf("Warning: invalid backslash sequence '\\%c' on line %d\n",
+                                               *unparsed, line_num);
+                                }
+                                unparsed++;
                                 break;
                         case '#':
                         case ';':

--- a/x.c
+++ b/x.c
@@ -1082,7 +1082,7 @@ void x_shortcut_init(keyboard_shortcut * ks)
         if (str == NULL)
                 die("Unable to allocate memory", EXIT_FAILURE);
 
-        while (strstr(str, "+")) {
+        while (strchr(str, '+')) {
                 char *mod = str;
                 while (*str != '+')
                         str++;


### PR DESCRIPTION
The feature:

I would like there to be backslash escapes for values in the INI file. It currently expands `"\n"` -> newline in the format string, but nothing else. There is no way to make a value include a double quote (`"`) character.

The patch:

This makes it recognize `\n`, `\t`, `\"` and `\\`. For anything else, it will print a warning, then include the character after the backslash verbatim (so `\f` would become `f`).

This patchset looks huge; it's not. Only look at the top commit; it is on top of the pull request to fix the parser.
