### PR TITLE
dbus: Fix iterator memory leak

### DIFF
--- a/dbus.c
+++ b/dbus.c
@@ -250,7 +250,7 @@ static void onNotify(GDBusConnection * connection,
                                         timeout = g_variant_get_int32(content);
                                 break;
                         }
-
+                        g_variant_unref(content);
                         idx++;
                 }
 


### PR DESCRIPTION
The manual for g_variant_iter_next_value states the following:

"[..]
Use g_variant_unref() to drop your reference on the return value when
you no longer need it.
[..]"
https://developer.gnome.org/glib/unstable/glib-GVariant.html#g-variant-iter-next-value

For most notifications (I guess), this is not a problem, since the leak
is relatively tiny. However, for notifications that contain big chunks
of binary data, such as those sent out by the new Spotify client, it
adds up fast.

The Spotify notifications in particular contain a rather large
"icon_data" byte array (contained in a dict), which while never recorded
is never-the-less iterated over and allocated, which in turn gives rise to
issue #173.

This fixes #173.
