### PR TITLE
Add Vim modeline for dunstrc.

### DIFF
--- a/dunstrc
+++ b/dunstrc
@@ -239,3 +239,4 @@
 #    summary = *twitter.com*
 #    urgency = normal
 #
+# vim: ft=cfg


### PR DESCRIPTION
With this modeline, the dunstrc gets syntax highlighting in vim by
default.
