### PR TITLE
Fix URL matching regex

### DIFF
--- a/menu.c
+++ b/menu.c
@@ -28,7 +28,9 @@ char *extract_urls(const char *to_match)
 
         if (!is_initialized) {
                 char *regex =
-                    "((http[s]?|ftp[s]?)(://))?(www\\.)?[[:alnum:]._-]+\\.[^[:space:].\"<>]{2,}";
+                    "\\b(https?://|ftps?://|news://|mailto:|file://|www\\.)"
+                    "[[:alnum:]\\-\\@;/?:&=%$.+!*\x27,~#]*"
+                    "(\\([[:alnum:]\\-\\@;/?:&=%$.+!*\x27,~#]*\\)|[[:alnum:]\\-\\@;/?:&=%$+*~])+";
                 int ret = regcomp(&cregex, regex, REG_EXTENDED | REG_ICASE);
                 if (ret != 0) {
                         printf("failed to compile regex\n");


### PR DESCRIPTION
The URL matching regex as currently used by dust is too liberal, and will just
match about anything.

Some examples:

  "establishing connection..." => connection...
  "setting volume to [50%]" => 50%]

The following expression is an adapted copy of urxvt's URL matcher.
