### PR TITLE
Fix handling of non V1.5 XRandr.

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -22,7 +22,7 @@ pkg_config_packs := dbus-1 \
                     pangocairo \
                     x11 \
                     xinerama \
-                    xrandr \
+                    "xrandr >= 1.5" \
                     xscrnsaver
 
 # check if we need libxdg-basedir


### PR DESCRIPTION
Due to the way Xlib handles errors XRRGetMonitors will cause dunst to exit if
the server doesn't support version 1.5 of Randr. The check for null is
effectively dead code. Change the code to fetch the Randr version and fallback
if the version is less than 1.5 when getting monitors.