### PR TITLE
Tests for string append

### DIFF
--- a/src/notification.c
+++ b/src/notification.c
@@ -522,14 +522,8 @@ int notification_init(notification *n, int id)
         char *tmp = g_strconcat(n->summary, " ", n->body, NULL);
 
         char *tmp_urls = extract_urls(tmp);
-        if (tmp_urls != NULL) {
-            if (n->urls != NULL) {
-                n->urls = string_append(n->urls, tmp_urls, "\n");
-                g_free(tmp_urls);
-            } else {
-                n->urls = tmp_urls;
-            }
-        }
+        n->urls = string_append(n->urls, tmp_urls, "\n");
+        g_free(tmp_urls);
 
         if (n->actions) {
                 n->actions->dmenu_str = NULL;

--- a/src/utils.c
+++ b/src/utils.c
@@ -78,6 +78,8 @@ char *string_append(char *a, const char *b, const char *sep)
 {
         if (!a)
                 return g_strdup(b);
+        if (!b)
+                return a;
 
         char *new;
         if (!sep)

--- a/src/utils.c
+++ b/src/utils.c
@@ -76,9 +76,11 @@ char *string_replace_all(const char *needle, const char *replacement,
 
 char *string_append(char *a, const char *b, const char *sep)
 {
-        if (!a)
+        if (!a || *a == '\0') {
+                g_free(a);
                 return g_strdup(b);
-        if (!b)
+        }
+        if (!b || *b == '\0')
                 return a;
 
         char *new;

--- a/test/utils.c
+++ b/test/utils.c
@@ -72,7 +72,29 @@ TEST test_string_replace(void)
 
 TEST test_string_append(void)
 {
-        SKIP(); //TODO: Implement this
+        char *exp;
+
+        ASSERT_STR_EQ("text_sep_bit", (exp = string_append(g_strdup("text"), "bit", "_sep_")));
+        g_free(exp);
+        ASSERT_STR_EQ("textbit", (exp = string_append(g_strdup("text"), "bit", NULL)));
+        g_free(exp);
+        ASSERT_STR_EQ("textbit", (exp = string_append(g_strdup("text"), "bit", "")));
+        g_free(exp);
+
+        ASSERT_STR_EQ("text", (exp = string_append(g_strdup("text"), "", NULL)));
+        g_free(exp);
+
+        ASSERT_STR_EQ("b", (exp = string_append(g_strdup(""), "b", NULL)));
+        g_free(exp);
+        ASSERT_STR_EQ("b", (exp = string_append(NULL, "b", "_sep_")));
+        g_free(exp);
+
+        ASSERT_STR_EQ("a", (exp = string_append(g_strdup("a"), "", NULL)));
+        g_free(exp);
+
+        ASSERT_EQ(NULL, (exp = string_append(NULL, NULL, "_sep_")));
+        g_free(exp);
+
         PASS();
 }
 

--- a/test/utils.c
+++ b/test/utils.c
@@ -83,6 +83,8 @@ TEST test_string_append(void)
 
         ASSERT_STR_EQ("text", (exp = string_append(g_strdup("text"), "", NULL)));
         g_free(exp);
+        ASSERT_STR_EQ("text", (exp = string_append(g_strdup("text"), "", "_sep_")));
+        g_free(exp);
 
         ASSERT_STR_EQ("b", (exp = string_append(g_strdup(""), "b", NULL)));
         g_free(exp);
@@ -94,6 +96,8 @@ TEST test_string_append(void)
         ASSERT_STR_EQ("a", (exp = string_append(g_strdup("a"), NULL, "_sep_")));
         g_free(exp);
 
+        ASSERT_STR_EQ("", (exp = string_append(g_strdup(""), "", "_sep_")));
+        g_free(exp);
         ASSERT_EQ(NULL, (exp = string_append(NULL, NULL, "_sep_")));
         g_free(exp);
 

--- a/test/utils.c
+++ b/test/utils.c
@@ -91,6 +91,8 @@ TEST test_string_append(void)
 
         ASSERT_STR_EQ("a", (exp = string_append(g_strdup("a"), "", NULL)));
         g_free(exp);
+        ASSERT_STR_EQ("a", (exp = string_append(g_strdup("a"), NULL, "_sep_")));
+        g_free(exp);
 
         ASSERT_EQ(NULL, (exp = string_append(NULL, NULL, "_sep_")));
         g_free(exp);


### PR DESCRIPTION
This is somewhat unrelated to previous PRs, but during test runs it bugged me, that this single skipped test was there.

Additionally, I made the `string_append` function also respect empty strings and concatenate the separator only, if both values are set.