### PR TITLE
Sort linker input file list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ include config.mk
 CFLAGS += -I.
 LDFLAGS += -L.
 
-SRC := $(shell find src/ -name '*.c')
+SRC := $(sort $(shell find src/ -name '*.c'))
 OBJ := ${SRC:.c=.o}
 
 all: doc dunst service


### PR DESCRIPTION
so that dunst binaries build in a reproducible way
in spite of indeterministic filesystem readdir order

See https://reproducible-builds.org/ for why this is good.

Note: the same change could be applied to the test/test part
but that does not end up in the (openSUSE) package so does not matter as much.