### PR TITLE
Allow dunst to be managed by systemd

### DIFF
--- a/org.knopwob.dunst.service.in
+++ b/org.knopwob.dunst.service.in
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=org.freedesktop.Notifications
 Exec=##PREFIX##/bin/dunst
+SystemdService=dunst.service


### PR DESCRIPTION
This should have no effect on systems without systemd; it just causes dunst to be started through systemd when possible.