### PR TITLE
parse raw icons from the (deprecated) image_data attribute

### DIFF
--- a/src/dbus.c
+++ b/src/dbus.c
@@ -196,6 +196,8 @@ static void on_notify(GDBusConnection * connection,
 
                                         dict_value = g_variant_lookup_value(content, "image-data", G_VARIANT_TYPE("(iiibiiay)"));
                                         if (!dict_value)
+                                                dict_value = g_variant_lookup_value(content, "image_data", G_VARIANT_TYPE("(iiibiiay)"));
+                                        if (!dict_value)
                                                 dict_value = g_variant_lookup_value(content, "icon_data", G_VARIANT_TYPE("(iiibiiay)"));
                                         if (dict_value)
                                                 raw_icon = get_raw_image_from_data_hint(dict_value);


### PR DESCRIPTION
The desktop notification spec version 1.1 used "image_data" instead of "image-data" as the key for raw icons. This is still used in some applications, e.g., in the [Clementine music player](https://github.com/clementine-player/Clementine/blob/42aafd247a3a96f7a6c07d31b3a0881691a8daf2/src/widgets/osd_x11.cpp#L111).