### PR TITLE
Fix Makefile to recreate config.h when config.def.h changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ options:
 
 ${OBJ}: config.h config.mk
 
-config.h:
+config.h: config.def.h
 	@echo creating $@ from config.def.h
 	@cp config.def.h $@
 


### PR DESCRIPTION
Changes to config.def.h are not seen by the make system and hence adding options results in compile-errors.
