### PR TITLE
Fix `#include`s and use only glib for memory management

### DIFF
--- a/src/dbus.c
+++ b/src/dbus.c
@@ -1,15 +1,16 @@
 /* copyright 2013 Sascha Kruse and contributors (see LICENSE for licensing information) */
-
-#include <stdlib.h>
-#include <stdio.h>
-#include <glib.h>
-#include <string.h>
-#include <gio/gio.h>
-#include "dunst.h"
 #include "dbus.h"
+
+#include <gio/gio.h>
+#include <glib.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "dunst.h"
 #include "notification.h"
-#include "utils.h"
 #include "settings.h"
+#include "utils.h"
 
 GDBusConnection *dbus_conn;
 

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -131,10 +131,7 @@ static void on_notify(GDBusConnection * connection,
         gchar *icon = NULL;
         gchar *summary = NULL;
         gchar *body = NULL;
-        Actions *actions = g_malloc(sizeof(Actions));
-        if(actions == NULL) {
-                die("Unable to allocate memory", EXIT_FAILURE);
-        }
+        Actions *actions = g_malloc0(sizeof(Actions));
         gint timeout = -1;
 
         /* hints */
@@ -144,10 +141,6 @@ static void on_notify(GDBusConnection * connection,
         gchar *bgcolor = NULL;
         gchar *category = NULL;
         RawImage *raw_icon = NULL;
-
-        actions->actions = NULL;
-        actions->count = 0;
-        actions->dmenu_str = NULL;
 
         {
                 GVariantIter *iter = g_variant_iter_new(parameters);

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -5,7 +5,6 @@
 #include <glib.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 
 #include "dunst.h"
 #include "notification.h"
@@ -132,7 +131,7 @@ static void on_notify(GDBusConnection * connection,
         gchar *icon = NULL;
         gchar *summary = NULL;
         gchar *body = NULL;
-        Actions *actions = malloc(sizeof(Actions));
+        Actions *actions = g_malloc(sizeof(Actions));
         if(actions == NULL) {
                 die("Unable to allocate memory", EXIT_FAILURE);
         }
@@ -309,13 +308,13 @@ static void on_notify(GDBusConnection * connection,
         n->progress = (progress < 0 || progress > 100) ? 0 : progress + 1;
         n->urgency = urgency;
         n->category = category;
-        n->dbus_client = strdup(sender);
+        n->dbus_client = g_strdup(sender);
         if (actions->count > 0) {
                 n->actions = actions;
         } else {
                 n->actions = NULL;
                 g_strfreev(actions->actions);
-                free(actions);
+                g_free(actions);
         }
 
         for (int i = 0; i < ColLast; i++) {
@@ -434,7 +433,7 @@ static void on_name_lost(GDBusConnection * connection,
 
 static RawImage * get_raw_image_from_data_hint(GVariant *icon_data)
 {
-    RawImage *image = malloc(sizeof(RawImage));
+    RawImage *image = g_malloc(sizeof(RawImage));
     GVariant *data_variant;
     gsize expected_len;
 
@@ -456,7 +455,7 @@ static RawImage * get_raw_image_from_data_hint(GVariant *icon_data)
                " but got a " "length of %" G_GSIZE_FORMAT,
                expected_len,
                g_variant_get_size (data_variant));
-        free(image);
+        g_free(image);
         return NULL;
     }
 

--- a/src/dbus.h
+++ b/src/dbus.h
@@ -3,8 +3,6 @@
 #ifndef DUNST_DBUS_H
 #define DUNST_DBUS_H
 
-#include <dbus/dbus.h>
-
 #include "notification.h"
 
 int initdbus(void);

--- a/src/dunst.c
+++ b/src/dunst.c
@@ -3,41 +3,24 @@
 #define _GNU_SOURCE
 #define XLIB_ILLEGAL_ACCESS
 
-#include <assert.h>
-#include <unistd.h>
-#include <time.h>
-#include <stdio.h>
-#include <ctype.h>
-#include <stdlib.h>
-#include <stdbool.h>
-#include <string.h>
-#include <fnmatch.h>
-#include <sys/time.h>
-#include <math.h>
-#include <errno.h>
-#include <signal.h>
-#include <sys/wait.h>
-#include <glib.h>
-#include <glib-unix.h>
-#include <X11/Xlib.h>
-#include <X11/XKBlib.h>
-#include <X11/Xatom.h>
-#include <X11/Xutil.h>
-#ifdef XINERAMA
-#include <X11/extensions/Xinerama.h>
-#endif
-#include <X11/extensions/scrnsaver.h>
-
 #include "dunst.h"
-#include "x.h"
-#include "dbus.h"
-#include "utils.h"
-#include "rules.h"
-#include "notification.h"
-#include "menu.h"
 
+#include <X11/Xlib.h>
+#include <glib-unix.h>
+#include <glib.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "dbus.h"
+#include "menu.h"
+#include "notification.h"
 #include "option_parser.h"
 #include "settings.h"
+#include "x.h"
 
 #define LENGTH(X)               (sizeof X / sizeof X[0])
 

--- a/src/dunst.c
+++ b/src/dunst.c
@@ -12,7 +12,6 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <time.h>
 
 #include "dbus.h"
@@ -328,9 +327,9 @@ int dunst_main(int argc, char *argv[])
 
         if (settings.startup_notification) {
                 notification *n = notification_create();
-                n->appname = strdup("dunst");
-                n->summary = strdup("startup");
-                n->body = strdup("dunst is up and running");
+                n->appname = g_strdup("dunst");
+                n->summary = g_strdup("startup");
+                n->body = g_strdup("dunst is up and running");
                 n->progress = 0;
                 n->timeout = 10;
                 n->markup = MARKUP_NO;

--- a/src/dunst.h
+++ b/src/dunst.h
@@ -7,7 +7,6 @@
 #include <stdio.h>
 #include <stdbool.h>
 
-#include "x.h"
 #include "notification.h"
 
 #define ERR(msg) printf("%s : %d\n", (msg), __LINE__)

--- a/src/menu.c
+++ b/src/menu.c
@@ -1,20 +1,23 @@
 /* copyright 2013 Sascha Kruse and contributors (see LICENSE for licensing information) */
 
 #define _GNU_SOURCE
-#include <stdlib.h>
-#include <stdbool.h>
-#include <regex.h>
-#include <stdio.h>
-#include <string.h>
-#include <unistd.h>
-#include <errno.h>
-#include <sys/wait.h>
-#include <glib.h>
+#include "menu.h"
 
-#include "dunst.h"
-#include "utils.h"
-#include "settings.h"
+#include <errno.h>
+#include <glib.h>
+#include <regex.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
 #include "dbus.h"
+#include "dunst.h"
+#include "settings.h"
+#include "notification.h"
+#include "utils.h"
 
 static bool is_initialized = false;
 static regex_t cregex;

--- a/src/menu.c
+++ b/src/menu.c
@@ -79,11 +79,11 @@ char *extract_urls(const char *to_match)
                 start = m.rm_so + (p - to_match);
                 finish = m.rm_eo + (p - to_match);
 
-                char *match = strndup(to_match + start, finish - start);
+                char *match = g_strndup(to_match + start, finish - start);
 
                 urls = string_append(urls, match, "\n");
 
-                free(match);
+                g_free(match);
 
                 p += m.rm_eo;
         }
@@ -162,7 +162,7 @@ void invoke_action(const char *action)
  */
 void dispatch_menu_result(const char *input)
 {
-        char *in = strdup(input);
+        char *in = g_strdup(input);
         g_strstrip(in);
         switch (in[0]) {
             case '#':
@@ -177,12 +177,12 @@ void dispatch_menu_result(const char *input)
                     char *maybe_url = extract_urls(in);
                     if (maybe_url) {
                             open_browser(maybe_url);
-                            free(maybe_url);
+                            g_free(maybe_url);
                             break;
                     }
                 }
         }
-        free(in);
+        g_free(in);
 }
 
 /*
@@ -215,12 +215,12 @@ void context_menu(void)
         int parent_io[2];
         if (pipe(child_io) != 0) {
                 PERR("pipe()", errno);
-                free(dmenu_input);
+                g_free(dmenu_input);
                 return;
         }
         if (pipe(parent_io) != 0) {
                 PERR("pipe()", errno);
-                free(dmenu_input);
+                g_free(dmenu_input);
                 return;
         }
         int pid = fork();
@@ -250,7 +250,7 @@ void context_menu(void)
 
                 size_t len = read(parent_io[0], buf, 1023);
                 if (len == 0) {
-                        free(dmenu_input);
+                        g_free(dmenu_input);
                         return;
                 }
 
@@ -262,6 +262,6 @@ void context_menu(void)
 
         dispatch_menu_result(buf);
 
-        free(dmenu_input);
+        g_free(dmenu_input);
 }
 /* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/menu.h
+++ b/src/menu.h
@@ -2,9 +2,6 @@
 #ifndef DUNST_MENU_H
 #define DUNST_MENU_H
 
-#include "dunst.h"
-#include <regex.h>
-
 char *extract_urls(const char *to_match);
 void open_browser(const char *url);
 void invoke_action(const char *action);

--- a/src/notification.c
+++ b/src/notification.c
@@ -323,10 +323,7 @@ char *notification_extract_markup_urls(char **str_ptr) {
  */
 notification *notification_create(void)
 {
-        notification *n = g_malloc(sizeof(notification));
-        if(n == NULL) die("Unable to allocate memory", EXIT_FAILURE);
-        memset(n, 0, sizeof(notification));
-        return n;
+        return g_malloc0(sizeof(notification));
 }
 
 void notification_init_defaults(notification *n)

--- a/src/notification.c
+++ b/src/notification.c
@@ -1,24 +1,26 @@
 /* copyright 2013 Sascha Kruse and contributors (see LICENSE for licensing information) */
 
 #define _GNU_SOURCE
-#include <stdlib.h>
-#include <time.h>
-#include <glib.h>
-#include <errno.h>
-#include <string.h>
-#include <stdbool.h>
-#include <unistd.h>
-#include <sys/wait.h>
+#include "notification.h"
+
 #include <assert.h>
+#include <errno.h>
+#include <glib.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
 
 #include "dbus.h"
-#include "x.h"
-#include "notification.h"
 #include "dunst.h"
-#include "utils.h"
-#include "settings.h"
-#include "rules.h"
 #include "menu.h"
+#include "rules.h"
+#include "settings.h"
+#include "utils.h"
+#include "x.h"
 
 int next_notification_id = 1;
 

--- a/src/notification.c
+++ b/src/notification.c
@@ -168,12 +168,12 @@ int notification_is_duplicate(const notification *a, const notification *b)
 void notification_free(notification * n)
 {
         assert(n != NULL);
-        free(n->appname);
-        free(n->summary);
-        free(n->body);
-        free(n->icon);
-        free(n->msg);
-        free(n->dbus_client);
+        g_free(n->appname);
+        g_free(n->summary);
+        g_free(n->body);
+        g_free(n->icon);
+        g_free(n->msg);
+        g_free(n->dbus_client);
         g_free(n->category);
 
         if (n->text_to_render)
@@ -184,16 +184,16 @@ void notification_free(notification * n)
 
         if (n->actions) {
                 g_strfreev(n->actions->actions);
-                free(n->actions->dmenu_str);
+                g_free(n->actions->dmenu_str);
         }
 
         if (n->raw_icon) {
             if (n->raw_icon->data)
-                free(n->raw_icon->data);
-            free(n->raw_icon);
+                g_free(n->raw_icon->data);
+            g_free(n->raw_icon);
         }
 
-        free(n);
+        g_free(n);
 }
 
 /*
@@ -246,10 +246,10 @@ char *notification_replace_format(const char *needle, const char *replacement,
         char* ret;
 
         if (markup_mode == MARKUP_NO) {
-                tmp = strdup(replacement);
+                tmp = g_strdup(replacement);
                 tmp = notification_quote_markup(tmp);
         } else {
-                tmp = strdup(replacement);
+                tmp = g_strdup(replacement);
                 if (settings.ignore_newline) {
                         tmp = string_replace_all("<br>", " ", tmp);
                         tmp = string_replace_all("<br/>", " ", tmp);
@@ -273,7 +273,7 @@ char *notification_replace_format(const char *needle, const char *replacement,
         }
 
         ret = string_replace_all(needle, tmp, haystack);
-        free(tmp);
+        g_free(tmp);
 
         return ret;
 }
@@ -286,7 +286,7 @@ char *notification_extract_markup_urls(char **str_ptr) {
     while ((start = strstr(str, "<a href")) != NULL) {
         end = strstr(start, ">");
         if (end != NULL) {
-                replace_buf = strndup(start, end - start + 1);
+                replace_buf = g_strndup(start, end - start + 1);
                 url = extract_urls(replace_buf);
                 if (url != NULL) {
                     str = string_replace(replace_buf, "[", str);
@@ -297,18 +297,18 @@ char *notification_extract_markup_urls(char **str_ptr) {
                     } else {
                         char *tmp = urls;
                         urls = g_strconcat(tmp, "\n", index_buf, " ", url, NULL);
-                        free(tmp);
+                        g_free(tmp);
                     }
 
                     index_buf[0] = ' ';
                     str = string_replace("</a>", index_buf, str);
-                    free(index_buf);
-                    free(url);
+                    g_free(index_buf);
+                    g_free(url);
                 } else {
                     str = string_replace(replace_buf, "", str);
                     str = string_replace("</a>", "", str);
                 }
-                free(replace_buf);
+                g_free(replace_buf);
         } else {
                 break;
         }
@@ -323,7 +323,7 @@ char *notification_extract_markup_urls(char **str_ptr) {
  */
 notification *notification_create(void)
 {
-        notification *n = malloc(sizeof(notification));
+        notification *n = g_malloc(sizeof(notification));
         if(n == NULL) die("Unable to allocate memory", EXIT_FAILURE);
         memset(n, 0, sizeof(notification));
         return n;
@@ -398,12 +398,12 @@ int notification_init(notification * n, int id)
         n->msg = g_strchomp(n->msg);
 
         if (n->icon != NULL && strlen(n->icon) <= 0) {
-                free(n->icon);
+                g_free(n->icon);
                 n->icon = NULL;
         }
 
         if (n->raw_icon == NULL && n->icon == NULL) {
-                n->icon = strdup(settings.icons[n->urgency]);
+                n->icon = g_strdup(settings.icons[n->urgency]);
         }
 
         if (id == 0) {
@@ -432,8 +432,8 @@ int notification_init(notification * n, int id)
                                 /* notifications that differ only in progress hints should be expected equal,
                                  * but we want the latest message, with the latest hint value
                                  */
-                                free(orig->msg);
-                                orig->msg = strdup(n->msg);
+                                g_free(orig->msg);
+                                orig->msg = g_strdup(n->msg);
                                 notification_free(n);
                                 wake_up();
                                 return orig->id;
@@ -447,8 +447,8 @@ int notification_init(notification * n, int id)
                                 /* notifications that differ only in progress hints should be expected equal,
                                  * but we want the latest message, with the latest hint value
                                  */
-                                free(orig->msg);
-                                orig->msg = strdup(n->msg);
+                                g_free(orig->msg);
+                                orig->msg = g_strdup(n->msg);
                                 /* If the progress differs this was probably intended to replace the notification
                                  * but notify-send was used. So don't increment dup_count in this case
                                  */
@@ -506,7 +506,7 @@ int notification_init(notification * n, int id)
         if (tmp_urls != NULL) {
             if (n->urls != NULL) {
                 n->urls = string_append(n->urls, tmp_urls, "\n");
-                free(tmp_urls);
+                g_free(tmp_urls);
             } else {
                 n->urls = tmp_urls;
             }
@@ -522,12 +522,12 @@ int notification_init(notification * n, int id)
                         char *act_str = g_strdup_printf("#%s [%s]", human_readable, n->appname);
                         if (act_str) {
                                 n->actions->dmenu_str = string_append(n->actions->dmenu_str, act_str, "\n");
-                                free(act_str);
+                                g_free(act_str);
                         }
                 }
         }
 
-        free(tmp);
+        g_free(tmp);
 
         if (settings.print_notifications)
                 notification_print(n);
@@ -590,7 +590,7 @@ int notification_close(notification * n, int reason)
 void notification_update_text_to_render(notification *n)
 {
         if (n->text_to_render) {
-                free(n->text_to_render);
+                g_free(n->text_to_render);
                 n->text_to_render = NULL;
         }
 
@@ -638,7 +638,7 @@ void notification_update_text_to_render(notification *n)
                         new_buf = g_strdup_printf("%s (%ds old)", buf, seconds);
                 }
 
-                free(buf);
+                g_free(buf);
                 buf = new_buf;
         }
 

--- a/src/notification.h
+++ b/src/notification.h
@@ -2,7 +2,10 @@
 #ifndef DUNST_NOTIFICATION_H
 #define DUNST_NOTIFICATION_H
 
-#include "x.h"
+#include <glib.h>
+#include <stdbool.h>
+#include <time.h>
+
 #include "settings.h"
 
 #define LOW 0

--- a/src/option_parser.c
+++ b/src/option_parser.c
@@ -48,7 +48,7 @@ section_t *new_section(char *name)
         }
 
         section_count++;
-        sections = realloc(sections, sizeof(section_t) * section_count);
+        sections = g_realloc(sections, sizeof(section_t) * section_count);
         if(sections == NULL) die("Unable to allocate memory.\n", 1);
         sections[section_count - 1].name = g_strdup(name);
         sections[section_count - 1].entries = NULL;
@@ -60,13 +60,13 @@ void free_ini(void)
 {
         for (int i = 0; i < section_count; i++) {
                 for (int j = 0; j < sections[i].entry_count; j++) {
-                        free(sections[i].entries[j].key);
-                        free(sections[i].entries[j].value);
+                        g_free(sections[i].entries[j].key);
+                        g_free(sections[i].entries[j].value);
                 }
-                free(sections[i].entries);
-                free(sections[i].name);
+                g_free(sections[i].entries);
+                g_free(sections[i].name);
         }
-        free(sections);
+        g_free(sections);
         section_count = 0;
         sections = NULL;
 }
@@ -90,7 +90,7 @@ void add_entry(char *section_name, char *key, char *value)
 
         s->entry_count++;
         int len = s->entry_count;
-        s->entries = realloc(s->entries, sizeof(entry_t) * len);
+        s->entries = g_realloc(s->entries, sizeof(entry_t) * len);
         s->entries[s->entry_count - 1].key = g_strdup(key);
         s->entries[s->entry_count - 1].value = clean_value(value);
 }
@@ -234,7 +234,7 @@ int load_ini_file(FILE * fp)
                         *end = '\0';
 
                         if (current_section)
-                                free(current_section);
+                                g_free(current_section);
                         current_section = (g_strdup(start + 1));
                         new_section(current_section);
                         continue;
@@ -282,7 +282,7 @@ int load_ini_file(FILE * fp)
         }
         free(line);
         if (current_section)
-                free(current_section);
+                g_free(current_section);
         return 0;
 }
 
@@ -308,7 +308,7 @@ int cmdline_find_option(char *key)
         /* look for first key */
         for (int i = 0; i < cmdline_argc; i++) {
                 if (strcmp(key1, cmdline_argv[i]) == 0) {
-                        free(key1);
+                        g_free(key1);
                         return i;
                 }
         }
@@ -317,13 +317,13 @@ int cmdline_find_option(char *key)
         if (key2) {
                 for (int i = 0; i < cmdline_argc; i++) {
                         if (strcmp(key2, cmdline_argv[i]) == 0) {
-                                free(key1);
+                                g_free(key1);
                                 return i;
                         }
                 }
         }
 
-        free(key1);
+        g_free(key1);
         return -1;
 }
 
@@ -466,16 +466,16 @@ void cmdline_usage_append(char *key, char *type, char *description)
         if (!usage_str) {
                 usage_str =
                     g_strdup_printf("%-40s - %s\n", key_type, description);
-                free(key_type);
+                g_free(key_type);
                 return;
         }
 
         char *tmp;
         tmp =
             g_strdup_printf("%s%-40s - %s\n", usage_str, key_type, description);
-        free(key_type);
+        g_free(key_type);
 
-        free(usage_str);
+        g_free(usage_str);
         usage_str = tmp;
 
 }

--- a/src/option_parser.c
+++ b/src/option_parser.c
@@ -262,12 +262,10 @@ int load_ini_file(FILE * fp)
                                 printf("Missing '\"'\n");
                                 continue;
                         }
-
-                        closing_quote = '\0';
                 } else {
                         char *comment = strpbrk(value, "#;");
                         if (comment)
-                                comment = '\0';
+                                *comment = '\0';
                 }
                 value = g_strstrip(value);
 

--- a/src/option_parser.c
+++ b/src/option_parser.c
@@ -1,15 +1,14 @@
 /* copyright 2013 Sascha Kruse and contributors (see LICENSE for licensing information) */
 
 #define _GNU_SOURCE
+#include "option_parser.h"
 
-#include <string.h>
-#include <stdlib.h>
-#include <unistd.h>
+#include <glib.h>
 #include <stdbool.h>
 #include <stdio.h>
-#include <glib.h>
+#include <stdlib.h>
+#include <string.h>
 
-#include "option_parser.h"
 #include "utils.h"
 
 typedef struct _entry_t {

--- a/src/option_parser.h
+++ b/src/option_parser.h
@@ -2,6 +2,7 @@
 #ifndef DUNST_OPTION_PARSER_H
 #define DUNST_OPTION_PARSER_H
 
+#include <stdbool.h>
 #include <stdio.h>
 
 int load_ini_file(FILE *);

--- a/src/rules.c
+++ b/src/rules.c
@@ -1,10 +1,11 @@
 /* copyright 2013 Sascha Kruse and contributors (see LICENSE for licensing information) */
 
-#include <glib.h>
+#include "rules.h"
+
 #include <fnmatch.h>
+#include <glib.h>
 
 #include "dunst.h"
-#include "rules.h"
 
 /*
  * Apply rule to notification.

--- a/src/rules.h
+++ b/src/rules.h
@@ -3,8 +3,8 @@
 #define DUNST_RULES_H
 
 #include <glib.h>
+#include <stdbool.h>
 
-#include "dunst.h"
 #include "notification.h"
 #include "settings.h"
 

--- a/src/settings.c
+++ b/src/settings.c
@@ -4,7 +4,6 @@
 
 #include <glib.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 #ifndef STATIC_CONFIG
 #include <basedir.h>
@@ -66,7 +65,7 @@ static int ini_get_urgency(char *section, char *key, int def)
                                 urg);
         }
         if (urg)
-                free(urg);
+                g_free(urg);
         return ret;
 }
 
@@ -114,7 +113,7 @@ void load_settings(char *cmdline_config_path)
                         );
 
                         settings.markup = parse_markup_mode(c);
-                        free(c);
+                        g_free(c);
                 } else if (ini_is_set("global", "allow_markup")) {
                         bool allow_markup = option_get_bool(
                                 "global",
@@ -180,7 +179,7 @@ void load_settings(char *cmdline_config_path)
 
                 if (strlen(c) > 0) {
                         parse_follow_mode(c);
-                        free(c);
+                        g_free(c);
                 }
         }
 
@@ -243,7 +242,7 @@ void load_settings(char *cmdline_config_path)
                         else
                                 fprintf(stderr,
                                         "Warning: unknown alignment\n");
-                        free(c);
+                        g_free(c);
                 }
         }
 
@@ -319,7 +318,7 @@ void load_settings(char *cmdline_config_path)
                                 settings.sep_color = CUSTOM;
                                 settings.sep_custom_color_str = g_strdup(c);
                         }
-                        free(c);
+                        g_free(c);
                 }
         }
 
@@ -375,7 +374,7 @@ void load_settings(char *cmdline_config_path)
                         else
                                 fprintf(stderr,
                                         "Warning: unknown icon position: %s\n", c);
-                        free(c);
+                        g_free(c);
                 }
         }
 
@@ -576,7 +575,7 @@ void load_settings(char *cmdline_config_path)
 
                         if (strlen(c) > 0) {
                                 r->markup = parse_markup_mode(c);
-                                free(c);
+                                g_free(c);
                         }
                 }
 

--- a/src/settings.c
+++ b/src/settings.c
@@ -1,19 +1,21 @@
 /* copyright 2013 Sascha Kruse and contributors (see LICENSE for licensing information) */
 
+#include "settings.h"
+
 #include <glib.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
 #ifndef STATIC_CONFIG
 #include <basedir.h>
 #include <basedir_fs.h>
 #endif
 
-#include "dunst.h"
-#include "rules.h"
-#include "option_parser.h"
-#include "settings.h"
+#include "rules.h" // put before config.h to fix missing include
 #include "config.h"
+#include "dunst.h"
+#include "notification.h"
+#include "option_parser.h"
 #include "utils.h"
 
 settings_t settings;

--- a/src/settings.h
+++ b/src/settings.h
@@ -2,6 +2,10 @@
 #ifndef DUNST_SETTINGS_H
 #define DUNST_SETTINGS_H
 
+#include <stdbool.h>
+
+#include "x.h"
+
 enum alignment { left, center, right };
 enum icon_position_t { icons_left, icons_right, icons_off };
 enum separator_color { FOREGROUND, AUTO, FRAME, CUSTOM };

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,14 +1,11 @@
 /* copyright 2013 Sascha Kruse and contributors (see LICENSE for licensing information) */
 #define _GNU_SOURCE
-
-#include <string.h>
-#include <ctype.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <glib.h>
-
 #include "utils.h"
-#include "dunst.h"
+
+#include <glib.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 char *string_replace_char(char needle, char replacement, char *haystack) {
         char *current = haystack;

--- a/src/utils.c
+++ b/src/utils.c
@@ -26,7 +26,7 @@ char *string_replace_at(char *buf, int pos, int len, const char *repl)
         if (repl_len <= len) {
                 tmp = buf;
         } else {
-                tmp = malloc(size);
+                tmp = g_malloc(size);
         }
 
         memcpy(tmp, buf, pos);
@@ -34,7 +34,7 @@ char *string_replace_at(char *buf, int pos, int len, const char *repl)
         memmove(tmp + pos + repl_len, buf + pos + len, buf_len - (pos + len) + 1);
 
         if(tmp != buf) {
-                free(buf);
+                g_free(buf);
         }
 
         return tmp;
@@ -84,7 +84,7 @@ char *string_append(char *a, const char *b, const char *sep)
                 new = g_strconcat(a, b, NULL);
         else
                 new = g_strconcat(a, sep, b, NULL);
-        free(a);
+        g_free(a);
 
         return new;
 

--- a/src/x.c
+++ b/src/x.c
@@ -385,9 +385,6 @@ static GdkPixbuf *get_pixbuf_from_raw_image(const RawImage *raw_image)
 static colored_layout *r_init_shared(cairo_t *c, notification *n)
 {
         colored_layout *cl = g_malloc(sizeof(colored_layout));
-        if(cl == NULL) {
-                die("Unable to allocate memory", EXIT_FAILURE);
-        }
         cl->l = pango_cairo_create_layout(c);
 
         if (!settings.word_wrap) {

--- a/src/x.c
+++ b/src/x.c
@@ -1,26 +1,30 @@
 /* copyright 2013 Sascha Kruse and contributors (see LICENSE for licensing information) */
-#include <math.h>
-#include <sys/time.h>
-#include <ctype.h>
-#include <assert.h>
-#include <locale.h>
-#include <stdarg.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <stdbool.h>
-#include <string.h>
-#include <X11/Xlib.h>
+#include "x.h"
+
 #include <X11/X.h>
+#include <X11/XKBlib.h>
 #include <X11/Xatom.h>
-#include <pango/pangocairo.h>
+#include <X11/Xlib.h>
+#include <X11/Xutil.h>
+#ifdef XINERAMA
+#include <X11/extensions/Xinerama.h>
+#include <assert.h>
+#endif
 #include <cairo-xlib.h>
 #include <gdk/gdk.h>
+#include <locale.h>
+#include <math.h>
+#include <pango/pangocairo.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
 
-#include "x.h"
-#include "utils.h"
 #include "dunst.h"
-#include "settings.h"
 #include "notification.h"
+#include "settings.h"
+#include "utils.h"
 
 #define WIDTH 400
 #define HEIGHT 400

--- a/src/x.c
+++ b/src/x.c
@@ -336,14 +336,14 @@ static GdkPixbuf *get_pixbuf_from_path(char *icon_path)
                                 end = strchr(start, ':');
                                 if (end == NULL) end = strchr(settings.icon_folders, '\0'); /* end = end of string */
 
-                                current_folder = strndup(start, end - start);
+                                current_folder = g_strndup(start, end - start);
                                 /* try svg */
                                 maybe_icon_path = g_strconcat(current_folder, "/", icon_path, ".svg", NULL);
                                 if (!does_file_exist(maybe_icon_path)) {
                                         /* fallback to png */
                                         maybe_icon_path = g_strconcat(current_folder, "/", icon_path, ".png", NULL);
                                 }
-                                free(current_folder);
+                                g_free(current_folder);
 
                                 pixbuf = get_pixbuf_from_file(maybe_icon_path);
                                 g_free(maybe_icon_path);
@@ -384,7 +384,7 @@ static GdkPixbuf *get_pixbuf_from_raw_image(const RawImage *raw_image)
 
 static colored_layout *r_init_shared(cairo_t *c, notification *n)
 {
-        colored_layout *cl = malloc(sizeof(colored_layout));
+        colored_layout *cl = g_malloc(sizeof(colored_layout));
         if(cl == NULL) {
                 die("Unable to allocate memory", EXIT_FAILURE);
         }
@@ -1418,7 +1418,7 @@ void x_shortcut_init(keyboard_shortcut * ks)
                 ks->is_valid = true;
         }
 
-        free(str_begin);
+        g_free(str_begin);
 }
 
 /* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/x.h
+++ b/src/x.h
@@ -2,16 +2,10 @@
 #ifndef DUNST_X_H
 #define DUNST_X_H
 
-#include <stdbool.h>
-#include "glib.h"
 #include <X11/Xlib.h>
-#include <X11/XKBlib.h>
-#include <X11/Xatom.h>
-#include <X11/Xutil.h>
-#ifdef XINERAMA
-#include <X11/extensions/Xinerama.h>
-#endif
 #include <X11/extensions/scrnsaver.h>
+#include <glib.h>
+#include <stdbool.h>
 
 #define BUTTONMASK              (ButtonPressMask|ButtonReleaseMask)
 #define FONT_HEIGHT_BORDER 2


### PR DESCRIPTION
1. Fix `#include`s.
2. Use only glib functions for memory management. Don't mix with stdlib
3. Fix a missing `*` in option_parser.c

There are lots of of changes and I wasn't sure if it would be a good pull request, but I was invited by a maintainer.

I know there are conflicts, but I'm busy this week and do not have time to resolve them.