### PR TITLE
Vertical centering and padding

### DIFF
--- a/x.c
+++ b/x.c
@@ -457,6 +457,9 @@ static dimension_t x_render_layout(cairo_t *c, colored_layout *cl, dimension_t d
         if (cl->icon && settings.icon_position == icons_left) {
                 cairo_move_to(c, settings.frame_width + cairo_image_surface_get_width(cl->icon) + 2 * settings.h_padding, bg_y + settings.padding + h/2 - h_text/2);
 	}
+        else if (cl->icon && settings.icon_position == icons_right) {
+		cairo_move_to(c, settings.frame_width + settings.h_padding, bg_y + settings.padding + h/2 - h_text/2);
+	}
         else {
 		cairo_move_to(c, settings.frame_width + settings.h_padding, bg_y + settings.padding);
 	}

--- a/x.c
+++ b/x.c
@@ -430,8 +430,10 @@ static void r_free_layouts(GSList *layouts)
 static dimension_t x_render_layout(cairo_t *c, colored_layout *cl, dimension_t dim, bool first, bool last)
 {
         int h;
+        int h_text;
         pango_layout_get_pixel_size(cl->l, NULL, &h);
         if (cl->icon) {
+		h_text = h;
 	       	h = MAX(cairo_image_surface_get_height(cl->icon), h);
 	}
 
@@ -453,7 +455,7 @@ static dimension_t x_render_layout(cairo_t *c, colored_layout *cl, dimension_t d
 
         dim.y += settings.padding;
         if (cl->icon && settings.icon_position == icons_left) {
-                cairo_move_to(c, cairo_image_surface_get_width(cl->icon) + 2 * settings.h_padding, bg_y + settings.padding );
+                cairo_move_to(c, cairo_image_surface_get_width(cl->icon) + 2 * settings.h_padding, bg_y + settings.padding + h/2 - h_text/2);
 	}
         else {
 		cairo_move_to(c, settings.h_padding, bg_y + settings.padding);

--- a/x.c
+++ b/x.c
@@ -455,10 +455,10 @@ static dimension_t x_render_layout(cairo_t *c, colored_layout *cl, dimension_t d
 
         dim.y += settings.padding;
         if (cl->icon && settings.icon_position == icons_left) {
-                cairo_move_to(c, cairo_image_surface_get_width(cl->icon) + 2 * settings.h_padding, bg_y + settings.padding + h/2 - h_text/2);
+                cairo_move_to(c, settings.frame_width + cairo_image_surface_get_width(cl->icon) + 2 * settings.h_padding, bg_y + settings.padding + h/2 - h_text/2);
 	}
         else {
-		cairo_move_to(c, settings.h_padding, bg_y + settings.padding);
+		cairo_move_to(c, settings.frame_width + settings.h_padding, bg_y + settings.padding);
 	}
         cairo_set_source_rgb(c, cl->fg.r, cl->fg.g, cl->fg.b);
         pango_cairo_update_layout(c, cl->l);
@@ -483,8 +483,8 @@ static dimension_t x_render_layout(cairo_t *c, colored_layout *cl, dimension_t d
                              image_x,
                              image_y = bg_y + settings.padding;
 
-                if (settings.icon_position == icons_left) image_x = settings.h_padding;
-                else image_x = bg_width - settings.h_padding - image_width;
+                if (settings.icon_position == icons_left) image_x = settings.frame_width + settings.h_padding;
+                else image_x = bg_width - settings.h_padding - image_width + settings.frame_width;
 
                 cairo_set_source_surface (c, cl->icon, image_x, image_y);
                 cairo_rectangle (c, image_x, image_y, image_width, image_height);

--- a/x.c
+++ b/x.c
@@ -219,6 +219,7 @@ static dimension_t calculate_dimensions(GSList *layouts)
 
         dim.h += (g_slist_length(layouts) - 1) * settings.separator_height;
         dim.h += g_slist_length(layouts) * settings.padding * 2;
+	dim.h += 2*settings.frame_width;
 
         int text_width = 0, total_width = 0;
         for (GSList *iter = layouts; iter; iter = iter->next) {
@@ -430,7 +431,9 @@ static dimension_t x_render_layout(cairo_t *c, colored_layout *cl, dimension_t d
 {
         int h;
         pango_layout_get_pixel_size(cl->l, NULL, &h);
-        if (cl->icon) h = MAX(cairo_image_surface_get_height(cl->icon), h);
+        if (cl->icon) {
+	       	h = MAX(cairo_image_surface_get_height(cl->icon), h);
+	}
 
         int bg_x = 0;
         int bg_y = dim.y;
@@ -439,22 +442,22 @@ static dimension_t x_render_layout(cairo_t *c, colored_layout *cl, dimension_t d
 
         /* adding frame */
         bg_x += settings.frame_width;
-        if (first) {
-                bg_y += settings.frame_width;
-                bg_height -= settings.frame_width;
-        }
+        bg_y += settings.frame_width;
+        bg_height -= settings.frame_width;
         bg_width -= 2 * settings.frame_width;
-        if (last)
-                bg_height -= settings.frame_width;
+        bg_height += settings.frame_width;
 
         cairo_set_source_rgb(c, cl->bg.r, cl->bg.g, cl->bg.b);
         cairo_rectangle(c, bg_x, bg_y, bg_width, bg_height);
         cairo_fill(c);
 
         dim.y += settings.padding;
-        if (cl->icon && settings.icon_position == icons_left)
-                cairo_move_to(c, cairo_image_surface_get_width(cl->icon) + 2 * settings.h_padding, dim.y);
-        else cairo_move_to(c, settings.h_padding, dim.y);
+        if (cl->icon && settings.icon_position == icons_left) {
+                cairo_move_to(c, cairo_image_surface_get_width(cl->icon) + 2 * settings.h_padding, bg_y + settings.padding );
+	}
+        else {
+		cairo_move_to(c, settings.h_padding, bg_y + settings.padding);
+	}
         cairo_set_source_rgb(c, cl->fg.r, cl->fg.g, cl->fg.b);
         pango_cairo_update_layout(c, cl->l);
         pango_cairo_show_layout(c, cl->l);
@@ -463,7 +466,7 @@ static dimension_t x_render_layout(cairo_t *c, colored_layout *cl, dimension_t d
         if (settings.separator_height > 0 && !last) {
                 cairo_set_source_rgb(c, sep_color.r, sep_color.g, sep_color.b);
 
-                cairo_rectangle(c, settings.frame_width, dim.y,
+                cairo_rectangle(c, settings.frame_width, dim.y + settings.frame_width,
                                 dim.w - 2 * settings.frame_width
                                 , settings.separator_height);
 


### PR DESCRIPTION
I made the text center when the icon is bigger than the text:
![centered text](https://cloud.githubusercontent.com/assets/5983710/3125246/4c20aad0-e787-11e3-914a-ae25fbf9ea1d.png)
This should solve issue #152.

I also edited the way the frames are drawn and the padding is made, with the current behavior icons are not padded correctly when they are bigger than the text (they appear too low and can even overflow out of the window if there is no padding).
With those edits, the icon will appear centered if it's bigger than the text, as shown in the picture above.

**Edit:**
Here is more explanation for why padding should be edited and how it is related to centering. With the current situation, the padding is very inconsistent when having multiple notifications, the separators are taken into account, but not the frame.

Making the padding internal to the frame (like with CSS borders), and not overlapping with it, would be more coherent in my opinion.

Here are some screenshots showing it with the padding set to zero. On the left is the current situation and on the right is the proposed solution.
![padding icons](https://cloud.githubusercontent.com/assets/5983710/3139387/48bd9a74-e8db-11e3-84f6-6b38280dbc67.png)
![padding text](https://cloud.githubusercontent.com/assets/5983710/3139386/48ae1a90-e8db-11e3-931c-b51cfaa177cd.png)
