### PR TITLE
handle removing of elements in GList correctly

### DIFF
--- a/src/dunst.c
+++ b/src/dunst.c
@@ -57,8 +57,8 @@ void check_timeouts(void)
         if (displayed->length == 0)
                 return;
 
-        for (GList * iter = g_queue_peek_head_link(displayed); iter;
-             iter = iter->next) {
+        GList *iter = g_queue_peek_head_link(displayed);
+        while (iter) {
                 notification *n = iter->data;
 
                 /* don't timeout when user is idle */
@@ -72,12 +72,12 @@ void check_timeouts(void)
                         continue;
                 }
 
+                /* shift iter before we possibly delete the current notification */
+                iter = iter->next;
+
                 /* remove old message */
                 if (difftime(time(NULL), n->start) > n->timeout) {
-                        /* close_notification may conflict with iter, so restart */
                         notification_close(n, 1);
-                        check_timeouts();
-                        return;
                 }
         }
 }


### PR DESCRIPTION
When closing a notification in check_timeouts, `iter` will get removed of the list and therefore `iter->next` is not available at the end of the loop anymore. This requires calling check_timeouts again.

Introducing the `nextiter` pointer, which will save `iter->next` in advance, solves this problem and does not require traversing the already traversed part of the list again.