### PR TITLE
replace 'folder' with 'path' in icon functionality

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -56,7 +56,7 @@ char *browser = "/usr/bin/firefox";
 int max_icon_size = 0;
 
 /* paths to default icons */
-char *icon_folders = "/usr/share/icons/gnome/16x16/status/:/usr/share/icons/gnome/16x16/devices/";
+char *icon_path = "/usr/share/icons/gnome/16x16/status/:/usr/share/icons/gnome/16x16/devices/";
 
 /* follow focus to different monitor and display notifications there?
  * possible values:

--- a/docs/dunst.pod
+++ b/docs/dunst.pod
@@ -383,7 +383,7 @@ Set to 0 to disable icon scaling. (default)
 
 If B<icon_position> is set to off, this setting is ignored.
 
-=item B<icon_folders> (default: "/usr/share/icons/gnome/16x16/status/:/usr/share/icons/gnome/16x16/devices/")
+=item B<icon_path> (default: "/usr/share/icons/gnome/16x16/status/:/usr/share/icons/gnome/16x16/devices/")
 
 Can be set to a colon-separated list of paths to search for icons to use with
 notifications.

--- a/dunstrc
+++ b/dunstrc
@@ -159,7 +159,7 @@
     max_icon_size = 32
 
     # Paths to default icons.
-    icon_folders = /usr/share/icons/gnome/16x16/status/:/usr/share/icons/gnome/16x16/devices/
+    icon_path = /usr/share/icons/gnome/16x16/status/:/usr/share/icons/gnome/16x16/devices/
 
     ### History ###
 

--- a/src/settings.c
+++ b/src/settings.c
@@ -390,9 +390,23 @@ void load_settings(char *cmdline_config_path)
                 "Scale larger icons down to this size, set to 0 to disable"
         );
 
+        // If the deprecated icon_folders option is used,
+        // read it and generate its usage string.
+        if (ini_is_set("global", "icon_folders") || cmdline_is_set("-icon_folders")) {
+                settings.icon_path = option_get_string(
+                        "global",
+                        "icon_folders", "-icon_folders", icon_path,
+                        "folders to default icons (deprecated, please use 'icon_path' instead)"
+                );
+                fprintf(stderr, "Warning: 'icon_folders' is deprecated, please use 'icon_path' instead.\n");
+        }
+        // Read value and generate usage string for icon_path.
+        // If icon_path is set, override icon_folder.
+        // if not, but icon_folder is set, use that instead of the compile time default.
         settings.icon_path = option_get_string(
                 "global",
-                "icon_path", "-icon_path", icon_path,
+                "icon_path", "-icon_path",
+                settings.icon_path ? settings.icon_path : icon_path,
                 "paths to default icons"
         );
 

--- a/src/settings.c
+++ b/src/settings.c
@@ -390,9 +390,9 @@ void load_settings(char *cmdline_config_path)
                 "Scale larger icons down to this size, set to 0 to disable"
         );
 
-        settings.icon_folders = option_get_string(
+        settings.icon_path = option_get_string(
                 "global",
-                "icon_folders", "-icon_folders", icon_folders,
+                "icon_path", "-icon_path", icon_path,
                 "paths to default icons"
         );
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -63,7 +63,7 @@ typedef struct _settings {
         char *browser;
         enum icon_position_t icon_position;
         int max_icon_size;
-        char *icon_folders;
+        char *icon_path;
         enum follow_mode f_mode;
         bool always_run_script;
         keyboard_shortcut close_ks;

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -329,13 +329,13 @@ static GdkPixbuf *get_pixbuf_from_path(char *icon_path)
                 if (icon_path[0] == '/' || icon_path[0] == '~') {
                         pixbuf = get_pixbuf_from_file(icon_path);
                 }
-                /* search in icon_folders */
+                /* search in icon_path */
                 if (pixbuf == NULL) {
-                        char *start = settings.icon_folders,
+                        char *start = settings.icon_path,
                              *end, *current_folder, *maybe_icon_path;
                         do {
                                 end = strchr(start, ':');
-                                if (end == NULL) end = strchr(settings.icon_folders, '\0'); /* end = end of string */
+                                if (end == NULL) end = strchr(settings.icon_path, '\0'); /* end = end of string */
 
                                 current_folder = g_strndup(start, end - start);
                                 /* try svg */


### PR DESCRIPTION
This bothered me.
I replaced all the instances of 'folder' with 'path'.
I tested the icon functionality and it worked, including the relevant configuration option; but please somebody else also look at it because I'm unfamiliar with the code.
