### PR TITLE
Set wm class and name

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -5,7 +5,8 @@ dunst - A customizable and lightweight notification-daemon
 =head1 SYNOPSIS
 
 dunst [-geometry geom] [-shrink shrink] [-fn font] [-nf/nb/lf/lb/cf/cb color]
-[-to/nto/lto/cto secs] [-format fmt] [-key key] [-mod mod] [-mon n] [-v]
+[-to/nto/lto/cto secs] [-format fmt] [-key key] [-mod mod] [-mon n]
+[-t/title title] [-c/class class] [-v]
 
 =head1 DESCRIPTION
 
@@ -83,6 +84,14 @@ message displayed. A positive x is measured from the left,
 a negative from the right side of the screen.
 Y is measured from the top and down respectevly.
 see also EXAMPLES show the notification on monitor n.
+
+=item B<-t/-title title>
+
+Define the title of notification windows spawned by dunst.
+
+=item B<-t/-class class>
+
+Define the class of notification windows spawned by dunst.
 
 =item B<-shrink>
 

--- a/config.def.h
+++ b/config.def.h
@@ -15,6 +15,8 @@ char *icons[] = { "info", "info", "emblem-important" }; /* low, normal, critical
 
 unsigned int transparency = 0;  /* transparency */
 char *geom = "0x0";             /* geometry */
+char *title = "Dunst";          /* the title of dunst notification windows */
+char *class = "Dunst";          /* the class of dunst notification windows */
 int shrink = False;             /* shrinking */
 int sort = True;                /* sort messages by urgency */
 int indicate_hidden = True;     /* show count of hidden messages */

--- a/settings.c
+++ b/settings.c
@@ -119,6 +119,12 @@ void load_settings(char *cmdline_config_path)
                         free(c);
                 }
         }
+        settings.title =
+            option_get_string("global", "title", "-t/-title", title,
+                              "Define the title of windows spawned by dunst.");
+        settings.class =
+            option_get_string("global", "class", "-c/-class", class,
+                              "Define the class of windows spawned by dunst.");
         settings.geom =
             option_get_string("global", "geometry", "-geom/-geometry", geom,
                               "Geometry for the window");

--- a/settings.h
+++ b/settings.h
@@ -17,6 +17,8 @@ typedef struct _settings {
         char *icons[3];
         unsigned int transparency;
         char *geom;
+        char *title;
+        char *class;
         int shrink;
         int sort;
         int indicate_hidden;

--- a/x.c
+++ b/x.c
@@ -957,6 +957,22 @@ static void x_set_wm(Window win)
 
         Atom data[2];
 
+        /* set window title */
+        char *title = settings.title != NULL ? settings.title : "Dunst";
+        Atom _net_wm_title =
+                XInternAtom(xctx.dpy, "_NET_WM_NAME", false);
+
+        XStoreName(xctx.dpy, win, title);
+        XChangeProperty(xctx.dpy, win, _net_wm_title,
+                XInternAtom(xctx.dpy, "UTF8_STRING", False), 8,
+                PropModeReplace, (unsigned char *) settings.title, strlen(settings.title));
+
+        /* set window class */
+        char *class = settings.class != NULL ? settings.class : "Dunst";
+        XClassHint classhint = { class, "Dunst" };
+
+        XSetClassHint(xctx.dpy, win, &classhint);
+
         /* set window type */
         Atom net_wm_window_type =
                 XInternAtom(xctx.dpy, "_NET_WM_WINDOW_TYPE", false);


### PR DESCRIPTION
Currently, dunst does not set neither provides a way to set the name and class of the notification windows.

This situation makes it not possible to customize the behaviour of the windows on tiling window managers, (See http://www.haskell.org/haskellwiki/Xmonad/Frequently_asked_questions#Make_new_windows_appear_.27below.27_rather_than_.27above.27_the_current_window and http://xmonad.org/xmonad-docs/xmonad/XMonad-ManageHook.html#v:composeAll).

This PR enable users to configure the class and title of the notification windows.

Possibly related to #68 but not really a fix for that, but can mitigate the issue.
