### PR TITLE
RGB*A* support (fixes #289)

### DIFF
--- a/config.h
+++ b/config.h
@@ -15,7 +15,6 @@ settings_t defaults = {
 .timeouts = { 10*G_USEC_PER_SEC, 10*G_USEC_PER_SEC, 0 }, /* low, normal, critical */
 .icons = { "dialog-information", "dialog-information", "dialog-warning" }, /* low, normal, critical */
 
-.transparency = 0,           /* transparency */
 .geom = "0x0",               /* geometry */
 .title = "Dunst",            /* the title of dunst notification windows */
 .class = "Dunst",            /* the class of dunst notification windows */

--- a/docs/dunst.pod
+++ b/docs/dunst.pod
@@ -160,13 +160,6 @@ This is used mainly in order to have the shrinking benefit of dynamic width (see
 geometry) while also having an upper bound on how long a notification can get
 before wrapping.
 
-=item B<transparency> (default: 0)
-
-A 0-100 range on how transparent the notification window should be, with 0
-being fully opaque and 100 invisible.
-
-This setting will only work if a compositor is running.
-
 =item B<notification_height> (default: 0)
 
 The minimum height of the notification window in pixels. If the text and

--- a/dunstrc
+++ b/dunstrc
@@ -38,11 +38,6 @@
     # width is 0.
     shrink = no
 
-    # The transparency of the window.  Range: [0; 100].
-    # This option will only work if a compositing window manager is
-    # present (e.g. xcompmgr, compiz, etc.).
-    transparency = 0
-
     # The height of the entire notification.  If the height is smaller
     # than the font height and padding combined, it will be raised
     # to the font height and padding.

--- a/src/settings.c
+++ b/src/settings.c
@@ -340,12 +340,6 @@ void load_settings(char *cmdline_config_path)
                 "horizontal padding"
         );
 
-        settings.transparency = option_get_int(
-                "global",
-                "transparency", "-transparency", defaults.transparency,
-                "Transparency. range 0-100"
-        );
-
         {
                 char *c = option_get_string(
                         "global",

--- a/src/settings.h
+++ b/src/settings.h
@@ -32,7 +32,6 @@ typedef struct _settings {
         char *format;
         gint64 timeouts[3];
         char *icons[3];
-        unsigned int transparency;
         char *geom;
         char *title;
         char *class;

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -64,7 +64,6 @@ cairo_ctx_t cairo_ctx;
 static void x_shortcut_setup_error_handler(void);
 static int x_shortcut_tear_down_error_handler(void);
 static void x_win_move(int width, int height);
-static void setopacity(Window win, unsigned long opacity);
 static void x_handle_click(XEvent ev);
 static void x_win_setup(void);
 
@@ -781,20 +780,6 @@ static void x_win_move(int width, int height)
         xctx.window_dim.w = width;
 }
 
-static void setopacity(Window win, unsigned long opacity)
-{
-        Atom _NET_WM_WINDOW_OPACITY =
-            XInternAtom(xctx.dpy, "_NET_WM_WINDOW_OPACITY", false);
-        XChangeProperty(xctx.dpy,
-                        win,
-                        _NET_WM_WINDOW_OPACITY,
-                        XA_CARDINAL,
-                        32,
-                        PropModeReplace,
-                        (unsigned char *)&opacity,
-                        1L);
-}
-
 /*
  * Returns the modifier which is NumLock.
  */
@@ -1178,11 +1163,6 @@ static void x_win_setup(void)
                                  &wa);
 
         x_set_wm(xctx.win);
-        settings.transparency =
-            settings.transparency > 100 ? 100 : settings.transparency;
-        setopacity(xctx.win,
-                   (unsigned long)((100 - settings.transparency) *
-                                   (0xffffffff / 100)));
 
         if (settings.f_mode != FOLLOW_NONE) {
                 long root_event_mask = FocusChangeMask | PropertyChangeMask;

--- a/src/x11/x.h
+++ b/src/x11/x.h
@@ -39,6 +39,7 @@ typedef struct _color_t {
         double r;
         double g;
         double b;
+        double a;
 } color_t;
 
 extern xctx_t xctx;

--- a/test/functional-tests/dunstrc.default
+++ b/test/functional-tests/dunstrc.default
@@ -9,7 +9,6 @@
     word_wrap = yes
     ignore_newline = no
     geometry = "300x5-30+20"
-    transparency = 0
     idle_threshold = 120
     monitor = 0
     follow = mouse

--- a/test/functional-tests/dunstrc.ignore_newline
+++ b/test/functional-tests/dunstrc.ignore_newline
@@ -9,7 +9,6 @@
     word_wrap = yes
     ignore_newline = yes
     geometry = "200x0-30+20"
-    transparency = 0
     idle_threshold = 120
     monitor = 0
     follow = mouse

--- a/test/functional-tests/dunstrc.ignore_newline_no_wrap
+++ b/test/functional-tests/dunstrc.ignore_newline_no_wrap
@@ -9,7 +9,6 @@
     word_wrap = no
     ignore_newline = yes
     geometry = "250x0-30+20"
-    transparency = 0
     idle_threshold = 120
     monitor = 0
     follow = mouse

--- a/test/functional-tests/dunstrc.markup
+++ b/test/functional-tests/dunstrc.markup
@@ -9,7 +9,6 @@
     word_wrap = yes
     ignore_newline = no
     geometry = "300x5-30+20"
-    transparency = 0
     idle_threshold = 120
     monitor = 0
     follow = mouse

--- a/test/functional-tests/dunstrc.nomarkup
+++ b/test/functional-tests/dunstrc.nomarkup
@@ -9,7 +9,6 @@
     word_wrap = yes
     ignore_newline = no
     geometry = "300x5-30+20"
-    transparency = 0
     idle_threshold = 120
     monitor = 0
     follow = mouse

--- a/test/functional-tests/dunstrc.nowrap
+++ b/test/functional-tests/dunstrc.nowrap
@@ -9,7 +9,6 @@
     word_wrap = no
     ignore_newline = no
     geometry = "300x5-30+20"
-    transparency = 0
     idle_threshold = 120
     monitor = 0
     follow = mouse

--- a/test/functional-tests/dunstrc.run_script
+++ b/test/functional-tests/dunstrc.run_script
@@ -9,7 +9,6 @@
     word_wrap = yes
     ignore_newline = no
     geometry = "300x5-30+20"
-    transparency = 0
     idle_threshold = 120
     monitor = 0
     follow = mouse

--- a/test/functional-tests/dunstrc.show_age
+++ b/test/functional-tests/dunstrc.show_age
@@ -9,7 +9,6 @@
     word_wrap = yes
     ignore_newline = no
     geometry = "300x5-30+20"
-    transparency = 0
     idle_threshold = 120
     monitor = 0
     follow = mouse


### PR DESCRIPTION
uses now rgba values instead of simple rgb. RGB is still the fallback, if no transparency value is given.

removes the transparency option (as it is redundant now).

fixes #289 