### PR TITLE
depend on gtk3 instead of gtk2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
     - libpango1.0-dev
     - libcairo2-dev
     - libnotify-dev
-    - libgtk2.0-dev
+    - libgtk-3-dev
 dist: trusty
 sudo: false
 language: c

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,6 @@ test-clean:
 	rm -f test/test test/*.o
 
 dunstify: dunstify.o
-	${CC} ${CFLAGS} -o $@ dunstify.o $(shell pkg-config --libs --cflags glib-2.0 libnotify gdk-2.0)
+	${CC} ${CFLAGS} -o $@ dunstify.o $(shell pkg-config --libs --cflags glib-2.0 libnotify gdk-3.0)
 
 .PHONY: all clean dist install uninstall

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Dunst has a number of build dependencies that must be present before attempting 
 - libxdg-basedir
 - glib
 - pango/cairo
-- libgtk2.0
+- libgtk-3-dev
 
 Checkout the [wiki][wiki] for more information.
 

--- a/config.mk
+++ b/config.mk
@@ -22,7 +22,7 @@ CFLAGS   += -g --std=gnu99 -pedantic -Wall -Wno-overlength-strings -Os ${STATIC}
 
 pkg_config_packs := dbus-1 x11 xscrnsaver \
                     "glib-2.0 >= 2.36" gio-2.0 \
-                    pangocairo gdk-2.0 xrandr xinerama
+                    pangocairo gdk-3.0 xrandr xinerama
 
 # check if we need libxdg-basedir
 ifeq (,$(findstring STATIC_CONFIG,$(CFLAGS)))


### PR DESCRIPTION
in #263 there was mentioned to depend on gtk3 instead of gtk2. Mainly this is only incrementing the number, as it seems to work so far. Further testing **is** needed.

- [x] verify the behavior of the used functions did not change (or adapt our code)

Edit: seen, that there's already an issue open: #327