### PR TITLE
Add support for minimum notification window size.

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -30,6 +30,7 @@ int word_wrap = false;
 int ignore_newline = false;
 int line_height = 0;            /* if line height < font height, it will be raised to font height */
 int notification_height = 0;    /* if notification height < font height and padding, it will be raised */
+int min_notification_width = 0; /* if window width < min notification width, it will be raised */
 
 int separator_height = 2;       /* height of the separator line between two notifications */
 int padding = 0;

--- a/docs/dunst.pod
+++ b/docs/dunst.pod
@@ -173,6 +173,15 @@ The minimum height of the notification window in pixels. If the text and
 padding cannot fit in within the height specified by this value, the height
 will be increased as needed.
 
+-item B<minimum notification width> (default: 0)
+
+The minimum height of the notification window in pixels. If the text and
+padding cannot fit in within the width specified by this value, the width
+will be increased as needed.
+
+This lets you avoid notifications being too small with a small amount of text.
+It only applies with dynamic width (window geometry is set to 0) or shrink set.
+
 =item B<separator_height> (default: 2)
 
 The height in pixels of the separator between notifications, if set to 0 there

--- a/src/settings.c
+++ b/src/settings.c
@@ -231,6 +231,12 @@ void load_settings(char *cmdline_config_path)
                 "Define height of the window"
         );
 
+        settings.min_notification_width = option_get_int(
+                "global",
+                "min_notification_width", "-nw/-min_notification_width", min_notification_width,
+                "Define the minimum width of the window, if it's dynamic"
+        );
+
         {
                 char *c = option_get_string(
                         "global",

--- a/src/settings.h
+++ b/src/settings.h
@@ -48,6 +48,7 @@ typedef struct _settings {
         int ignore_newline;
         int line_height;
         int notification_height;
+        int min_notification_width;
         int separator_height;
         int padding;
         int h_padding;

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -244,7 +244,8 @@ static dimension_t calculate_dimensions(GSList *layouts)
 
                 if (have_dynamic_width() || settings.shrink) {
                         /* dynamic width */
-                        total_width = MAX(text_width + 2 * settings.h_padding, total_width);
+                        total_width = MAX(text_width + 2 * settings.h_padding,
+                            MAX(settings.min_notification_width, total_width));
 
                         /* subtract height from the unwrapped text */
                         dim.h -= h;
@@ -261,6 +262,7 @@ static dimension_t calculate_dimensions(GSList *layouts)
                         w = dim.w;
                         w -= 2 * settings.h_padding;
                         w -= 2 * settings.frame_width;
+
                         if (cl->icon) w -= cairo_image_surface_get_width(cl->icon) + settings.h_padding;
                         r_setup_pango_layout(cl->l, w);
 


### PR DESCRIPTION
I like having my notification windows be expandable, but sometimes they're too small if there isn't enough text. This lets you specify a "minimum width" for the windows. It's only enabled for `-shrink` or dynamic width mode.

Parameter details:
  - `-nw`/`-notification-width` -- command line
  - `min_notification_width` -- config file

Naming suggestions are welcome.