### PR TITLE
Modernize the systemd unit a bit

### DIFF
--- a/contrib/dunst.systemd.service.in
+++ b/contrib/dunst.systemd.service.in
@@ -1,5 +1,6 @@
 [Unit]
 Description=Dunst notification daemon
+Documentation=man:dunst(1)
 
 [Service]
 Type=dbus

--- a/contrib/dunst.systemd.service.in
+++ b/contrib/dunst.systemd.service.in
@@ -2,7 +2,8 @@
 Description=Dunst notification daemon
 
 [Service]
-Type=simple
+Type=dbus
+BusName=org.freedesktop.Notifications
 ExecStart=##PREFIX##/bin/dunst
 Environment=DISPLAY=:0
 

--- a/contrib/dunst.systemd.service.in
+++ b/contrib/dunst.systemd.service.in
@@ -8,5 +8,5 @@ ExecStart=##PREFIX##/bin/dunst
 Environment=DISPLAY=:0
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target
 


### PR DESCRIPTION
* Add `Documentation` field.
* Make it `WantedBy` `default.target` (`multi-user.target` isn't a valid user target).
* Make it a dbus unit (consider it active when it acquires the dbus interface).