### PR TITLE
Expand "\\n" to "\n" in the format string only; not message text.

### DIFF
--- a/src/notification.c
+++ b/src/notification.c
@@ -267,7 +267,6 @@ char *notification_replace_format(const char *needle, const char *replacement,
 
         }
 
-        tmp = string_replace_all("\\n", "\n", tmp);
         if (settings.ignore_newline) {
                 tmp = string_replace_all("\n", " ", tmp);
         }


### PR DESCRIPTION
This was originally submitted as #125, but it ended up being incorporated into #204, which was merged instead of my version. That's fine.

However, later, commit 3ef1506 (presumably accidentally) reverted back to the pre-#204 behavior.

So this PR re-applies that change.