### PR TITLE
replace variables and ~ in script paths

### DIFF
--- a/docs/dunst.pod
+++ b/docs/dunst.pod
@@ -588,9 +588,7 @@ suppressed.
 =head2 SCRIPTING
 
 Within rules you can specify a script to be run every time the rule is matched
-by assigning the 'script' option to the name of the script to be run. (If the
-value is not an absolute path, the directories in the PATH variable will be
-searched for an executable of the same name).
+by assigning the 'script' option to the name of the script to be run.
 
 When the script is called details of the notification that triggered it will be
 passed via command line parameters in the following order: appname, summary,
@@ -601,6 +599,10 @@ one of "LOW", "NORMAL" or "CRITICAL".
 
 If the notification is suppressed, the script will not be run unless
 B<always_run_scripts> is set to true.
+
+If '~/' occurs at the beginning of the script parameter, it will get replaced by the
+users' home directory. If the value is not an absolute path, the directories in the
+PATH variable will be searched for an executable of the same name.
 
 =head1 COLORS
 

--- a/src/option_parser.c
+++ b/src/option_parser.c
@@ -109,6 +109,11 @@ char *get_value(char *section, char *key)
         return NULL;
 }
 
+char *ini_get_path(char *section, char *key, const char *def)
+{
+        return string_to_path(ini_get_string(section, key, def));
+}
+
 char *ini_get_string(char *section, char *key, const char *def)
 {
         char *value = get_value(section, key);
@@ -355,6 +360,17 @@ char *cmdline_get_string(char *key, const char *def, char *description)
                 return g_strdup(def);
 }
 
+char *cmdline_get_path(char *key, const char *def, char *description)
+{
+        cmdline_usage_append(key, "string", description);
+        char *str = cmdline_get_value(key);
+
+        if (str)
+                return string_to_path(g_strdup(str));
+        else
+                return string_to_path(g_strdup(def));
+}
+
 int cmdline_get_int(char *key, int def, char *description)
 {
         cmdline_usage_append(key, "double", description);
@@ -389,6 +405,24 @@ int cmdline_get_bool(char *key, int def, char *description)
 bool cmdline_is_set(char *key)
 {
         return cmdline_get_value(key) != NULL;
+}
+
+char *option_get_path(char *ini_section, char *ini_key, char *cmdline_key,
+                        const char *def, char *description)
+{
+        char *val = NULL;
+
+        if (cmdline_key) {
+                val = cmdline_get_path(cmdline_key, NULL, description);
+        }
+
+
+        if (val) {
+                return val;
+        } else {
+                return ini_get_path(ini_section, ini_key, def);
+        }
+
 }
 
 char *option_get_string(char *ini_section, char *ini_key, char *cmdline_key,

--- a/src/option_parser.h
+++ b/src/option_parser.h
@@ -6,6 +6,7 @@
 #include <stdio.h>
 
 int load_ini_file(FILE *);
+char *ini_get_path(char *section, char *key, const char *def);
 char *ini_get_string(char *section, char *key, const char *def);
 int ini_get_int(char *section, char *key, int def);
 double ini_get_double(char *section, char *key, double def);
@@ -16,6 +17,7 @@ void free_ini(void);
 void cmdline_load(int argc, char *argv[]);
 /* for all cmdline_get_* key can be either "-key" or "-key/-longkey" */
 char *cmdline_get_string(char *key, const char *def, char *description);
+char *cmdline_get_path(char *key, const char *def, char *description);
 int cmdline_get_int(char *key, int def, char *description);
 double cmdline_get_double(char *key, double def, char *description);
 int cmdline_get_bool(char *key, int def, char *description);
@@ -23,6 +25,8 @@ bool cmdline_is_set(char *key);
 char *cmdline_create_usage(void);
 
 char *option_get_string(char *ini_section, char *ini_key, char *cmdline_key,
+                        const char *def, char *description);
+char *option_get_path(char *ini_section, char *ini_key, char *cmdline_key,
                         const char *def, char *description);
 int option_get_int(char *ini_section, char *ini_key, char *cmdline_key, int def,
                    char *description);

--- a/src/settings.c
+++ b/src/settings.c
@@ -345,7 +345,7 @@ void load_settings(char *cmdline_config_path)
                 "print notification on startup"
         );
 
-        settings.dmenu = option_get_string(
+        settings.dmenu = option_get_path(
                 "global",
                 "dmenu", "-dmenu", dmenu,
                 "path to dmenu"
@@ -362,7 +362,7 @@ void load_settings(char *cmdline_config_path)
         }
 
 
-        settings.browser = option_get_string(
+        settings.browser = option_get_path(
                 "global",
                 "browser", "-browser", browser,
                 "path to browser"
@@ -636,7 +636,7 @@ void load_settings(char *cmdline_config_path)
                 r->format = ini_get_string(cur_section, "format", r->format);
                 r->new_icon = ini_get_string(cur_section, "new_icon", r->new_icon);
                 r->history_ignore = ini_get_bool(cur_section, "history_ignore", r->history_ignore);
-                r->script = ini_get_string(cur_section, "script", NULL);
+                r->script = ini_get_path(cur_section, "script", NULL);
         }
 
 #ifndef STATIC_CONFIG

--- a/src/utils.c
+++ b/src/utils.c
@@ -105,6 +105,19 @@ void string_strip_delimited(char *str, char a, char b)
         str[iwrite] = 0;
 }
 
+char* string_to_path(char* string) {
+
+        if (string && 0 == strncmp(string, "~/", 2)) {
+                char* home = g_strconcat(getenv("HOME"), "/", NULL);
+
+                string = string_replace("~/", home, string);
+
+                g_free(home);
+        }
+
+        return string;
+}
+
 void die(char *text, int exit_value)
 {
         fputs(text, stderr);

--- a/src/utils.h
+++ b/src/utils.h
@@ -21,5 +21,8 @@ void string_strip_delimited(char *str, char a, char b);
 /* exit with an error message */
 void die(char *msg, int exit_value);
 
+/* replace tilde and path-specific values with its equivalents */
+char* string_to_path(char* string);
+
 #endif
 /* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/test/data/test-ini
+++ b/test/data/test-ini
@@ -23,6 +23,9 @@
 	quoted = "A quoted string"
 	quoted_with_quotes = "A string "with quotes""
 
+[path]
+	expand_tilde    = ~/.path/to/tilde
+
 [int]
 	simple = 5
 	negative = -10

--- a/test/utils.c
+++ b/test/utils.c
@@ -1,6 +1,8 @@
 #include "greatest.h"
 #include "src/utils.h"
 
+#include <glib.h>
+
 TEST test_string_replace_char(void)
 {
         char *text = malloc(128 * sizeof(char));
@@ -102,6 +104,32 @@ TEST test_string_strip_delimited(void)
         PASS();
 }
 
+TEST test_string_to_path(void)
+{
+        char *ptr, *exp;
+        char *home = getenv("HOME");
+
+        exp = "/usr/local/bin/script";
+        ASSERT_STR_EQ(exp, (ptr = string_to_path(g_strdup(exp))));
+        free(ptr);
+
+        exp = "~path/with/wrong/tilde";
+        ASSERT_STR_EQ(exp, (ptr = string_to_path(g_strdup(exp))));
+        free(ptr);
+
+        ASSERT_STR_EQ((exp = g_strconcat(home, "/.path/with/tilde", NULL)),
+                      (ptr = string_to_path(g_strdup("~/.path/with/tilde"))));
+        free(exp);
+        free(ptr);
+
+        ASSERT_STR_EQ((exp = g_strconcat(home, "/.path/with/tilde and some space", NULL)),
+                      (ptr = string_to_path(g_strdup("~/.path/with/tilde and some space"))));
+        free(exp);
+        free(ptr);
+
+        PASS();
+}
+
 SUITE(suite_utils)
 {
         RUN_TEST(test_string_replace_char);
@@ -109,5 +137,6 @@ SUITE(suite_utils)
         RUN_TEST(test_string_replace);
         RUN_TEST(test_string_append);
         RUN_TEST(test_string_strip_delimited);
+        RUN_TEST(test_string_to_path);
 }
 /* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */


### PR DESCRIPTION
wordexp replaces all variables and `~` in the string. TBH I don't quite like the thing, that it replaces all variables, but there is no other way.

Fixes #350 