### PR TITLE
print usage only on stdout

### DIFF
--- a/src/dunst.c
+++ b/src/dunst.c
@@ -390,7 +390,7 @@ int dunst_main(int argc, char *argv[])
 
 void usage(int exit_status)
 {
-        fputs("usage:\n", stderr);
+        puts("usage:\n");
         char *us = cmdline_create_usage();
         puts(us);
         exit(exit_status);


### PR DESCRIPTION
Print out the full usage on STDERR. Currently only the string `usage` gets printed there, but not the other stuff. This is stupid.

