### PR TITLE
Add centering to -geometry flag

### DIFF
--- a/src/settings.c
+++ b/src/settings.c
@@ -533,6 +533,27 @@ void load_settings(char *cmdline_config_path)
                 "Always run rule-defined scripts, even if the notification is suppressed with format = \"\"."
         );
 
+        {
+                char *c = option_get_string(
+                        "global",
+                        "centering", "-centering", "off",
+                        "Align notifications on screen off/horizontal/vertical/both"
+                );
+
+                if (strcmp(c, "off") == 0)
+                        settings.centering = CENTERING_OFF;
+                else if (strcmp(c, "horizontal") == 0)
+                        settings.centering = CENTERING_HORIZONTAL;
+                else if (strcmp(c, "vertical") == 0)
+                        settings.centering = CENTERING_VERTICAL;
+                else if (strcmp(c, "both") == 0)
+                        settings.centering = CENTERING_BOTH;
+                else
+                        fprintf(stderr,
+                                "Warning: unknown centering option: %s\n", c);
+                g_free(c);
+        }
+
         /* push hardcoded default rules into rules list */
         for (int i = 0; i < LENGTH(default_rules); i++) {
                 rules = g_slist_insert(rules, &(default_rules[i]), -1);

--- a/src/settings.h
+++ b/src/settings.h
@@ -11,6 +11,7 @@ enum icon_position_t { icons_left, icons_right, icons_off };
 enum separator_color { FOREGROUND, AUTO, FRAME, CUSTOM };
 enum follow_mode { FOLLOW_NONE, FOLLOW_MOUSE, FOLLOW_KEYBOARD };
 enum markup_mode { MARKUP_NULL, MARKUP_NO, MARKUP_STRIP, MARKUP_FULL };
+enum centering { CENTERING_OFF, CENTERING_HORIZONTAL, CENTERING_VERTICAL, CENTERING_BOTH };
 
 typedef struct _settings {
         bool print_notifications;
@@ -72,6 +73,7 @@ typedef struct _settings {
         keyboard_shortcut close_all_ks;
         keyboard_shortcut history_ks;
         keyboard_shortcut context_ks;
+        enum centering centering;
 } settings_t;
 
 extern settings_t settings;

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -703,6 +703,14 @@ static void x_win_move(int width, int height)
                 y = scr->dim.y + xctx.geometry.y;
         }
 
+        if (settings.centering == CENTERING_HORIZONTAL || settings.centering == CENTERING_BOTH) {
+                x = scr->dim.x + (scr->dim.w - width) / 2 + xctx.geometry.x;
+        }
+
+        if (settings.centering == CENTERING_VERTICAL || settings.centering == CENTERING_BOTH) {
+                y = scr->dim.y + (scr->dim.h - height) / 2 + xctx.geometry.y;
+        }
+
         /* move and resize */
         if (x != xctx.window_dim.x || y != xctx.window_dim.y) {
                 XMoveWindow(xctx.dpy, xctx.win, x, y);


### PR DESCRIPTION
It seems from XParseGeometry documentation, that it's valid to have `=` sign as first character of spec, but it's not documented how it's handled. So, I propose to use `=` at the geometry spec as indicator, that notification window should be positioned in the center of monitor (if both X and Y offsets are 0). It makes possible to align notification windows so they are shown at the X-center of active monitor by specifying geometry like `=<width>x<height>+0-40` — display notification window at the X-center of monitor and 40 px from bottom.