### PR TITLE
Remove _GNU_SOURCE macro

### DIFF
--- a/src/dunst.c
+++ b/src/dunst.c
@@ -1,6 +1,5 @@
 /* copyright 2012 - 2013 Sascha Kruse and contributors (see LICENSE for licensing information) */
 
-#define _GNU_SOURCE
 #define XLIB_ILLEGAL_ACCESS
 
 #include "dunst.h"

--- a/src/markup.c
+++ b/src/markup.c
@@ -1,6 +1,5 @@
 /* copyright 2013 Sascha Kruse and contributors (see LICENSE for licensing information) */
 
-#define _GNU_SOURCE
 #include "markup.h"
 
 #include <assert.h>

--- a/src/menu.c
+++ b/src/menu.c
@@ -1,6 +1,5 @@
 /* copyright 2013 Sascha Kruse and contributors (see LICENSE for licensing information) */
 
-#define _GNU_SOURCE
 #include "menu.h"
 
 #include <errno.h>

--- a/src/notification.c
+++ b/src/notification.c
@@ -1,6 +1,5 @@
 /* copyright 2013 Sascha Kruse and contributors (see LICENSE for licensing information) */
 
-#define _GNU_SOURCE
 #include "notification.h"
 
 #include <assert.h>

--- a/src/option_parser.c
+++ b/src/option_parser.c
@@ -1,6 +1,5 @@
 /* copyright 2013 Sascha Kruse and contributors (see LICENSE for licensing information) */
 
-#define _GNU_SOURCE
 #include "option_parser.h"
 
 #include <glib.h>

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,5 +1,4 @@
 /* copyright 2013 Sascha Kruse and contributors (see LICENSE for licensing information) */
-#define _GNU_SOURCE
 #include "utils.h"
 
 #include <assert.h>


### PR DESCRIPTION
After some research, the _GNU_SOURCE does not affect any function call
anymore. To avoid future failures on other systems not using glibc,
_GNU_SOURCE gets removed.

---
To answer my own question:

> So, how can we require POSIX.1-2008?

I had the wrong mindset about this. There is no dynamic check for different versions of  functions. Also these do not change over time. So you simply don't check for this in your code. Either the function is defined (and then POSIX.1-2008 compatible) or the function is not defined (then it's not POSIX.1-2008) and the code does not compile. So dunst never runs with a wrong libc.

Fixes #359 