### PR TITLE
Tidy and fix markup handling.

### DIFF
--- a/src/markup.c
+++ b/src/markup.c
@@ -1,0 +1,89 @@
+/* copyright 2013 Sascha Kruse and contributors (see LICENSE for licensing information) */
+
+#define _GNU_SOURCE
+#include "markup.h"
+
+#include <assert.h>
+#include <stdbool.h>
+
+#include "settings.h"
+#include "utils.h"
+
+/*
+ * Quote a text string for rendering with pango
+ */
+static char *markup_quote(char *str)
+{
+        if (str == NULL) {
+                return NULL;
+        }
+
+        str = string_replace_all("&", "&amp;", str);
+        str = string_replace_all("\"", "&quot;", str);
+        str = string_replace_all("'", "&apos;", str);
+        str = string_replace_all("<", "&lt;", str);
+        str = string_replace_all(">", "&gt;", str);
+
+        return str;
+}
+
+/*
+ * Strip any markup from text
+ */
+char *markup_strip(char *str)
+{
+        if (str == NULL) {
+                return NULL;
+        }
+
+        /* strip all tags */
+        string_strip_delimited(str, '<', '>');
+
+        /* unquote the remainder */
+        str = string_replace_all("&quot;", "\"", str);
+        str = string_replace_all("&apos;", "'", str);
+        str = string_replace_all("&amp;", "&", str);
+        str = string_replace_all("&lt;", "<", str);
+        str = string_replace_all("&gt;", ">", str);
+
+        return str;
+}
+
+/*
+ * Transform the string in accordance with `markup_mode` and
+ * `settings.ignore_newline`
+ */
+char *markup_transform(char *str, enum markup_mode markup_mode)
+{
+        if (str == NULL) {
+                return NULL;
+        }
+
+        if (markup_mode == MARKUP_NO) {
+                str = markup_quote(str);
+        } else {
+                if (settings.ignore_newline) {
+                        str = string_replace_all("<br>", " ", str);
+                        str = string_replace_all("<br/>", " ", str);
+                        str = string_replace_all("<br />", " ", str);
+                } else {
+                        str = string_replace_all("<br>", "\n", str);
+                        str = string_replace_all("<br/>", "\n", str);
+                        str = string_replace_all("<br />", "\n", str);
+                }
+
+                if (markup_mode != MARKUP_FULL ) {
+                        str = markup_strip(str);
+                        str = markup_quote(str);
+                }
+
+        }
+
+        if (settings.ignore_newline) {
+                str = string_replace_all("\n", " ", str);
+        }
+
+        return str;
+}
+
+/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/markup.c
+++ b/src/markup.c
@@ -28,9 +28,9 @@ static char *markup_unquote(char *str)
 
         str = string_replace_all("&quot;", "\"", str);
         str = string_replace_all("&apos;", "'", str);
-        str = string_replace_all("&amp;", "&", str);
         str = string_replace_all("&lt;", "<", str);
         str = string_replace_all("&gt;", ">", str);
+        str = string_replace_all("&amp;", "&", str);
 
         return str;
 }

--- a/src/markup.h
+++ b/src/markup.h
@@ -1,0 +1,11 @@
+/* copyright 2013 Sascha Kruse and contributors (see LICENSE for licensing information) */
+#ifndef DUNST_MARKUP_H
+#define DUNST_MARKUP_H
+
+#include "settings.h"
+
+char *markup_strip(char *str);
+char *markup_transform(char *str, enum markup_mode markup_mode);
+
+#endif
+/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/notification.h
+++ b/src/notification.h
@@ -69,8 +69,6 @@ int notification_is_duplicate(const notification *a, const notification *b);
 void notification_run_script(notification * n);
 int notification_close(notification * n, int reason);
 void notification_print(notification * n);
-char *notification_strip_markup(char *str);
-char *notification_quote_markup(char *str);
 char *notification_replace_format(const char *needle, const char *replacement, char *haystack, enum markup_mode markup);
 void notification_update_text_to_render(notification *n);
 int notification_get_ttl(notification *n);

--- a/src/x.c
+++ b/src/x.c
@@ -22,6 +22,7 @@
 #include <unistd.h>
 
 #include "dunst.h"
+#include "markup.h"
 #include "notification.h"
 #include "settings.h"
 #include "utils.h"
@@ -475,7 +476,7 @@ static colored_layout *r_create_layout_from_notification(cairo_t *c, notificatio
                 pango_layout_set_attributes(cl->l, cl->attr);
         } else {
                 /* remove markup and display plain message instead */
-                n->text_to_render = notification_strip_markup(n->text_to_render);
+                n->text_to_render = markup_strip(n->text_to_render);
                 cl->text = NULL;
                 cl->attr = NULL;
                 pango_layout_set_text(cl->l, n->text_to_render, -1);

--- a/test/markup.c
+++ b/test/markup.c
@@ -1,0 +1,57 @@
+#include "greatest.h"
+
+#include <stdbool.h>
+#include <glib.h>
+
+#include "src/markup.h"
+
+TEST test_markup_strip(void)
+{
+        char *ptr;
+
+        ASSERT_STR_EQ("&quot;", (ptr=markup_strip(g_strdup("&amp;quot;"))));
+        g_free(ptr);
+        ASSERT_STR_EQ("&apos;", (ptr=markup_strip(g_strdup("&amp;apos;"))));
+        g_free(ptr);
+        ASSERT_STR_EQ("&lt;", (ptr=markup_strip(g_strdup("&amp;lt;"))));
+        g_free(ptr);
+        ASSERT_STR_EQ("&gt;", (ptr=markup_strip(g_strdup("&amp;gt;"))));
+        g_free(ptr);
+        ASSERT_STR_EQ("&amp;", (ptr=markup_strip(g_strdup("&amp;amp;"))));
+        g_free(ptr);
+        ASSERT_STR_EQ(">A  ", (ptr=markup_strip(g_strdup(">A <img> <string"))));
+        g_free(ptr);
+
+        PASS();
+}
+
+TEST test_markup_transform(void)
+{
+        char *ptr;
+
+        settings.ignore_newline = false;
+        ASSERT_STR_EQ("&lt;i&gt;foo&lt;/i&gt;&lt;br&gt;bar\nbaz", (ptr=markup_transform(g_strdup("<i>foo</i><br>bar\nbaz"), MARKUP_NO)));
+        g_free(ptr);
+        ASSERT_STR_EQ("foo\nbar\nbaz", (ptr=markup_transform(g_strdup("<i>foo</i><br>bar\nbaz"), MARKUP_STRIP)));
+        g_free(ptr);
+        ASSERT_STR_EQ("<i>foo</i>\nbar\nbaz", (ptr=markup_transform(g_strdup("<i>foo</i><br>bar\nbaz"), MARKUP_FULL)));
+        g_free(ptr);
+
+        settings.ignore_newline = true;
+        ASSERT_STR_EQ("&lt;i&gt;foo&lt;/i&gt;&lt;br&gt;bar baz", (ptr=markup_transform(g_strdup("<i>foo</i><br>bar\nbaz"), MARKUP_NO)));
+        g_free(ptr);
+        ASSERT_STR_EQ("foo bar baz", (ptr=markup_transform(g_strdup("<i>foo</i><br>bar\nbaz"), MARKUP_STRIP)));
+        g_free(ptr);
+        ASSERT_STR_EQ("<i>foo</i> bar baz", (ptr=markup_transform(g_strdup("<i>foo</i><br>bar\nbaz"), MARKUP_FULL)));
+        g_free(ptr);
+
+        PASS();
+}
+
+SUITE(suite_markup)
+{
+        RUN_TEST(test_markup_strip);
+        RUN_TEST(test_markup_transform);
+}
+
+/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/test/test.c
+++ b/test/test.c
@@ -3,6 +3,7 @@
 SUITE_EXTERN(suite_utils);
 SUITE_EXTERN(suite_option_parser);
 SUITE_EXTERN(suite_notification);
+SUITE_EXTERN(suite_markup);
 
 GREATEST_MAIN_DEFS();
 
@@ -11,6 +12,7 @@ int main(int argc, char *argv[]) {
         RUN_SUITE(suite_utils);
         RUN_SUITE(suite_option_parser);
         RUN_SUITE(suite_notification);
+        RUN_SUITE(suite_markup);
         GREATEST_MAIN_END();
 }
 /* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */


### PR DESCRIPTION
This has 4 commits: The first two tidy and reorganize the markup handling without making any functional changes. The last two commits each fix an issue with the markup handling that is now easy-to-spot in the reorganized code.

There are two user-visible changes here.  In one case, the behavior is straight-up a bug, and fixing it is OK.  In the other case, it improves the error-handling behavior; since an error is encountered anyway (and it says so on stdout), I believe that a change in behavior is fair game.  That is, I believe that this can be merged in to `master`, rather than `next`.