### PR TITLE
Refactor star scheme of pointers

### DIFF
--- a/src/dbus.c
+++ b/src/dbus.c
@@ -59,30 +59,30 @@ static const char *introspection_xml =
     "   </interface>"
     "</node>";
 
-static void on_get_capabilities(GDBusConnection * connection,
-                              const gchar * sender,
-                              const GVariant * parameters,
-                              GDBusMethodInvocation * invocation);
-static void on_notify(GDBusConnection * connection,
-                     const gchar * sender,
-                     GVariant * parameters, GDBusMethodInvocation * invocation);
-static void on_close_notification(GDBusConnection * connection,
-                                const gchar * sender,
-                                GVariant * parameters,
-                                GDBusMethodInvocation * invocation);
-static void on_get_server_information(GDBusConnection * connection,
-                                   const gchar * sender,
-                                   const GVariant * parameters,
-                                   GDBusMethodInvocation * invocation);
-static RawImage * get_raw_image_from_data_hint(GVariant *icon_data);
+static void on_get_capabilities(GDBusConnection *connection,
+                              const gchar *sender,
+                              const GVariant *parameters,
+                              GDBusMethodInvocation *invocation);
+static void on_notify(GDBusConnection *connection,
+                     const gchar *sender,
+                     GVariant *parameters, GDBusMethodInvocation *invocation);
+static void on_close_notification(GDBusConnection *connection,
+                                const gchar *sender,
+                                GVariant *parameters,
+                                GDBusMethodInvocation *invocation);
+static void on_get_server_information(GDBusConnection *connection,
+                                   const gchar *sender,
+                                   const GVariant *parameters,
+                                   GDBusMethodInvocation *invocation);
+static RawImage *get_raw_image_from_data_hint(GVariant *icon_data);
 
-void handle_method_call(GDBusConnection * connection,
-                        const gchar * sender,
-                        const gchar * object_path,
-                        const gchar * interface_name,
-                        const gchar * method_name,
-                        GVariant * parameters,
-                        GDBusMethodInvocation * invocation, gpointer user_data)
+void handle_method_call(GDBusConnection *connection,
+                        const gchar *sender,
+                        const gchar *object_path,
+                        const gchar *interface_name,
+                        const gchar *method_name,
+                        GVariant *parameters,
+                        GDBusMethodInvocation *invocation, gpointer user_data)
 {
         if (g_strcmp0(method_name, "GetCapabilities") == 0) {
                 on_get_capabilities(connection, sender, parameters, invocation);
@@ -99,10 +99,10 @@ void handle_method_call(GDBusConnection * connection,
         }
 }
 
-static void on_get_capabilities(GDBusConnection * connection,
-                              const gchar * sender,
-                              const GVariant * parameters,
-                              GDBusMethodInvocation * invocation)
+static void on_get_capabilities(GDBusConnection *connection,
+                              const gchar *sender,
+                              const GVariant *parameters,
+                              GDBusMethodInvocation *invocation)
 {
         GVariantBuilder *builder;
         GVariant *value;
@@ -122,9 +122,9 @@ static void on_get_capabilities(GDBusConnection * connection,
         g_dbus_connection_flush(connection, NULL, NULL, NULL);
 }
 
-static void on_notify(GDBusConnection * connection,
-                     const gchar * sender,
-                     GVariant * parameters, GDBusMethodInvocation * invocation)
+static void on_notify(GDBusConnection *connection,
+                     const gchar *sender,
+                     GVariant *parameters, GDBusMethodInvocation *invocation)
 {
 
         gchar *appname = NULL;
@@ -270,10 +270,10 @@ static void on_notify(GDBusConnection * connection,
         run(NULL);
 }
 
-static void on_close_notification(GDBusConnection * connection,
-                                const gchar * sender,
-                                GVariant * parameters,
-                                GDBusMethodInvocation * invocation)
+static void on_close_notification(GDBusConnection *connection,
+                                const gchar *sender,
+                                GVariant *parameters,
+                                GDBusMethodInvocation *invocation)
 {
         guint32 id;
         g_variant_get(parameters, "(u)", &id);
@@ -282,10 +282,10 @@ static void on_close_notification(GDBusConnection * connection,
         g_dbus_connection_flush(connection, NULL, NULL, NULL);
 }
 
-static void on_get_server_information(GDBusConnection * connection,
-                                   const gchar * sender,
-                                   const GVariant * parameters,
-                                   GDBusMethodInvocation * invocation)
+static void on_get_server_information(GDBusConnection *connection,
+                                   const gchar *sender,
+                                   const GVariant *parameters,
+                                   GDBusMethodInvocation *invocation)
 {
         GVariant *value;
 
@@ -295,7 +295,7 @@ static void on_get_server_information(GDBusConnection * connection,
         g_dbus_connection_flush(connection, NULL, NULL, NULL);
 }
 
-void notification_closed(notification * n, int reason)
+void notification_closed(notification *n, int reason)
 {
         if (!dbus_conn) {
                 fprintf(stderr, "ERROR: Tried to close notification but dbus connection not set!\n");
@@ -318,7 +318,7 @@ void notification_closed(notification * n, int reason)
 
 }
 
-void action_invoked(notification * n, const char *identifier)
+void action_invoked(notification *n, const char *identifier)
 {
         GVariant *body = g_variant_new("(us)", n->id, identifier);
         GError *err = NULL;
@@ -339,8 +339,8 @@ static const GDBusInterfaceVTable interface_vtable = {
         handle_method_call
 };
 
-static void on_bus_acquired(GDBusConnection * connection,
-                            const gchar * name, gpointer user_data)
+static void on_bus_acquired(GDBusConnection *connection,
+                            const gchar *name, gpointer user_data)
 {
         guint registration_id;
 
@@ -358,20 +358,20 @@ static void on_bus_acquired(GDBusConnection * connection,
         }
 }
 
-static void on_name_acquired(GDBusConnection * connection,
-                             const gchar * name, gpointer user_data)
+static void on_name_acquired(GDBusConnection *connection,
+                             const gchar *name, gpointer user_data)
 {
         dbus_conn = connection;
 }
 
-static void on_name_lost(GDBusConnection * connection,
-                         const gchar * name, gpointer user_data)
+static void on_name_lost(GDBusConnection *connection,
+                         const gchar *name, gpointer user_data)
 {
         fprintf(stderr, "Name Lost. Is Another notification daemon running?\n");
         exit(1);
 }
 
-static RawImage * get_raw_image_from_data_hint(GVariant *icon_data)
+static RawImage *get_raw_image_from_data_hint(GVariant *icon_data)
 {
     RawImage *image = g_malloc(sizeof(RawImage));
     GVariant *data_variant;

--- a/src/dbus.h
+++ b/src/dbus.h
@@ -8,8 +8,8 @@
 int initdbus(void);
 void dbus_tear_down(int id);
 /* void dbus_poll(int timeout); */
-void notification_closed(notification * n, int reason);
-void action_invoked(notification * n, const char *identifier);
+void notification_closed(notification *n, int reason);
+void action_invoked(notification *n, const char *identifier);
 
 #endif
 /* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/menu.c
+++ b/src/menu.c
@@ -137,7 +137,7 @@ void invoke_action(const char *action)
         int appname_len = strlen(appname_begin) - 1; // remove ]
         int action_len = strlen(action) - appname_len - 3; // remove space, [, ]
 
-        for (GList * iter = g_queue_peek_head_link(displayed); iter;
+        for (GList *iter = g_queue_peek_head_link(displayed); iter;
              iter = iter->next) {
                 notification *n = iter->data;
                 if (g_str_has_prefix(appname_begin, n->appname) && strlen(n->appname) == appname_len) {
@@ -189,7 +189,7 @@ void context_menu(void)
         }
         char *dmenu_input = NULL;
 
-        for (GList * iter = g_queue_peek_head_link(displayed); iter;
+        for (GList *iter = g_queue_peek_head_link(displayed); iter;
              iter = iter->next) {
                 notification *n = iter->data;
 

--- a/src/notification.c
+++ b/src/notification.c
@@ -30,7 +30,7 @@ int next_notification_id = 1;
  * print a human readable representation
  * of the given notification to stdout.
  */
-void notification_print(notification * n)
+void notification_print(notification *n)
 {
         printf("{\n");
         printf("\tappname: '%s'\n", n->appname);
@@ -71,7 +71,7 @@ void notification_print(notification * n)
  * Run the script associated with the
  * given notification.
  */
-void notification_run_script(notification * n)
+void notification_run_script(notification *n)
 {
         if (!n->script || strlen(n->script) < 1)
                 return;
@@ -167,7 +167,7 @@ int notification_is_duplicate(const notification *a, const notification *b)
 /*
  * Free the memory used by the given notification.
  */
-void notification_free(notification * n)
+void notification_free(notification *n)
 {
         assert(n != NULL);
         g_free(n->appname);
@@ -204,8 +204,8 @@ void notification_free(notification * n)
  */
 char *notification_replace_format(const char *needle, const char *replacement,
                                   char *haystack, enum markup_mode markup_mode) {
-        char* tmp;
-        char* ret;
+        char *tmp;
+        char *ret;
 
         tmp = markup_transform(g_strdup(replacement), markup_mode);
         ret = string_replace_all(needle, tmp, haystack);
@@ -279,7 +279,7 @@ void notification_init_defaults(notification *n)
  * notification_create, it is undefined behaviour to pass a notification
  * allocated some other way.
  */
-int notification_init(notification * n, int id)
+int notification_init(notification *n, int id)
 {
         assert(n != NULL);
 
@@ -337,7 +337,7 @@ int notification_init(notification * n, int id)
 
         /* truncate overlong messages */
         if (strlen(n->msg) > DUNST_NOTIF_MAX_CHARS) {
-                char* buffer = g_malloc(DUNST_NOTIF_MAX_CHARS);
+                char *buffer = g_malloc(DUNST_NOTIF_MAX_CHARS);
                 strncpy(buffer, n->msg, DUNST_NOTIF_MAX_CHARS);
                 buffer[DUNST_NOTIF_MAX_CHARS-1] = '\0';
 
@@ -365,7 +365,7 @@ int notification_init(notification * n, int id)
 
         /* check if n is a duplicate */
         if (settings.stack_duplicates) {
-                for (GList * iter = g_queue_peek_head_link(queue); iter;
+                for (GList *iter = g_queue_peek_head_link(queue); iter;
                      iter = iter->next) {
                         notification *orig = iter->data;
                         if (notification_is_duplicate(orig, n)) {
@@ -388,7 +388,7 @@ int notification_init(notification * n, int id)
                         }
                 }
 
-                for (GList * iter = g_queue_peek_head_link(displayed); iter;
+                for (GList *iter = g_queue_peek_head_link(displayed); iter;
                      iter = iter->next) {
                         notification *orig = iter->data;
                         if (notification_is_duplicate(orig, n)) {
@@ -496,7 +496,7 @@ int notification_close_by_id(int id, int reason)
 {
         notification *target = NULL;
 
-        for (GList * iter = g_queue_peek_head_link(displayed); iter;
+        for (GList *iter = g_queue_peek_head_link(displayed); iter;
              iter = iter->next) {
                 notification *n = iter->data;
                 if (n->id == id) {
@@ -507,7 +507,7 @@ int notification_close_by_id(int id, int reason)
                 }
         }
 
-        for (GList * iter = g_queue_peek_head_link(queue); iter;
+        for (GList *iter = g_queue_peek_head_link(queue); iter;
              iter = iter->next) {
                 notification *n = iter->data;
                 if (n->id == id) {
@@ -529,7 +529,7 @@ int notification_close_by_id(int id, int reason)
 /*
  * Close the given notification. SEE notification_close_by_id.
  */
-int notification_close(notification * n, int reason)
+int notification_close(notification *n, int reason)
 {
         assert(n != NULL);
         return notification_close_by_id(n->id, reason);

--- a/src/notification.h
+++ b/src/notification.h
@@ -63,15 +63,15 @@ typedef struct _notification {
 } notification;
 
 notification *notification_create(void);
-int notification_init(notification * n, int id);
-void notification_free(notification * n);
+int notification_init(notification *n, int id);
+void notification_free(notification *n);
 int notification_close_by_id(int id, int reason);
 int notification_cmp(const void *a, const void *b);
 int notification_cmp_data(const void *a, const void *b, void *data);
 int notification_is_duplicate(const notification *a, const notification *b);
-void notification_run_script(notification * n);
-int notification_close(notification * n, int reason);
-void notification_print(notification * n);
+void notification_run_script(notification *n);
+int notification_close(notification *n, int reason);
+void notification_print(notification *n);
 char *notification_replace_format(const char *needle, const char *replacement, char *haystack, enum markup_mode markup);
 void notification_update_text_to_render(notification *n);
 int notification_get_ttl(notification *n);

--- a/src/option_parser.c
+++ b/src/option_parser.c
@@ -207,7 +207,7 @@ char *clean_value(char *value)
 
 }
 
-int load_ini_file(FILE * fp)
+int load_ini_file(FILE *fp)
 {
         if (!fp)
                 return 1;

--- a/src/rules.c
+++ b/src/rules.c
@@ -10,7 +10,7 @@
 /*
  * Apply rule to notification.
  */
-void rule_apply(rule_t * r, notification * n)
+void rule_apply(rule_t *r, notification *n)
 {
         if (r->timeout != -1)
                 n->timeout = r->timeout;
@@ -39,9 +39,9 @@ void rule_apply(rule_t * r, notification * n)
 /*
  * Check all rules if they match n and apply.
  */
-void rule_apply_all(notification * n)
+void rule_apply_all(notification *n)
 {
-        for (GSList * iter = rules; iter; iter = iter->next) {
+        for (GSList *iter = rules; iter; iter = iter->next) {
                 rule_t *r = iter->data;
                 if (rule_matches_notification(r, n)) {
                         rule_apply(r, n);
@@ -52,7 +52,7 @@ void rule_apply_all(notification * n)
 /*
  * Initialize rule with default values.
  */
-void rule_init(rule_t * r)
+void rule_init(rule_t *r)
 {
         r->name = NULL;
         r->appname = NULL;
@@ -74,7 +74,7 @@ void rule_init(rule_t * r)
 /*
  * Check whether rule should be applied to n.
  */
-bool rule_matches_notification(rule_t * r, notification * n)
+bool rule_matches_notification(rule_t *r, notification *n)
 {
         return ((!r->appname || !fnmatch(r->appname, n->appname, 0))
                 && (!r->summary || !fnmatch(r->summary, n->summary, 0))

--- a/src/rules.h
+++ b/src/rules.h
@@ -32,10 +32,10 @@ typedef struct _rule_t {
 
 extern GSList *rules;
 
-void rule_init(rule_t * r);
-void rule_apply(rule_t * r, notification * n);
-void rule_apply_all(notification * n);
-bool rule_matches_notification(rule_t * r, notification * n);
+void rule_init(rule_t *r);
+void rule_apply(rule_t *r, notification *n);
+void rule_apply_all(notification *n);
+bool rule_matches_notification(rule_t *r, notification *n);
 
 #endif
 /* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/settings.c
+++ b/src/settings.c
@@ -596,7 +596,7 @@ void load_settings(char *cmdline_config_path)
 
                 /* check for existing rule with same name */
                 rule_t *r = NULL;
-                for (GSList * iter = rules; iter; iter = iter->next) {
+                for (GSList *iter = rules; iter; iter = iter->next) {
                         rule_t *match = iter->data;
                         if (match->name &&
                             strcmp(match->name, cur_section) == 0)

--- a/src/utils.c
+++ b/src/utils.c
@@ -105,10 +105,10 @@ void string_strip_delimited(char *str, char a, char b)
         str[iwrite] = 0;
 }
 
-char* string_to_path(char* string) {
+char *string_to_path(char *string) {
 
         if (string && 0 == strncmp(string, "~/", 2)) {
-                char* home = g_strconcat(getenv("HOME"), "/", NULL);
+                char *home = g_strconcat(getenv("HOME"), "/", NULL);
 
                 string = string_replace("~/", home, string);
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -22,7 +22,7 @@ void string_strip_delimited(char *str, char a, char b);
 void die(char *msg, int exit_value);
 
 /* replace tilde and path-specific values with its equivalents */
-char* string_to_path(char* string);
+char *string_to_path(char *string);
 
 #endif
 /* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/x11/screen.c
+++ b/src/x11/screen.c
@@ -290,7 +290,7 @@ static int x_follow_tear_down_error_handler(void)
         return dunst_follow_errored;
 }
 
-static int FollowXErrorHandler(Display * display, XErrorEvent * e)
+static int FollowXErrorHandler(Display *display, XErrorEvent *e)
 {
         dunst_follow_errored = true;
         char err_buf[BUFSIZ];

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -108,9 +108,9 @@ static color_t calculate_foreground_color(color_t bg)
 
         int signedness = darken ? -1 : 1;
 
-        color.r = _apply_delta(color.r, c_delta * signedness);
-        color.g = _apply_delta(color.g, c_delta * signedness);
-        color.b = _apply_delta(color.b, c_delta * signedness);
+        color.r = _apply_delta(color.r, c_delta *signedness);
+        color.g = _apply_delta(color.g, c_delta *signedness);
+        color.b = _apply_delta(color.b, c_delta *signedness);
 
         return color;
 }
@@ -737,7 +737,7 @@ static KeySym x_numlock_mod()
 {
         static KeyCode nl = 0;
         KeySym sym = 0;
-        XModifierKeymap * map = XGetModifierMapping(xctx.dpy);
+        XModifierKeymap *map = XGetModifierMapping(xctx.dpy);
 
         if (!nl)
                 nl = XKeysymToKeycode(xctx.dpy, XStringToKeysym("Num_Lock"));
@@ -787,7 +787,7 @@ end:
  * Helper function to use glib's mainloop mechanic
  * with Xlib
  */
-gboolean x_mainloop_fd_prepare(GSource * source, gint * timeout)
+gboolean x_mainloop_fd_prepare(GSource *source, gint *timeout)
 {
         if (timeout)
                 *timeout = -1;
@@ -800,7 +800,7 @@ gboolean x_mainloop_fd_prepare(GSource * source, gint * timeout)
  * Helper function to use glib's mainloop mechanic
  * with Xlib
  */
-gboolean x_mainloop_fd_check(GSource * source)
+gboolean x_mainloop_fd_check(GSource *source)
 {
         return XPending(xctx.dpy) > 0;
 }
@@ -808,7 +808,7 @@ gboolean x_mainloop_fd_check(GSource * source)
 /*
  * Main Dispatcher for XEvents
  */
-gboolean x_mainloop_fd_dispatch(GSource * source, GSourceFunc callback,
+gboolean x_mainloop_fd_dispatch(GSource *source, GSourceFunc callback,
                                 gpointer user_data)
 {
         XEvent ev;
@@ -904,7 +904,7 @@ static void x_handle_click(XEvent ev)
                 int y = settings.separator_height;
                 notification *n = NULL;
                 int first = true;
-                for (GList * iter = g_queue_peek_head_link(displayed); iter;
+                for (GList *iter = g_queue_peek_head_link(displayed); iter;
                      iter = iter->next) {
                         n = iter->data;
                         if (ev.xbutton.y > y && ev.xbutton.y < y + n->displayed_height)
@@ -1155,7 +1155,7 @@ KeySym x_shortcut_string_to_mask(const char *str)
 /*
  * Error handler for grabbing mouse and keyboard errors.
  */
-static int GrabXErrorHandler(Display * display, XErrorEvent * e)
+static int GrabXErrorHandler(Display *display, XErrorEvent *e)
 {
         dunst_grab_errored = true;
         char err_buf[BUFSIZ];
@@ -1195,7 +1195,7 @@ static int x_shortcut_tear_down_error_handler(void)
 /*
  * Grab the given keyboard shortcut.
  */
-int x_shortcut_grab(keyboard_shortcut * ks)
+int x_shortcut_grab(keyboard_shortcut *ks)
 {
         if (!ks->is_valid)
                 return 1;
@@ -1222,7 +1222,7 @@ int x_shortcut_grab(keyboard_shortcut * ks)
 /*
  * Ungrab the given keyboard shortcut.
  */
-void x_shortcut_ungrab(keyboard_shortcut * ks)
+void x_shortcut_ungrab(keyboard_shortcut *ks)
 {
         Window root;
         root = RootWindow(xctx.dpy, DefaultScreen(xctx.dpy));
@@ -1235,7 +1235,7 @@ void x_shortcut_ungrab(keyboard_shortcut * ks)
 /*
  * Initialize the keyboard shortcut.
  */
-void x_shortcut_init(keyboard_shortcut * ks)
+void x_shortcut_init(keyboard_shortcut *ks)
 {
         if (ks == NULL || ks->str == NULL)
                 return;

--- a/src/x11/x.h
+++ b/src/x11/x.h
@@ -48,9 +48,9 @@ void x_win_hide(void);
 void x_win_show(void);
 
 /* shortcut */
-void x_shortcut_init(keyboard_shortcut * shortcut);
-void x_shortcut_ungrab(keyboard_shortcut * ks);
-int x_shortcut_grab(keyboard_shortcut * ks);
+void x_shortcut_init(keyboard_shortcut *shortcut);
+void x_shortcut_ungrab(keyboard_shortcut *ks);
+int x_shortcut_grab(keyboard_shortcut *ks);
 KeySym x_shortcut_string_to_mask(const char *str);
 
 /* X misc */
@@ -58,10 +58,10 @@ bool x_is_idle(void);
 void x_setup(void);
 void x_free(void);
 
-gboolean x_mainloop_fd_dispatch(GSource * source, GSourceFunc callback,
+gboolean x_mainloop_fd_dispatch(GSource *source, GSourceFunc callback,
                                 gpointer user_data);
-gboolean x_mainloop_fd_check(GSource * source);
-gboolean x_mainloop_fd_prepare(GSource * source, gint * timeout);
+gboolean x_mainloop_fd_check(GSource *source);
+gboolean x_mainloop_fd_prepare(GSource *source, gint *timeout);
 
 #endif
 /* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */


### PR DESCRIPTION
As @tsipinakis mentioned in #365 ([here](https://github.com/dunst-project/dunst/pull/365#discussion_r137354820)), this unifies all pointer declarations.

To achieve a consistent scheme, all stars of the pointers should be on the side of the variable and not on the side of the type.

wrong: `char* a`
wrong: `char * a`
good:  `char *a`

This commit is generated by the following sed command with manual fixes of all false positives.

```
find src \( -name '*.c' -or -name '*.h' \) -print0 | xargs -0 -n1 sed -i 's/\([a-zA-Z]\+[-_a-zA-Z0-9]*\)\s*\*\s\+\([a-zA-Z]\+[-_a-zA-Z0-9]*\)/\1 *\2/g'
```