### PR TITLE
Fix a double free in on_get_capabilities.

### DIFF
--- a/src/dbus.c
+++ b/src/dbus.c
@@ -116,7 +116,6 @@ static void on_get_capabilities(GDBusConnection * connection,
         g_dbus_method_invocation_return_value(invocation, value);
 
         g_dbus_connection_flush(connection, NULL, NULL, NULL);
-        g_variant_unref(value);
 }
 
 static void on_notify(GDBusConnection * connection,


### PR DESCRIPTION
`value` was already being freed by `g_dbus_method_invocation_return_value`.

Fixes #215