### PR TITLE
option_parser: Allow comments on lines with quoted strings

### DIFF
--- a/src/notification.c
+++ b/src/notification.c
@@ -368,7 +368,7 @@ int notification_init(notification * n, int id)
 
         n->urls = notification_extract_markup_urls(&(n->body));
 
-        n->msg = string_replace_all("\\n", "\n", g_strdup(n->format));
+        n->msg = g_strdup(n->format);
         n->msg = notification_replace_format("%a", n->appname, n->msg,
                 MARKUP_NO);
         n->msg = notification_replace_format("%s", n->summary, n->msg,

--- a/src/option_parser.c
+++ b/src/option_parser.c
@@ -205,11 +205,14 @@ char *clean_value(char *value, int line_num)
                                 unparsed++;
                                 break;
                         default:
-                                // Unrecognized backslash sequence;
-                                // treat the backslash as an ordinary character.
-                                // Consider issuing an error or warning here instead.
                                 unparsed++;
-                                break;
+                                fprintf(stderr,
+                                       "Warning: invalid config file at line %d\n",
+                                       line_num);
+                                fprintf(stderr,
+                                       "Unrecognized backslash sequence '\\%c'\n",
+                                       *unparsed);
+                                return NULL;
                         }
                         break;
                 case '#':

--- a/src/option_parser.c
+++ b/src/option_parser.c
@@ -198,14 +198,12 @@ char *clean_value(char *value, int line_num)
                         in_quote = !in_quote;
                         break;
                 case '\\':
-                        switch (unparsed[1]) {
+                        memmove(unparsed, unparsed + 1, strlen(unparsed));
+                        switch (*unparsed) {
                         case '\\':
                         case '"':
-                                memmove(unparsed, unparsed + 1, strlen(unparsed));
-                                unparsed++;
                                 break;
                         default:
-                                unparsed++;
                                 fprintf(stderr,
                                        "Warning: invalid config file at line %d\n",
                                        line_num);
@@ -214,6 +212,7 @@ char *clean_value(char *value, int line_num)
                                        *unparsed);
                                 return NULL;
                         }
+                        unparsed++;
                         break;
                 case '#':
                 case ';':

--- a/src/option_parser.c
+++ b/src/option_parser.c
@@ -203,6 +203,9 @@ char *clean_value(char *value, int line_num)
                         case '\\':
                         case '"':
                                 break;
+                        case 'n':
+                                *unparsed = '\n';
+                                break;
                         default:
                                 fprintf(stderr,
                                        "Warning: invalid config file at line %d\n",

--- a/test/data/test-ini
+++ b/test/data/test-ini
@@ -22,9 +22,11 @@
 	simple = A simple string
 	simple_with_hcomment = A simple string # a comment
 	simple_with_scomment = A simple string ; a comment
+	simple_with_nl = A simple string\nwith newline
 	quoted = "A quoted string"
 	quoted_with_hcomment = "A quoted string" # a comment
 	quoted_with_scomment = "A quoted string" ; a comment
+	quoted_with_nl = "A quoted string\nwith newline"
 	quoted_with_quotes = "A string \"with quotes\""
 	quoted_with_escapes = "A string \\\"with escapes\\"
 	quoted_with_cchar = "A string; with #comment characters" # a comment

--- a/test/data/test-ini
+++ b/test/data/test-ini
@@ -20,8 +20,16 @@
 
 [string]
 	simple = A simple string
+	simple_with_hcomment = A simple string # a comment
+	simple_with_scomment = A simple string ; a comment
 	quoted = "A quoted string"
-	quoted_with_quotes = "A string "with quotes""
+	quoted_with_hcomment = "A quoted string" # a comment
+	quoted_with_scomment = "A quoted string" ; a comment
+	quoted_with_quotes = "A string \"with quotes\""
+	quoted_with_escapes = "A string \\\"with escapes\\"
+	quoted_with_cchar = "A string; with #comment characters" # a comment
+	quoted_in_middle  = A string"; with #comment" characters # a comment
+	escaped_quotes = String \"with quotes\"
 
 [int]
 	simple = 5

--- a/test/option_parser.c
+++ b/test/option_parser.c
@@ -45,12 +45,30 @@ TEST test_ini_get_string(void)
 {
         char *string_section = "string";
         char *ptr;
+
         ASSERT_STR_EQ("A simple string", (ptr = ini_get_string(string_section, "simple", "")));
+        free(ptr);
+        ASSERT_STR_EQ("A simple string", (ptr = ini_get_string(string_section, "simple_with_hcomment", "")));
+        free(ptr);
+        ASSERT_STR_EQ("A simple string", (ptr = ini_get_string(string_section, "simple_with_scomment", "")));
         free(ptr);
 
         ASSERT_STR_EQ("A quoted string", (ptr = ini_get_string(string_section, "quoted", "")));
         free(ptr);
+        ASSERT_STR_EQ("A quoted string", (ptr = ini_get_string(string_section, "quoted_with_hcomment", "")));
+        free(ptr);
+        ASSERT_STR_EQ("A quoted string", (ptr = ini_get_string(string_section, "quoted_with_scomment", "")));
+        free(ptr);
         ASSERT_STR_EQ("A string \"with quotes\"", (ptr = ini_get_string(string_section, "quoted_with_quotes", "")));
+        free(ptr);
+        ASSERT_STR_EQ("A string \\\"with escapes\\", (ptr = ini_get_string(string_section, "quoted_with_escapes", "")));
+        free(ptr);
+        ASSERT_STR_EQ("A string; with #comment characters", (ptr = ini_get_string(string_section, "quoted_with_cchar", "")));
+        free(ptr);
+        ASSERT_STR_EQ("A string; with #comment characters", (ptr = ini_get_string(string_section, "quoted_in_middle", "")));
+        free(ptr);
+
+        ASSERT_STR_EQ("String \"with quotes\"", (ptr = ini_get_string(string_section, "escaped_quotes", "")));
         free(ptr);
 
         ASSERT_STR_EQ("default value", (ptr = ini_get_string(string_section, "nonexistent", "default value")));

--- a/test/option_parser.c
+++ b/test/option_parser.c
@@ -52,12 +52,16 @@ TEST test_ini_get_string(void)
         free(ptr);
         ASSERT_STR_EQ("A simple string", (ptr = ini_get_string(string_section, "simple_with_scomment", "")));
         free(ptr);
+        ASSERT_STR_EQ("A simple string\nwith newline", (ptr = ini_get_string(string_section, "simple_with_nl", "")));
+        free(ptr);
 
         ASSERT_STR_EQ("A quoted string", (ptr = ini_get_string(string_section, "quoted", "")));
         free(ptr);
         ASSERT_STR_EQ("A quoted string", (ptr = ini_get_string(string_section, "quoted_with_hcomment", "")));
         free(ptr);
         ASSERT_STR_EQ("A quoted string", (ptr = ini_get_string(string_section, "quoted_with_scomment", "")));
+        free(ptr);
+        ASSERT_STR_EQ("A quoted string\nwith newline", (ptr = ini_get_string(string_section, "quoted_with_nl", "")));
         free(ptr);
         ASSERT_STR_EQ("A string \"with quotes\"", (ptr = ini_get_string(string_section, "quoted_with_quotes", "")));
         free(ptr);


### PR DESCRIPTION
This is an updated version of #126 (2013).

The current behavior is
 - If the value contains a double-quote:
   - 1. Verify that it must contains at least two quotes.
   - 2. If one of the quotes is the first character, trim it.
   - 3. If one of the quotes is the last character, trim it.
 - Else:
   - 1. Trim a trailing comment from the value.

This has the effect that

    `key = "value" # comment` => `value " #comment`

This is surprising and almost certainly not what the user wants.

However, it allows simple nested quotes like:

    `key = "A string "with quotes""` => `A string "with quotes"`

Adjust the brokenness of the first example at the expense of breaking the
second.  A user seeking that value will now have to type:

    key = "A string \"with quotes\""