### PR TITLE
Add option to control how to ellipsize truncated lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Added
+- `ellipsize` option to control how long lines should be ellipsized when `word_wrap` is set to `false`
+
 ### Fixed
 - `new_icon` rule being ignored on notifications that had a raw icon
 - Do not replace format strings, which are in notification content

--- a/docs/dunst.pod
+++ b/docs/dunst.pod
@@ -351,6 +351,11 @@ If it's set to false, long lines will be truncated an ellipsised.
 If it's set to true, long lines will be broken into multiple lines expanding
 the notification window height as necessary for them to fit.
 
+=item B<ellipsize> (values: [start/middle/end], default: middle)
+
+If word_wrap is set to false, specifies where truncated lines should be
+ellipsized.
+
 =item B<ignore_newline> (values: [true/false], default: false)
 
 If set to true, replace newline characters in notifications with whitespace.

--- a/dunstrc
+++ b/dunstrc
@@ -140,6 +140,9 @@
     # geometry.
     word_wrap = yes
 
+    # When word_wrap is set to no, specify where to ellipsize long lines.
+    ellipsize = middle
+
     # Ignore newlines '\n' in notifications.
     ignore_newline = no
 

--- a/src/settings.c
+++ b/src/settings.c
@@ -169,6 +169,29 @@ void load_settings(char *cmdline_config_path)
                 "Truncating long lines or do word wrap"
         );
 
+        {
+                char *c = option_get_string(
+                        "global",
+                        "ellipsize", "-ellipsize", "middle",
+                        "Ellipsize truncated lines on the start/middle/end"
+                );
+
+                if (strlen(c) > 0) {
+                        if (strcmp(c, "start") == 0)
+                                settings.ellipsize = start;
+                        else if (strcmp(c, "middle") == 0)
+                                settings.ellipsize = middle;
+                        else if (strcmp(c, "end") == 0)
+                                settings.ellipsize = end;
+                        else {
+                                fprintf(stderr,
+                                        "Warning: unknown value for ellipsize\n");
+                                settings.ellipsize = middle;
+                        }
+                        g_free(c);
+                }
+        }
+
         settings.ignore_newline = option_get_bool(
                 "global",
                 "ignore_newline", "-ignore_newline", ignore_newline,

--- a/src/settings.h
+++ b/src/settings.h
@@ -7,6 +7,7 @@
 #include "x11/x.h"
 
 enum alignment { left, center, right };
+enum ellipsize { start, middle, end };
 enum icon_position_t { icons_left, icons_right, icons_off };
 enum separator_color { FOREGROUND, AUTO, FRAME, CUSTOM };
 enum follow_mode { FOLLOW_NONE, FOLLOW_MOUSE, FOLLOW_KEYBOARD };
@@ -45,6 +46,7 @@ typedef struct _settings {
         int history_length;
         int show_indicators;
         int word_wrap;
+        enum ellipsize ellipsize;
         int ignore_newline;
         int line_height;
         int notification_height;

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -6,6 +6,7 @@
 #include <X11/Xatom.h>
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
+#include <assert.h>
 #include <cairo.h>
 #include <cairo-xlib.h>
 #include <gdk/gdk.h>
@@ -404,7 +405,21 @@ static colored_layout *r_init_shared(cairo_t *c, notification *n)
         cl->l = create_layout(c);
 
         if (!settings.word_wrap) {
-                pango_layout_set_ellipsize(cl->l, PANGO_ELLIPSIZE_MIDDLE);
+                PangoEllipsizeMode ellipsize;
+                switch (settings.ellipsize) {
+                        case start:
+                                ellipsize = PANGO_ELLIPSIZE_START;
+                                break;
+                        case middle:
+                                ellipsize = PANGO_ELLIPSIZE_MIDDLE;
+                                break;
+                        case end:
+                                ellipsize = PANGO_ELLIPSIZE_END;
+                                break;
+                        default:
+                                assert(false);
+                }
+                pango_layout_set_ellipsize(cl->l, ellipsize);
         }
 
         GdkPixbuf *pixbuf = NULL;


### PR DESCRIPTION
Add the option `ellipsize` to be able to select how the truncated lines should be ellipsized, accepting `start`, `middle` and `end`.

`middle` is the default value to not change the current behaviour.
`start` is maybe useless as it removes the "summary", but who knows.
`end` is useful to not ellipsize the (long) summary (e.g. IRC notifications where the summary (and/or the start of the body) contains "IRC", the user, and the server/channel).