### PR TITLE
Replace notifications flickerless

### DIFF
--- a/src/notification.h
+++ b/src/notification.h
@@ -67,6 +67,7 @@ notification *notification_create(void);
 int notification_init(notification *n, int id);
 void notification_free(notification *n);
 int notification_close_by_id(int id, int reason);
+bool notification_replace_by_id(notification *n);
 int notification_cmp(const void *a, const void *b);
 int notification_cmp_data(const void *a, const void *b, void *data);
 int notification_is_duplicate(const notification *a, const notification *b);


### PR DESCRIPTION
Previously, notifications had been replaced by removing the notification
out of the displayed/queue lists, redrawing the window and then adding
the new notification into the queue. This produced a flickering in
dunst.

By avoiding the overhead of closing and opening the window (simply
replacing the datapointer of the list), the flickering disappears.

Fixes #320 