### PR TITLE
Fix #281 bad free. Also fix a memory leak.

### DIFF
--- a/src/rules.c
+++ b/src/rules.c
@@ -2,8 +2,6 @@
 
 #include <glib.h>
 #include <fnmatch.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include "dunst.h"
 #include "rules.h"
@@ -23,8 +21,8 @@ void rule_apply(rule_t * r, notification * n)
                 n->plain_text = r->plain_text;
         if (r->new_icon) {
                 if(n->icon)
-                        free(n->icon);
-                n->icon = strdup(r->new_icon);
+                        g_free(n->icon);
+                n->icon = g_strdup(r->new_icon);
         }
         if (r->fg)
                 n->color_strings[ColFG] = r->fg;

--- a/src/rules.c
+++ b/src/rules.c
@@ -2,6 +2,8 @@
 
 #include <glib.h>
 #include <fnmatch.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "dunst.h"
 #include "rules.h"
@@ -19,8 +21,11 @@ void rule_apply(rule_t * r, notification * n)
                 n->allow_markup = r->allow_markup;
         if (r->plain_text != -1)
                 n->plain_text = r->plain_text;
-        if (r->new_icon)
-                n->icon = r->new_icon;
+        if (r->new_icon) {
+                if(n->icon)
+                        free(n->icon);
+                n->icon = strdup(r->new_icon);
+        }
         if (r->fg)
                 n->color_strings[ColFG] = r->fg;
         if (r->bg)


### PR DESCRIPTION
With `n->icon = r->new_icon` and later `free(n->icon)`, `r->new_icon` is wrongly freed. Fix that with strdup.
Also fix an obvious memory leak by the way.

Intended to fix #281.