### PR TITLE
Add g_strdup to argv elements in string_to_argv

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -77,7 +77,7 @@ char **string_to_argv(const char *s)
 
         while (p) {
                 argv = realloc (argv, sizeof (char*) * ++n_spaces);
-                argv[n_spaces-1] = p;
+                argv[n_spaces-1] = g_strdup(p);
                 p = strtok (NULL, " ");
         }
         argv = realloc (argv, sizeof (char*) * (n_spaces+1));


### PR DESCRIPTION
This makes context menus work again on my computer.
