### PR TITLE
option_parser: Fix inconsistent Warning message.

### DIFF
--- a/src/option_parser.c
+++ b/src/option_parser.c
@@ -271,7 +271,7 @@ int load_ini_file(FILE * fp)
 
                 if (!current_section) {
                         fprintf(stderr,
-                               "Warning: invalid config file at line: %d\n",
+                               "Warning: invalid config file at line %d\n",
                                line_num);
                         fprintf(stderr, "Key value pair without a section\n");
                         continue;


### PR DESCRIPTION
Usually, it's "Warning: invalid config file at line %d", but in one case there's a colon after "line".

I noticed this while working on #298.