### PR TITLE
Drop gtk and use gdk-pixbuf

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -17,7 +17,7 @@ LDFLAGS_DEBUG  :=
 
 pkg_config_packs := dbus-1 \
                     gio-2.0 \
-                    gdk-3.0 \
+                    gdk-pixbuf-2.0 \
                     "glib-2.0 >= 2.36" \
                     pangocairo \
                     x11 \

--- a/src/x11/screen.c
+++ b/src/x11/screen.c
@@ -122,6 +122,7 @@ void randr_update()
         alloc_screen_ar(n);
 
         for (int i = 0; i < n; i++) {
+                screens[i].scr = i;
                 screens[i].dim.x = m[i].x;
                 screens[i].dim.y = m[i].y;
                 screens[i].dim.w = m[i].width;
@@ -157,6 +158,7 @@ void xinerama_update()
         alloc_screen_ar(n);
 
         for (int i = 0; i < n; i++) {
+                screens[i].scr = i;
                 screens[i].dim.x = info[i].x_org;
                 screens[i].dim.y = info[i].y_org;
                 screens[i].dim.h = info[i].height;

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -301,6 +301,13 @@ static cairo_status_t read_from_buf(void *closure, unsigned char *data, unsigned
 
 static cairo_surface_t *gdk_pixbuf_to_cairo_surface(GdkPixbuf *pixbuf)
 {
+        /*
+         * Export the gdk pixbuf into buffer as a png and import the png buffer
+         * via cairo again as a cairo_surface_t.
+         * It looks counterintuitive, as there is gdk_cairo_set_source_pixbuf,
+         * which does the job faster. But this would require gtk3 as a dependency
+         * for a single function call. See discussion in #334 and #376.
+         */
         cairo_surface_t *icon_surface = NULL;
         GByteArray *buffer;
         char *bufstr;

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -730,6 +730,7 @@ static void x_win_move(int width, int height)
 
         int x, y;
         screen_info *scr = get_active_screen();
+        xctx.cur_screen = scr->scr;
         /* calculate window position */
         if (xctx.geometry.mask & XNegative) {
                 x = (scr->dim.x + (scr->dim.w - width)) + xctx.geometry.x;
@@ -908,8 +909,16 @@ gboolean x_mainloop_fd_dispatch(GSource *source, GSourceFunc callback, gpointer 
                         break;
                 case FocusIn:
                 case FocusOut:
-                case PropertyNotify:
                         wake_up();
+                        break;
+                case PropertyNotify:
+                        /* Ignore PropertyNotify, when we're still on the
+                         * same screen. PropertyNotify is only neccessary
+                         * to detect a focus change to another screen
+                         */
+                        if(   settings.f_mode != FOLLOW_NONE
+                           && get_active_screen()->scr != xctx.cur_screen)
+                                wake_up();
                         break;
                 default:
                         screen_check_event(ev);

--- a/src/x11/x.h
+++ b/src/x11/x.h
@@ -25,6 +25,7 @@ typedef struct _keyboard_shortcut {
 typedef struct _xctx {
         Atom utf8;
         Display *dpy;
+        int cur_screen;
         Window win;
         bool visible;
         dimension_t geometry;


### PR DESCRIPTION
Removes the neccessity of gdk3.

From #334:

> As it is right now it runs in ~20-30 microseconds and according to my tests when converting it to a png and back goes up to ~200-250 microseconds.
> 
> While that's obviously going to vary from CPU to CPU but a 10x overhead is a significant slowdown and I further discovered that this function gets called every time there's a focus change, that's a lot of needless CPU time.

That's correct. It's unacceptable to have a 10x slowdown. Additionally I think also it is bad spending on every focus change cpu power for the exact same calculation, when it's ok to save it in memory. So why should we spend even 20-30 usec on it?

With this PR, dunst generates the `cairo_surface_t` for the icon now in `notification_init` and saves it as a part of the notification.

> I pushed a proof of concept to a new branch but I really don't like how this is implemented (especially having a separate struct just to pass the buffer pointer and size)

Using `GByteArray` from glib fixes this quite nicely.

---

The code is currently not the best. There are still a few TODO marks left in the commits, but I want to get general feedback before fine-tuning this PR.

Not using `gdk_cairo_set_source_pixbuf` because of the dependency to gtk3, might be a bit counterintuitive in the code, but I think having just because of this function call >160MB dependencies, while dunst is 160KB big it's ok to use a workaround here. KIM, why dunst is mainly used: 

> Dunst is a _lightweight_ repl....

And I think it's ridiculous to pretend it's lightweight, while the deps are factor 1000 bigger.