### PR TITLE
Use config.h for default ellipsize value

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -27,6 +27,7 @@ int sticky_history = true;
 int history_length = 20;          /* max amount of notifications kept in history */
 int show_indicators = true;
 int word_wrap = false;
+enum ellipsize ellipsize = middle;
 int ignore_newline = false;
 int line_height = 0;            /* if line height < font height, it will be raised to font height */
 int notification_height = 0;    /* if notification height < font height and padding, it will be raised */

--- a/src/settings.c
+++ b/src/settings.c
@@ -172,24 +172,23 @@ void load_settings(char *cmdline_config_path)
         {
                 char *c = option_get_string(
                         "global",
-                        "ellipsize", "-ellipsize", "middle",
+                        "ellipsize", "-ellipsize", "",
                         "Ellipsize truncated lines on the start/middle/end"
                 );
 
-                if (strlen(c) > 0) {
-                        if (strcmp(c, "start") == 0)
-                                settings.ellipsize = start;
-                        else if (strcmp(c, "middle") == 0)
-                                settings.ellipsize = middle;
-                        else if (strcmp(c, "end") == 0)
-                                settings.ellipsize = end;
-                        else {
-                                fprintf(stderr,
-                                        "Warning: unknown value for ellipsize\n");
-                                settings.ellipsize = middle;
-                        }
-                        g_free(c);
+                if (strlen(c) == 0) {
+                        settings.ellipsize = ellipsize;
+                } else if (strcmp(c, "start") == 0) {
+                        settings.ellipsize = start;
+                } else if (strcmp(c, "middle") == 0) {
+                        settings.ellipsize = middle;
+                } else if (strcmp(c, "end") == 0) {
+                        settings.ellipsize = end;
+                } else {
+                        fprintf(stderr, "Warning: unknown ellipsize value: \"%s\"\n", c);
+                        settings.ellipsize = ellipsize;
                 }
+                g_free(c);
         }
 
         settings.ignore_newline = option_get_bool(


### PR DESCRIPTION
Get the default value for `ellipsize` from `config.h`, instead of setting it in two different places (in case it is not set, and in case its value is invalid).