### PR TITLE
limit length of single fields in notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Text and icons are now centred vertically
 - Notifications aren't considered duplicate if urgency or icons differ
 - The frame width and color settings were moved to the global section as frame\_width and frame\_color respectively.
+- The maximum displayed field length is limited to 5000 characters
 
 ### Deprecated
 - `allow_markup` will be removed in later versions. It is being replaced by `markup`

--- a/src/notification.c
+++ b/src/notification.c
@@ -329,6 +329,16 @@ int notification_init(notification * n, int id)
 
         n->msg = g_strchomp(n->msg);
 
+        /* truncate overlong messages */
+        if (strlen(n->msg) > DUNST_NOTIF_MAX_CHARS) {
+                char* buffer = g_malloc(DUNST_NOTIF_MAX_CHARS);
+                strncpy(buffer, n->msg, DUNST_NOTIF_MAX_CHARS);
+                buffer[DUNST_NOTIF_MAX_CHARS-1] = '\0';
+
+                g_free(n->msg);
+                n->msg = buffer;
+        }
+
         if (n->icon != NULL && strlen(n->icon) <= 0) {
                 g_free(n->icon);
                 n->icon = NULL;

--- a/src/notification.h
+++ b/src/notification.h
@@ -12,6 +12,8 @@
 #define NORM 1
 #define CRIT 2
 
+#define DUNST_NOTIF_MAX_CHARS 5000
+
 typedef struct _raw_image {
         int width;
         int height;


### PR DESCRIPTION
This would be my 2 cents to fix #248 and remove the last blocker to have a new release.

This PR adds the option `max_fieldlength` to have a maximum of specific chars per field. So overlong messages will get truncated to the specified length.

Also if it's not wanted to have a limit, a minus-value can be chosen to skip the cutting.

I'm not sure yet, what a reasonable default would be. I've used `100`, but I'd like to have other's opinions here. Alternatively `-1` (=> no limit) would also be a good default.