### PR TITLE
Notifcations that replace another still 'stack'

### DIFF
--- a/notification.c
+++ b/notification.c
@@ -318,7 +318,6 @@ int notification_init(notification * n, int id)
         } else {
                 notification_close_by_id(id, -1);
                 n->id = id;
-
         }
 
         n->dup_count = 0;


### PR DESCRIPTION
I'm using dustify in a volume changing script. If you replace the id of a notification it still acts like its stacking even though you are replacing it.
relavent dunstrc option

```
[global]
stack_duplicates = yes
```

When stack_duplicates = no the behavior does not exist

Example command that duplicates this.

```
dunstify -p -r 8 "Hello World" "Hello o/"
```

Moving the replace id logic to before the stack_duplicates check fixes this
