### PR TITLE
Tweak systemd.service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ install-doc:
 install-service: service
 	mkdir -p ${DESTDIR}${PREFIX}/share/dbus-1/services/
 	install -m644 org.knopwob.dunst.service ${DESTDIR}${PREFIX}/share/dbus-1/services
+	install -Dm644 dunst.systemd.service ${DESTDIR}${PREFIX}/lib/systemd/user/dunst.service
 
 install: install-dunst install-doc install-service
 

--- a/contrib/dunst.systemd.service.in
+++ b/contrib/dunst.systemd.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=Dunst notification daemon
 Documentation=man:dunst(1)
+PartOf=graphical-session.target
 
 [Service]
 Type=dbus

--- a/contrib/dunst.systemd.service.in
+++ b/contrib/dunst.systemd.service.in
@@ -6,7 +6,6 @@ Documentation=man:dunst(1)
 Type=dbus
 BusName=org.freedesktop.Notifications
 ExecStart=##PREFIX##/bin/dunst
-Environment=DISPLAY=:0
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
Hardcoding a DISPLAY variable is a bad idea because it means that dunst
will only run on X11, and only for that specific configuration.

FWIW, this actually applies to any desktop app run via systemd:

1. `DISPLAY` should be set by `systemctl --user set-environment` elsewhere.
2. `DISPLAY=:0` is not universally valid.
3. This breaks dunst if attempting to run wayland, and requires manually
  starting it (eg: not via systemd), or editing the file.

See [this comment](https://github.com/dunst-project/dunst/issues/314#issuecomment-300527201) for context.