### PR TITLE
Fix/simplify notification_strip_markup

### DIFF
--- a/notification.c
+++ b/notification.c
@@ -163,23 +163,12 @@ void notification_free(notification * n)
          */
 char *notification_strip_markup(char *str)
 {
-        char *replace_buf, *start, *end;
-
         if (str == NULL) {
                 return NULL;
         }
 
         /* strip all tags */
-        while ((start = strstr(str, "<")) != NULL) {
-                end = strstr(start, ">");
-                if (end != NULL) {
-                        replace_buf = strndup(start, end - start + 1);
-                        str = string_replace(replace_buf, "", str);
-                        free(replace_buf);
-                } else {
-                    break;
-                }
-        }
+        string_strip_delimited(str, '<', '>');
 
         /* unquote the remainder */
         str = string_replace_all("&quot;", "\"", str);

--- a/utils.c
+++ b/utils.c
@@ -105,6 +105,21 @@ char **string_to_argv(const char *s)
         return argv;
 }
 
+void string_strip_delimited(char *str, char a, char b)
+{
+        int iread=-1, iwrite=0, copen=0;
+        while (str[++iread] != 0) {
+                if (str[iread] == a) {
+                        ++copen;
+                } else if (str[iread] == b && copen > 0) {
+                        --copen;
+                } else if (copen == 0) {
+                        str[iwrite++] = str[iread];
+                }
+        }
+        str[iwrite] = 0;
+}
+
 int digit_count(int i)
 {
         i = ABS(i);

--- a/utils.c
+++ b/utils.c
@@ -11,10 +11,10 @@
 #include "dunst.h"
 
 char *string_replace_char(char needle, char replacement, char *haystack) {
-    char *current = haystack;
-    while ((current = strchr (current, needle)) != NULL)
-        *current++ = replacement;
-    return haystack;
+        char *current = haystack;
+        while ((current = strchr (current, needle)) != NULL)
+                *current++ = replacement;
+        return haystack;
 }
 
 char *string_replace_at(char *buf, int pos, int len, const char *repl)

--- a/utils.c
+++ b/utils.c
@@ -25,13 +25,21 @@ char *string_replace_at(char *buf, int pos, int len, const char *repl)
         buf_len = strlen(buf);
         repl_len = strlen(repl);
         size = (buf_len - len) + repl_len + 1;
-        tmp = malloc(size);
+
+        if (repl_len <= len) {
+                tmp = buf;
+        } else {
+                tmp = malloc(size);
+        }
 
         memcpy(tmp, buf, pos);
         memcpy(tmp + pos, repl, repl_len);
-        memcpy(tmp + pos + repl_len, buf + pos + len, buf_len - (pos + len) + 1);
+        memmove(tmp + pos + repl_len, buf + pos + len, buf_len - (pos + len) + 1);
 
-        free(buf);
+        if(tmp != buf) {
+                free(buf);
+        }
+
         return tmp;
 }
 

--- a/utils.h
+++ b/utils.h
@@ -17,6 +17,9 @@ char *string_append(char *a, const char *b, const char *sep);
 
 char **string_to_argv(const char *s);
 
+/* strip content between two delimiter characters (inplace) */
+void string_strip_delimited(char *str, char a, char b);
+
 /* exit with an error message */
 void die(char *msg, int exit_value);
 


### PR DESCRIPTION
Some extra tweaks to the markup support, since I noticed that the old strip_markup was also broken:
- Strip markup before interpreting entities.
- Handle _any_ tag uniformly (`<span>`is also handled by pango)
