### PR TITLE
Fixed #241 and adds a command to replace the last notification

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -180,6 +180,11 @@ When paused dunst will not display any notifications but keep all notifications 
 This can for example be wrapped around a screen locker (i3lock, slock) to prevent flickering
 of notifications through the lock and to read all missed notifications after returning to the computer.
 
+Sending a notification with a summary of "DUNST_COMMAND_CLOSEALL" will remove all the notifications.
+Sending a notification with a summary of "DUNST_COMMAND_CLOSE" will remove the most recent notification.
+Sending a notification with a summary of "DUNST_COMMAND_HISTORY" will redisplay the last notification.
+Sending a notification with a summary of "DUNST_COMMAND_REPLACE NEW TEXT" will replace the text on the current notification with the new text.
+
 =head1 CONFIGURATION
 
 An example configuration file is included (usually /usr/share/dunst/dunstrc).

--- a/README.pod
+++ b/README.pod
@@ -181,8 +181,11 @@ This can for example be wrapped around a screen locker (i3lock, slock) to preven
 of notifications through the lock and to read all missed notifications after returning to the computer.
 
 Sending a notification with a summary of "DUNST_COMMAND_CLOSEALL" will remove all the notifications.
+
 Sending a notification with a summary of "DUNST_COMMAND_CLOSE" will remove the most recent notification.
+
 Sending a notification with a summary of "DUNST_COMMAND_HISTORY" will redisplay the last notification.
+
 Sending a notification with a summary of "DUNST_COMMAND_REPLACE NEW TEXT" will replace the text on the current notification with the new text.
 
 =head1 CONFIGURATION

--- a/notification.c
+++ b/notification.c
@@ -330,10 +330,45 @@ int notification_init(notification * n, int id)
                 return 0;
         }
 
-        if (strcmp("DUNST_COMMAND_CLEAR", n->summary) == 0) {
+        if (strcmp("DUNST_COMMAND_CLOSEALL", n->summary) == 0) {
                 move_all_to_history();
                 return 0;
         }
+
+        if (strcmp("DUNST_COMMAND_CLOSE", n->summary) == 0) {
+                if (displayed) {
+                	notification *no = g_queue_peek_head(displayed);
+                    if (no)
+                    	notification_close(no, 2);
+                }
+				return 0;
+        }
+
+		if (strcmp("DUNST_COMMAND_HISTORY", n->summary) == 0) {
+            	history_pop();
+				return 0;
+        }
+
+		if (strncmp("DUNST_COMMAND_REPLACE", n->summary, 21) == 0) {
+				int msglen = strlen(n->summary) - 21;
+				char* msg = (char*) malloc(msglen + 1);
+				msg = strncpy(msg, n->summary + 21, msglen);
+				msg[msglen] = '\0';
+				if (displayed) {
+                	notification *no = g_queue_peek_head(displayed);
+                	if (no && difftime(time(NULL), no->start) <= no->timeout) {
+						no->msg = msg;
+						notification_update_text_to_render(no);
+                        no->start = time(NULL);
+						return 0;							
+					} else {
+						n->summary = msg;
+					}
+				} else {
+					n->summary = msg;
+				}
+		}	
+
 
         n->script = NULL;
         n->text_to_render = NULL;

--- a/notification.c
+++ b/notification.c
@@ -330,6 +330,11 @@ int notification_init(notification * n, int id)
                 return 0;
         }
 
+        if (strcmp("DUNST_COMMAND_CLEAR", n->summary) == 0) {
+                move_all_to_history();
+                return 0;
+        }
+
         n->script = NULL;
         n->text_to_render = NULL;
 

--- a/notification.c
+++ b/notification.c
@@ -337,37 +337,37 @@ int notification_init(notification * n, int id)
 
         if (strcmp("DUNST_COMMAND_CLOSE", n->summary) == 0) {
                 if (displayed) {
-                	notification *no = g_queue_peek_head(displayed);
+                    notification *no = g_queue_peek_head(displayed);
                     if (no)
-                    	notification_close(no, 2);
+                        notification_close(no, 2);
                 }
-				return 0;
+                return 0;
         }
 
-		if (strcmp("DUNST_COMMAND_HISTORY", n->summary) == 0) {
-            	history_pop();
-				return 0;
+        if (strcmp("DUNST_COMMAND_HISTORY", n->summary) == 0) {
+                history_pop();
+                return 0;
         }
 
-		if (strncmp("DUNST_COMMAND_REPLACE", n->summary, 21) == 0) {
-				int msglen = strlen(n->summary) - 21;
-				char* msg = (char*) malloc(msglen + 1);
-				msg = strncpy(msg, n->summary + 21, msglen);
-				msg[msglen] = '\0';
-				if (displayed) {
-                	notification *no = g_queue_peek_head(displayed);
-                	if (no && difftime(time(NULL), no->start) <= no->timeout) {
-						no->msg = msg;
-						notification_update_text_to_render(no);
+        if (strncmp("DUNST_COMMAND_REPLACE", n->summary, 21) == 0) {
+                int msglen = strlen(n->summary) - 21;
+                char* msg = (char*) malloc(msglen + 1);
+                msg = strncpy(msg, n->summary + 21, msglen);
+                msg[msglen] = '\0';
+                if (displayed) {
+                    notification *no = g_queue_peek_head(displayed);
+                    if (no && difftime(time(NULL), no->start) <= no->timeout) {
+                        no->msg = msg;
+                        notification_update_text_to_render(no);
                         no->start = time(NULL);
-						return 0;							
-					} else {
-						n->summary = msg;
-					}
-				} else {
-					n->summary = msg;
-				}
-		}	
+                        return 0;                           
+                    } else {
+                        n->summary = msg;
+                    }
+                } else {
+                    n->summary = msg;
+                }
+        }   
 
 
         n->script = NULL;


### PR DESCRIPTION
This little piece of code allows to clear the message queue, close the last message, call the last message from history or replace the text of thelast notification by sending a message, the same way the program can be (un)paused.

This allows for these actions to be used in scripts.
