### PR TITLE
Refactor queues

### DIFF
--- a/src/dbus.c
+++ b/src/dbus.c
@@ -282,7 +282,7 @@ static void on_close_notification(GDBusConnection *connection,
 {
         guint32 id;
         g_variant_get(parameters, "(u)", &id);
-        notification_close_by_id(id, 3);
+        queues_notification_close_id(id, 3);
         wake_up();
         g_dbus_method_invocation_return_value(invocation, NULL);
         g_dbus_connection_flush(connection, NULL, NULL, NULL);

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -266,13 +266,18 @@ static void on_notify(GDBusConnection *connection,
 
         notification_init(n);
         int id = queues_notification_insert(n, replaces_id);
-        wake_up();
 
         GVariant *reply = g_variant_new("(u)", id);
         g_dbus_method_invocation_return_value(invocation, reply);
         g_dbus_connection_flush(connection, NULL, NULL, NULL);
 
-        run(NULL);
+        // The message got discarded
+        if (id == 0) {
+                notification_closed(n, 2);
+                notification_free(n);
+        }
+
+        wake_up();
 }
 
 static void on_close_notification(GDBusConnection *connection,

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -8,6 +8,7 @@
 
 #include "dunst.h"
 #include "notification.h"
+#include "queues.h"
 #include "settings.h"
 #include "utils.h"
 

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -282,6 +282,7 @@ static void on_close_notification(GDBusConnection *connection,
         guint32 id;
         g_variant_get(parameters, "(u)", &id);
         notification_close_by_id(id, 3);
+        wake_up();
         g_dbus_method_invocation_return_value(invocation, NULL);
         g_dbus_connection_flush(connection, NULL, NULL, NULL);
 }

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -264,7 +264,8 @@ static void on_notify(GDBusConnection *connection,
         n->color_strings[ColFG] = fgcolor;
         n->color_strings[ColBG] = bgcolor;
 
-        int id = notification_init(n, replaces_id);
+        notification_init(n);
+        int id = queues_notification_insert(n, replaces_id);
         wake_up();
 
         GVariant *reply = g_variant_new("(u)", id);

--- a/src/dunst.c
+++ b/src/dunst.c
@@ -261,7 +261,9 @@ int dunst_main(int argc, char *argv[])
                 n->timeout = 10 * G_USEC_PER_SEC;
                 n->markup = MARKUP_NO;
                 n->urgency = LOW;
-                notification_init(n, 0);
+                notification_init(n);
+                queues_notification_insert(n, 0);
+                // we do not call wakeup now, wake_up does not work here yet
         }
 
         mainloop = g_main_loop_new(NULL, FALSE);

--- a/src/dunst.c
+++ b/src/dunst.c
@@ -240,10 +240,7 @@ static void teardown(void)
 int dunst_main(int argc, char *argv[])
 {
 
-        /*TODO: move to queues.c */
-        history = g_queue_new();
-        displayed = g_queue_new();
-        queue = g_queue_new();
+        queues_init();
 
         cmdline_load(argc, argv);
 

--- a/src/dunst.c
+++ b/src/dunst.c
@@ -36,7 +36,6 @@ typedef struct _x11_source {
 } x11_source_t;
 
 /* index of colors fit to urgency level */
-bool pause_display = false;
 
 GMainLoop *mainloop = NULL;
 
@@ -85,7 +84,7 @@ void update_lists()
 {
         check_timeouts();
 
-        if (pause_display) {
+        if (queues_pause_status()) {
                 while (displayed->length > 0) {
                         g_queue_insert_sorted(queue, g_queue_pop_head(displayed),
                                               notification_cmp_data, NULL);
@@ -130,11 +129,11 @@ gboolean run(void *data)
                 timeout_cnt--;
         }
 
-        if (displayed->length > 0 && !xctx.visible && !pause_display) {
+        if (displayed->length > 0 && !xctx.visible) {
                 x_win_show();
         }
 
-        if (xctx.visible && (pause_display || displayed->length == 0)) {
+        if (xctx.visible && displayed->length == 0) {
                 x_win_hide();
         }
 
@@ -162,7 +161,7 @@ gboolean run(void *data)
 
 gboolean pause_signal(gpointer data)
 {
-        pause_display = true;
+        queues_pause_on();
         wake_up();
 
         return G_SOURCE_CONTINUE;
@@ -170,7 +169,7 @@ gboolean pause_signal(gpointer data)
 
 gboolean unpause_signal(gpointer data)
 {
-        pause_display = false;
+        queues_pause_off();
         wake_up();
 
         return G_SOURCE_CONTINUE;

--- a/src/dunst.c
+++ b/src/dunst.c
@@ -60,11 +60,11 @@ gboolean run(void *data)
                 timeout_cnt--;
         }
 
-        if (displayed->length > 0 && !xctx.visible) {
+        if (queues_length_displayed() > 0 && !xctx.visible) {
                 x_win_show();
         }
 
-        if (xctx.visible && displayed->length == 0) {
+        if (xctx.visible && queues_length_displayed() == 0) {
                 x_win_hide();
         }
 

--- a/src/dunst.c
+++ b/src/dunst.c
@@ -83,8 +83,6 @@ void check_timeouts(void)
 /*TODO: move to queues.c */
 void update_lists()
 {
-        int limit;
-
         check_timeouts();
 
         if (pause_display) {
@@ -95,20 +93,10 @@ void update_lists()
                 return;
         }
 
-        if (xctx.geometry.h == 0) {
-                limit = 0;
-        } else if (xctx.geometry.h == 1) {
-                limit = 1;
-        } else if (settings.indicate_hidden) {
-                limit = xctx.geometry.h - 1;
-        } else {
-                limit = xctx.geometry.h;
-        }
-
         /* move notifications from queue to displayed */
         while (queue->length > 0) {
 
-                if (limit > 0 && displayed->length >= limit) {
+                if (displayed_limit > 0 && displayed->length >= displayed_limit) {
                         /* the list is full */
                         break;
                 }

--- a/src/dunst.h
+++ b/src/dunst.h
@@ -16,9 +16,6 @@
 #define ColFG 1
 #define ColBG 0
 
-extern GQueue *queue;
-extern GQueue *displayed;
-extern GQueue *history;
 extern GSList *rules;
 extern bool pause_display;
 extern const char *color_strings[3][3];
@@ -30,10 +27,7 @@ void wake_up(void);
 int dunst_main(int argc, char *argv[]);
 
 void check_timeouts(void);
-void history_pop(void);
-void history_push(notification *n);
 void usage(int exit_status);
-void move_all_to_history(void);
 void print_version(void);
 char *extract_urls(const char *str);
 void context_menu(void);

--- a/src/dunst.h
+++ b/src/dunst.h
@@ -17,7 +17,6 @@
 #define ColBG 0
 
 extern GSList *rules;
-extern bool pause_display;
 extern const char *color_strings[3][3];
 
 /* return id of notification */

--- a/src/menu.c
+++ b/src/menu.c
@@ -137,7 +137,7 @@ void invoke_action(const char *action)
         int appname_len = strlen(appname_begin) - 1; // remove ]
         int action_len = strlen(action) - appname_len - 3; // remove space, [, ]
 
-        for (GList *iter = g_queue_peek_head_link(displayed); iter;
+        for (const GList *iter = queues_get_displayed(); iter;
              iter = iter->next) {
                 notification *n = iter->data;
                 if (g_str_has_prefix(appname_begin, n->appname) && strlen(n->appname) == appname_len) {
@@ -189,7 +189,7 @@ void context_menu(void)
         }
         char *dmenu_input = NULL;
 
-        for (GList *iter = g_queue_peek_head_link(displayed); iter;
+        for (const GList *iter = queues_get_displayed(); iter;
              iter = iter->next) {
                 notification *n = iter->data;
 

--- a/src/menu.c
+++ b/src/menu.c
@@ -16,6 +16,7 @@
 #include "dunst.h"
 #include "settings.h"
 #include "notification.h"
+#include "queues.h"
 #include "utils.h"
 
 static bool is_initialized = false;

--- a/src/notification.c
+++ b/src/notification.c
@@ -292,17 +292,6 @@ void notification_init(notification *n)
         //Prevent undefined behaviour by initialising required fields
         notification_init_defaults(n);
 
-        // TODO: this does not belong into notification_init
-        if (strcmp("DUNST_COMMAND_PAUSE", n->summary) == 0) {
-                queues_pause_on();
-                return;
-        }
-
-        if (strcmp("DUNST_COMMAND_RESUME", n->summary) == 0) {
-                queues_pause_off();
-                return;
-        }
-
         n->script = NULL;
         n->text_to_render = NULL;
 
@@ -448,15 +437,6 @@ void notification_init(notification *n)
         n->redisplayed = false;
 
         n->first_render = true;
-
-        /* TODO: this should not be part of notification_init */
-        if (strlen(n->msg) == 0) {
-                queues_notification_close(n, 2);
-                if (settings.always_run_script) {
-                        notification_run_script(n);
-                }
-                printf("skipping notification: %s %s\n", n->body, n->summary);
-        }
 
         char *tmp = g_strconcat(n->summary, " ", n->body, NULL);
 

--- a/src/notification.c
+++ b/src/notification.c
@@ -23,7 +23,6 @@
 #include "utils.h"
 #include "x11/x.h"
 
-int next_notification_id = 1;
 
 /*
  * print a human readable representation
@@ -280,28 +279,28 @@ void notification_init_defaults(notification *n)
 }
 
 /*
- * Initialize the given notification and add it to
- * the queue. Replace notification with id if id > 0.
+ * Initialize the given notification
  *
  * n should be a pointer to a notification allocated with
  * notification_create, it is undefined behaviour to pass a notification
  * allocated some other way.
  */
-int notification_init(notification *n, int id)
+void notification_init(notification *n)
 {
         assert(n != NULL);
 
         //Prevent undefined behaviour by initialising required fields
         notification_init_defaults(n);
 
+        // TODO: this does not belong into notification_init
         if (strcmp("DUNST_COMMAND_PAUSE", n->summary) == 0) {
                 pause_display = true;
-                return 0;
+                return;
         }
 
         if (strcmp("DUNST_COMMAND_RESUME", n->summary) == 0) {
                 pause_display = false;
-                return 0;
+                return;
         }
 
         n->script = NULL;
@@ -423,64 +422,7 @@ int notification_init(notification *n, int id)
                 n->msg = buffer;
         }
 
-        if (id == 0) {
-                n->id = ++next_notification_id;
-        } else {
-                n->id = id;
-        }
-
         n->dup_count = 0;
-
-        /* TODO: move this to queue.c */
-        /* check if n is a duplicate */
-        if (settings.stack_duplicates) {
-                for (GList *iter = g_queue_peek_head_link(queue); iter;
-                     iter = iter->next) {
-                        notification *orig = iter->data;
-                        if (notification_is_duplicate(orig, n)) {
-                                /* If the progress differs this was probably intended to replace the notification
-                                 * but notify-send was used. So don't increment dup_count in this case
-                                 */
-                                if (orig->progress == n->progress) {
-                                        orig->dup_count++;
-                                } else {
-                                        orig->progress = n->progress;
-                                }
-                                /* notifications that differ only in progress hints should be expected equal,
-                                 * but we want the latest message, with the latest hint value
-                                 */
-                                g_free(orig->msg);
-                                orig->msg = g_strdup(n->msg);
-                                notification_free(n);
-                                wake_up();
-                                return orig->id;
-                        }
-                }
-
-                for (GList *iter = g_queue_peek_head_link(displayed); iter;
-                     iter = iter->next) {
-                        notification *orig = iter->data;
-                        if (notification_is_duplicate(orig, n)) {
-                                /* notifications that differ only in progress hints should be expected equal,
-                                 * but we want the latest message, with the latest hint value
-                                 */
-                                g_free(orig->msg);
-                                orig->msg = g_strdup(n->msg);
-                                /* If the progress differs this was probably intended to replace the notification
-                                 * but notify-send was used. So don't increment dup_count in this case
-                                 */
-                                if (orig->progress == n->progress) {
-                                        orig->dup_count++;
-                                } else {
-                                        orig->progress = n->progress;
-                                }
-                                orig->start = g_get_monotonic_time();
-                                notification_free(n);
-                                wake_up();
-                                return orig->id;
-                        }
-                }
-        }
 
         /* urgency > CRIT -> array out of range */
         n->urgency = n->urgency > CRIT ? CRIT : n->urgency;
@@ -507,15 +449,13 @@ int notification_init(notification *n, int id)
 
         n->first_render = true;
 
+        /* TODO: this should not be part of notification_init */
         if (strlen(n->msg) == 0) {
                 notification_close(n, 2);
                 if (settings.always_run_script) {
                         notification_run_script(n);
                 }
                 printf("skipping notification: %s %s\n", n->body, n->summary);
-        } else {
-                if (id == 0 || !notification_replace_by_id(n))
-                        g_queue_insert_sorted(queue, n, notification_cmp_data, NULL);
         }
 
         char *tmp = g_strconcat(n->summary, " ", n->body, NULL);
@@ -540,11 +480,6 @@ int notification_init(notification *n, int id)
         }
 
         g_free(tmp);
-
-        if (settings.print_notifications)
-                notification_print(n);
-
-        return n->id;
 }
 
 void notification_update_text_to_render(notification *n)

--- a/src/notification.c
+++ b/src/notification.c
@@ -294,12 +294,12 @@ void notification_init(notification *n)
 
         // TODO: this does not belong into notification_init
         if (strcmp("DUNST_COMMAND_PAUSE", n->summary) == 0) {
-                pause_display = true;
+                queues_pause_on();
                 return;
         }
 
         if (strcmp("DUNST_COMMAND_RESUME", n->summary) == 0) {
-                pause_display = false;
+                queues_pause_off();
                 return;
         }
 

--- a/src/notification.c
+++ b/src/notification.c
@@ -451,7 +451,7 @@ void notification_init(notification *n)
 
         /* TODO: this should not be part of notification_init */
         if (strlen(n->msg) == 0) {
-                notification_close(n, 2);
+                queues_notification_close(n, 2);
                 if (settings.always_run_script) {
                         notification_run_script(n);
                 }

--- a/src/notification.h
+++ b/src/notification.h
@@ -64,13 +64,10 @@ typedef struct _notification {
 notification *notification_create(void);
 int notification_init(notification *n, int id);
 void notification_free(notification *n);
-int notification_close_by_id(int id, int reason);
-bool notification_replace_by_id(notification *n);
 int notification_cmp(const void *a, const void *b);
 int notification_cmp_data(const void *a, const void *b, void *data);
 int notification_is_duplicate(const notification *a, const notification *b);
 void notification_run_script(notification *n);
-int notification_close(notification *n, int reason);
 void notification_print(notification *n);
 void notification_replace_single_field(char **haystack, char **needle, const char *replacement, enum markup_mode markup_mode);
 void notification_update_text_to_render(notification *n);

--- a/src/notification.h
+++ b/src/notification.h
@@ -62,7 +62,7 @@ typedef struct _notification {
 } notification;
 
 notification *notification_create(void);
-int notification_init(notification *n, int id);
+void notification_init(notification *n);
 void notification_free(notification *n);
 int notification_cmp(const void *a, const void *b);
 int notification_cmp_data(const void *a, const void *b, void *data);

--- a/src/queues.c
+++ b/src/queues.c
@@ -14,6 +14,13 @@ GQueue *queue     = NULL; /* all new notifications get into here */
 GQueue *displayed = NULL; /* currently displayed notifications */
 GQueue *history   = NULL; /* history of displayed notifications */
 
+void queues_init(void)
+{
+        history   = g_queue_new();
+        displayed = g_queue_new();
+        queue     = g_queue_new();
+}
+
 bool notification_replace_by_id(notification *new)
 {
 

--- a/src/queues.c
+++ b/src/queues.c
@@ -35,8 +35,6 @@ int queues_notification_insert(notification *n, int replaces_id)
 {
         if (replaces_id == 0) {
 
-                n->id = ++next_notification_id;
-
                 if (settings.stack_duplicates) {
                         int stacked = queues_stack_duplicate(n);
                         if (stacked > 0) {
@@ -44,6 +42,8 @@ int queues_notification_insert(notification *n, int replaces_id)
                                 return stacked;
                         }
                 }
+
+                n->id = ++next_notification_id;
 
                 g_queue_insert_sorted(queue, n, notification_cmp_data, NULL);
 

--- a/src/queues.c
+++ b/src/queues.c
@@ -6,7 +6,6 @@
 #include <glib.h>
 
 #include "dbus.h"
-#include "dunst.h"
 #include "notification.h"
 #include "settings.h"
 
@@ -76,7 +75,6 @@ int notification_close_by_id(int id, int reason)
                 notification_closed(target, reason);
         }
 
-        wake_up();
         return reason;
 }
 
@@ -107,8 +105,6 @@ void history_pop(void)
         n->start = 0;
         n->timeout = settings.sticky_history ? 0 : n->timeout;
         g_queue_push_head(queue, n);
-
-        wake_up();
 }
 
 void history_push(notification *n)

--- a/src/queues.c
+++ b/src/queues.c
@@ -10,9 +10,9 @@
 #include "settings.h"
 
 /* notification lists */
-GQueue *queue     = NULL; /* all new notifications get into here */
-GQueue *displayed = NULL; /* currently displayed notifications */
-GQueue *history   = NULL; /* history of displayed notifications */
+static GQueue *queue     = NULL; /* all new notifications get into here */
+static GQueue *displayed = NULL; /* currently displayed notifications */
+static GQueue *history   = NULL; /* history of displayed notifications */
 
 unsigned int displayed_limit = 0;
 int next_notification_id = 1;
@@ -30,6 +30,24 @@ void queues_init(void)
 void queues_displayed_limit(unsigned int limit)
 {
         displayed_limit = limit;
+}
+
+/* misc getter functions */
+const GList *queues_get_displayed()
+{
+        return g_queue_peek_head_link(displayed);
+}
+unsigned int queues_length_waiting()
+{
+        return queue->length;
+}
+unsigned int queues_length_displayed()
+{
+        return displayed->length;
+}
+unsigned int queues_length_history()
+{
+        return history->length;
 }
 
 int queues_notification_insert(notification *n, int replaces_id)

--- a/src/queues.c
+++ b/src/queues.c
@@ -4,6 +4,8 @@
 
 #include <assert.h>
 #include <glib.h>
+#include <stdio.h>
+#include <string.h>
 
 #include "dbus.h"
 #include "notification.h"
@@ -52,6 +54,24 @@ unsigned int queues_length_history()
 
 int queues_notification_insert(notification *n, int replaces_id)
 {
+        /* do not display the message, if the message is empty */
+        if (strlen(n->msg) == 0) {
+                if (settings.always_run_script) {
+                        notification_run_script(n);
+                }
+                printf("skipping notification: %s %s\n", n->body, n->summary);
+                return 0;
+        }
+        /* Do not insert the message if it's a command */
+        if (strcmp("DUNST_COMMAND_PAUSE", n->summary) == 0) {
+                pause_displayed = true;
+                return 0;
+        }
+        if (strcmp("DUNST_COMMAND_RESUME", n->summary) == 0) {
+                pause_displayed = false;
+                return 0;
+        }
+
         if (replaces_id == 0) {
 
                 if (settings.stack_duplicates) {

--- a/src/queues.c
+++ b/src/queues.c
@@ -50,7 +50,7 @@ int queues_notification_insert(notification *n, int replaces_id)
 
         } else {
                 n->id = replaces_id;
-                if (!notification_replace_by_id(n))
+                if (!queues_notification_replace_id(n))
                         g_queue_insert_sorted(queue, n, notification_cmp_data, NULL);
         }
 
@@ -110,7 +110,7 @@ static int queues_stack_duplicate(notification *n)
         return -1;
 }
 
-bool notification_replace_by_id(notification *new)
+bool queues_notification_replace_id(notification *new)
 {
 
         for (GList *iter = g_queue_peek_head_link(displayed);
@@ -141,7 +141,7 @@ bool notification_replace_by_id(notification *new)
         return false;
 }
 
-int notification_close_by_id(int id, int reason)
+int queues_notification_close_id(int id, int reason)
 {
         notification *target = NULL;
 
@@ -174,20 +174,20 @@ int notification_close_by_id(int id, int reason)
         return reason;
 }
 
-int notification_close(notification *n, int reason)
+int queues_notification_close(notification *n, int reason)
 {
         assert(n != NULL);
-        return notification_close_by_id(n->id, reason);
+        return queues_notification_close_id(n->id, reason);
 }
 
 void move_all_to_history()
 {
         while (displayed->length > 0) {
-                notification_close(g_queue_peek_head_link(displayed)->data, 2);
+                queues_notification_close(g_queue_peek_head_link(displayed)->data, 2);
         }
 
         while (queue->length > 0) {
-                notification_close(g_queue_peek_head_link(queue)->data, 2);
+                queues_notification_close(g_queue_peek_head_link(queue)->data, 2);
         }
 }
 
@@ -244,7 +244,7 @@ void queues_check_timeouts(bool idle)
 
                 /* remove old message */
                 if (g_get_monotonic_time() - n->start > n->timeout) {
-                        notification_close(n, 1);
+                        queues_notification_close(n, 1);
                 }
         }
 }

--- a/src/queues.c
+++ b/src/queues.c
@@ -122,7 +122,7 @@ bool queues_notification_replace_id(notification *new)
                         new->start = time(NULL);
                         new->dup_count = old->dup_count;
                         notification_run_script(new);
-                        history_push(old);
+                        queues_history_push(old);
                         return true;
                 }
         }
@@ -134,7 +134,7 @@ bool queues_notification_replace_id(notification *new)
                 if (old->id == new->id) {
                         iter->data = new;
                         new->dup_count = old->dup_count;
-                        history_push(old);
+                        queues_history_push(old);
                         return true;
                 }
         }
@@ -150,7 +150,7 @@ int queues_notification_close_id(int id, int reason)
                 notification *n = iter->data;
                 if (n->id == id) {
                         g_queue_remove(displayed, n);
-                        history_push(n);
+                        queues_history_push(n);
                         target = n;
                         break;
                 }
@@ -161,7 +161,7 @@ int queues_notification_close_id(int id, int reason)
                 notification *n = iter->data;
                 if (n->id == id) {
                         g_queue_remove(queue, n);
-                        history_push(n);
+                        queues_history_push(n);
                         target = n;
                         break;
                 }
@@ -180,18 +180,7 @@ int queues_notification_close(notification *n, int reason)
         return queues_notification_close_id(n->id, reason);
 }
 
-void move_all_to_history()
-{
-        while (displayed->length > 0) {
-                queues_notification_close(g_queue_peek_head_link(displayed)->data, 2);
-        }
-
-        while (queue->length > 0) {
-                queues_notification_close(g_queue_peek_head_link(queue)->data, 2);
-        }
-}
-
-void history_pop(void)
+void queues_history_pop(void)
 {
         if (g_queue_is_empty(history))
                 return;
@@ -203,7 +192,7 @@ void history_pop(void)
         g_queue_push_head(queue, n);
 }
 
-void history_push(notification *n)
+void queues_history_push(notification *n)
 {
         if (settings.history_length > 0 && history->length >= settings.history_length) {
                 notification *to_free = g_queue_pop_head(history);
@@ -212,6 +201,17 @@ void history_push(notification *n)
 
         if (!n->history_ignore)
                 g_queue_push_tail(history, n);
+}
+
+void queues_history_push_all(void)
+{
+        while (displayed->length > 0) {
+                queues_notification_close(g_queue_peek_head_link(displayed)->data, 2);
+        }
+
+        while (queue->length > 0) {
+                queues_notification_close(g_queue_peek_head_link(queue)->data, 2);
+        }
 }
 
 void queues_check_timeouts(bool idle)

--- a/src/queues.c
+++ b/src/queues.c
@@ -213,6 +213,37 @@ void history_push(notification *n)
                 g_queue_push_tail(history, n);
 }
 
+gint64 queues_get_next_datachange(gint64 time)
+{
+        gint64 sleep = G_MAXINT64;
+
+        for (GList *iter = g_queue_peek_head_link(displayed); iter;
+                        iter = iter->next) {
+                notification *n = iter->data;
+                gint64 ttl = n->timeout - (time - n->start);
+
+                if (n->timeout > 0) {
+                        if (ttl > 0)
+                                sleep = MIN(sleep, ttl);
+                        else
+                                // while we're processing, the notification already timed out
+                                return 0;
+                }
+
+                if (settings.show_age_threshold >= 0) {
+                        gint64 age = time - n->timestamp;
+
+                        if (age > settings.show_age_threshold)
+                                // sleep exactly until the next shift of the second happens
+                                sleep = MIN(sleep, ((G_USEC_PER_SEC) - (age % (G_USEC_PER_SEC))));
+                        else if (ttl > settings.show_age_threshold)
+                                sleep = MIN(sleep, settings.show_age_threshold);
+                }
+        }
+
+        return sleep != G_MAXINT64 ? sleep : -1;
+}
+
 static void teardown_notification(gpointer data)
 {
         notification *n = data;

--- a/src/queues.c
+++ b/src/queues.c
@@ -16,6 +16,7 @@ GQueue *history   = NULL; /* history of displayed notifications */
 
 unsigned int displayed_limit = 0;
 int next_notification_id = 1;
+bool pause_displayed = false;
 
 static int queues_stack_duplicate(notification *n);
 
@@ -242,6 +243,21 @@ gint64 queues_get_next_datachange(gint64 time)
         }
 
         return sleep != G_MAXINT64 ? sleep : -1;
+}
+
+void queues_pause_on(void)
+{
+        pause_displayed = true;
+}
+
+void queues_pause_off(void)
+{
+        pause_displayed = false;
+}
+
+bool queues_pause_status(void)
+{
+        return pause_displayed;
 }
 
 static void teardown_notification(gpointer data)

--- a/src/queues.c
+++ b/src/queues.c
@@ -14,11 +14,18 @@ GQueue *queue     = NULL; /* all new notifications get into here */
 GQueue *displayed = NULL; /* currently displayed notifications */
 GQueue *history   = NULL; /* history of displayed notifications */
 
+unsigned int displayed_limit = 0;
+
 void queues_init(void)
 {
         history   = g_queue_new();
         displayed = g_queue_new();
         queue     = g_queue_new();
+}
+
+void queues_displayed_limit(unsigned int limit)
+{
+        displayed_limit = limit;
 }
 
 bool notification_replace_by_id(notification *new)

--- a/src/queues.c
+++ b/src/queues.c
@@ -1,0 +1,137 @@
+/* copyright 2013 Sascha Kruse and contributors (see LICENSE for licensing information) */
+
+#include "queues.h"
+
+#include <assert.h>
+#include <glib.h>
+
+#include "dbus.h"
+#include "dunst.h"
+#include "notification.h"
+#include "settings.h"
+
+/* notification lists */
+GQueue *queue     = NULL; /* all new notifications get into here */
+GQueue *displayed = NULL; /* currently displayed notifications */
+GQueue *history   = NULL; /* history of displayed notifications */
+
+bool notification_replace_by_id(notification *new)
+{
+
+        for (GList *iter = g_queue_peek_head_link(displayed);
+                    iter;
+                    iter = iter->next) {
+                notification *old = iter->data;
+                if (old->id == new->id) {
+                        iter->data = new;
+                        new->start = time(NULL);
+                        new->dup_count = old->dup_count;
+                        notification_run_script(new);
+                        history_push(old);
+                        return true;
+                }
+        }
+
+        for (GList *iter = g_queue_peek_head_link(queue);
+                    iter;
+                    iter = iter->next) {
+                notification *old = iter->data;
+                if (old->id == new->id) {
+                        iter->data = new;
+                        new->dup_count = old->dup_count;
+                        history_push(old);
+                        return true;
+                }
+        }
+        return false;
+}
+
+int notification_close_by_id(int id, int reason)
+{
+        notification *target = NULL;
+
+        for (GList *iter = g_queue_peek_head_link(displayed); iter;
+             iter = iter->next) {
+                notification *n = iter->data;
+                if (n->id == id) {
+                        g_queue_remove(displayed, n);
+                        history_push(n);
+                        target = n;
+                        break;
+                }
+        }
+
+        for (GList *iter = g_queue_peek_head_link(queue); iter;
+             iter = iter->next) {
+                notification *n = iter->data;
+                if (n->id == id) {
+                        g_queue_remove(queue, n);
+                        history_push(n);
+                        target = n;
+                        break;
+                }
+        }
+
+        if (reason > 0 && reason < 4 && target != NULL) {
+                notification_closed(target, reason);
+        }
+
+        wake_up();
+        return reason;
+}
+
+int notification_close(notification *n, int reason)
+{
+        assert(n != NULL);
+        return notification_close_by_id(n->id, reason);
+}
+
+void move_all_to_history()
+{
+        while (displayed->length > 0) {
+                notification_close(g_queue_peek_head_link(displayed)->data, 2);
+        }
+
+        while (queue->length > 0) {
+                notification_close(g_queue_peek_head_link(queue)->data, 2);
+        }
+}
+
+void history_pop(void)
+{
+        if (g_queue_is_empty(history))
+                return;
+
+        notification *n = g_queue_pop_tail(history);
+        n->redisplayed = true;
+        n->start = 0;
+        n->timeout = settings.sticky_history ? 0 : n->timeout;
+        g_queue_push_head(queue, n);
+
+        wake_up();
+}
+
+void history_push(notification *n)
+{
+        if (settings.history_length > 0 && history->length >= settings.history_length) {
+                notification *to_free = g_queue_pop_head(history);
+                notification_free(to_free);
+        }
+
+        if (!n->history_ignore)
+                g_queue_push_tail(history, n);
+}
+
+static void teardown_notification(gpointer data)
+{
+        notification *n = data;
+        notification_free(n);
+}
+
+void teardown_queues(void)
+{
+        g_queue_free_full(history, teardown_notification);
+        g_queue_free_full(displayed, teardown_notification);
+        g_queue_free_full(queue, teardown_notification);
+}
+/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/queues.h
+++ b/src/queues.h
@@ -37,6 +37,7 @@ unsigned int queues_length_history();
  * If replaces_id == 0, n gets occupies a new position
  *
  * Returns the assigned notification id
+ * If returned id == 0, the message was dismissed
  */
 int queues_notification_insert(notification *n, int replaces_id);
 

--- a/src/queues.h
+++ b/src/queues.h
@@ -8,11 +8,18 @@
 extern GQueue *queue;
 extern GQueue *displayed;
 extern GQueue *history;
+extern unsigned int displayed_limit;
 
 /*
  * Initialise neccessary queues
  */
 void queues_init(void);
+
+/*
+ * Set maximum notification count to display
+ * and store in displayed queue
+ */
+void queues_displayed_limit(unsigned int limit);
 
 /*
  * Replace the notification which matches the id field of

--- a/src/queues.h
+++ b/src/queues.h
@@ -40,7 +40,7 @@ int queues_notification_insert(notification *n, int replaces_id);
  * Returns true, if a matching notification has been found
  * and is replaced. Else false.
  */
-bool notification_replace_by_id(notification *new);
+bool queues_notification_replace_id(notification *new);
 
 /*
  * Close the notification that has id.
@@ -53,10 +53,10 @@ bool notification_replace_by_id(notification *new);
  *  2 -> the notification was dismissed by the user_data
  *  3 -> The notification was closed by a call to CloseNotification
  */
-int notification_close_by_id(int id, int reason);
+int queues_notification_close_id(int id, int reason);
 
-/* Close the given notification. SEE notification_close_by_id. */
-int notification_close(notification *n, int reason);
+/* Close the given notification. SEE queues_notification_close_id. */
+int queues_notification_close(notification *n, int reason);
 
 void history_pop(void);
 void history_push(notification *n);

--- a/src/queues.h
+++ b/src/queues.h
@@ -75,6 +75,17 @@ void move_all_to_history(void);
 gint64 queues_get_next_datachange(gint64 time);
 
 /*
+ * Pause queue-management of dunst
+ *   pause_on  = paused (no notifications displayed)
+ *   pause_off = running
+ *
+ * Calling update_lists is neccessary
+ */
+void queues_pause_on(void);
+void queues_pause_off(void);
+bool queues_pause_status(void);
+
+/*
  * Remove all notifications from all lists
  * and free the notifications
  */

--- a/src/queues.h
+++ b/src/queues.h
@@ -1,0 +1,49 @@
+/* copyright 2013 Sascha Kruse and contributors (see LICENSE for licensing information) */
+
+#ifndef DUNST_QUEUE_H
+#define DUNST_QUEUE_H
+
+#include "notification.h"
+
+extern GQueue *queue;
+extern GQueue *displayed;
+extern GQueue *history;
+
+/*
+ * Replace the notification which matches the id field of
+ * the new notification. The given notification is inserted
+ * right in the same position as the old notification.
+ *
+ * Returns true, if a matching notification has been found
+ * and is replaced. Else false.
+ */
+bool notification_replace_by_id(notification *new);
+
+/*
+ * Close the notification that has id.
+ *
+ * After closing, call wake_up to remove the notification from UI
+ *
+ * reasons:
+ * -1 -> notification is a replacement, no NotificationClosed signal emitted
+ *  1 -> the notification expired
+ *  2 -> the notification was dismissed by the user_data
+ *  3 -> The notification was closed by a call to CloseNotification
+ */
+int notification_close_by_id(int id, int reason);
+
+/* Close the given notification. SEE notification_close_by_id. */
+int notification_close(notification *n, int reason);
+
+void history_pop(void);
+void history_push(notification *n);
+void move_all_to_history(void);
+
+/*
+ * Remove all notifications from all lists
+ * and free the notifications
+ */
+void teardown_queues(void);
+
+#endif
+/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/queues.h
+++ b/src/queues.h
@@ -58,9 +58,22 @@ int queues_notification_close_id(int id, int reason);
 /* Close the given notification. SEE queues_notification_close_id. */
 int queues_notification_close(notification *n, int reason);
 
-void history_pop(void);
-void history_push(notification *n);
-void move_all_to_history(void);
+/*
+ * Pushed the latest notification of history to the displayed queue
+ * and removes it from history
+ */
+void queues_history_pop(void);
+
+/*
+ * Push a single notification to history
+ * The given notification has to be removed its queue
+ */
+void queues_history_push(notification *n);
+
+/*
+ * Push all waiting and displayed notifications to history
+ */
+void queues_history_push_all(void);
 
 /*
  * Check timeout of each notification and close it, if neccessary

--- a/src/queues.h
+++ b/src/queues.h
@@ -5,11 +5,6 @@
 
 #include "notification.h"
 
-extern GQueue *queue;
-extern GQueue *displayed;
-extern GQueue *history;
-extern unsigned int displayed_limit;
-
 /*
  * Initialise neccessary queues
  */
@@ -20,6 +15,19 @@ void queues_init(void);
  * and store in displayed queue
  */
 void queues_displayed_limit(unsigned int limit);
+
+/*
+ * Return read only list of notifications
+ */
+const GList *queues_get_displayed();
+
+/*
+ * Returns the current amount of notifications,
+ * which are shown, waiting or already in history
+ */
+unsigned int queues_length_waiting();
+unsigned int queues_length_displayed();
+unsigned int queues_length_history();
 
 /*
  * Insert a fully initialized notification into queues
@@ -43,9 +51,12 @@ int queues_notification_insert(notification *n, int replaces_id);
 bool queues_notification_replace_id(notification *new);
 
 /*
- * Close the notification that has id.
+ * Close the notification that has n->id == id
  *
- * After closing, call wake_up to remove the notification from UI
+ * Sends a signal and pushes it automatically to history.
+ *
+ * After closing, call wake_up to synchronize the queues with the UI
+ * (which closes the notification on screen)
  *
  * reasons:
  * -1 -> notification is a replacement, no NotificationClosed signal emitted

--- a/src/queues.h
+++ b/src/queues.h
@@ -63,6 +63,18 @@ void history_push(notification *n);
 void move_all_to_history(void);
 
 /*
+ * Return the distance to the next event in the queue,
+ * which forces an update visible to the user
+ *
+ * This may be:
+ *
+ * - notification hits timeout
+ * - notification's age second changes
+ * - notification's age threshold is hit
+ */
+gint64 queues_get_next_datachange(gint64 time);
+
+/*
  * Remove all notifications from all lists
  * and free the notifications
  */

--- a/src/queues.h
+++ b/src/queues.h
@@ -22,6 +22,17 @@ void queues_init(void);
 void queues_displayed_limit(unsigned int limit);
 
 /*
+ * Insert a fully initialized notification into queues
+ * Respects stack_duplicates, and notification replacement
+ *
+ * If replaces_id != 0, n replaces notification with id replaces_id
+ * If replaces_id == 0, n gets occupies a new position
+ *
+ * Returns the assigned notification id
+ */
+int queues_notification_insert(notification *n, int replaces_id);
+
+/*
  * Replace the notification which matches the id field of
  * the new notification. The given notification is inserted
  * right in the same position as the old notification.

--- a/src/queues.h
+++ b/src/queues.h
@@ -10,6 +10,11 @@ extern GQueue *displayed;
 extern GQueue *history;
 
 /*
+ * Initialise neccessary queues
+ */
+void queues_init(void);
+
+/*
  * Replace the notification which matches the id field of
  * the new notification. The given notification is inserted
  * right in the same position as the old notification.

--- a/src/queues.h
+++ b/src/queues.h
@@ -63,6 +63,18 @@ void history_push(notification *n);
 void move_all_to_history(void);
 
 /*
+ * Check timeout of each notification and close it, if neccessary
+ */
+void queues_check_timeouts(bool idle);
+
+/*
+ * Move inserted notifications from waiting queue to displayed queue
+ * and show them. In displayed queue, the amount of elements is limited
+ * to the amount set via queues_displayed_limit
+ */
+void queues_update();
+
+/*
  * Return the distance to the next event in the queue,
  * which forces an update visible to the user
  *

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -866,14 +866,14 @@ gboolean x_mainloop_fd_dispatch(GSource *source, GSourceFunc callback,
                             && XLookupKeysym(&ev.xkey,
                                              0) == settings.history_ks.sym
                             && settings.history_ks.mask == state) {
-                                history_pop();
+                                queues_history_pop();
                                 wake_up();
                         }
                         if (settings.close_all_ks.str
                             && XLookupKeysym(&ev.xkey,
                                              0) == settings.close_all_ks.sym
                             && settings.close_all_ks.mask == state) {
-                                move_all_to_history();
+                                queues_history_push_all();
                                 wake_up();
                         }
                         if (settings.context_ks.str
@@ -917,7 +917,7 @@ bool x_is_idle(void)
 static void x_handle_click(XEvent ev)
 {
         if (ev.xbutton.button == Button3) {
-                move_all_to_history();
+                queues_history_push_all();
 
                 return;
         }

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -857,7 +857,7 @@ gboolean x_mainloop_fd_dispatch(GSource *source, GSourceFunc callback,
                                 if (displayed) {
                                         notification *n = g_queue_peek_head(displayed);
                                         if (n) {
-                                                notification_close(n, 2);
+                                                queues_notification_close(n, 2);
                                                 wake_up();
                                         }
                                 }
@@ -939,7 +939,7 @@ static void x_handle_click(XEvent ev)
 
                 if (n) {
                         if (ev.xbutton.button == Button1)
-                                notification_close(n, 2);
+                                queues_notification_close(n, 2);
                         else
                                 notification_do_action(n);
                 }

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -29,6 +29,7 @@
 #include "src/markup.h"
 #include "src/notification.h"
 #include "src/settings.h"
+#include "src/queues.h"
 #include "src/utils.h"
 
 #include "screen.h"

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -843,6 +843,7 @@ gboolean x_mainloop_fd_dispatch(GSource *source, GSourceFunc callback,
                 case ButtonRelease:
                         if (ev.xbutton.window == xctx.win) {
                                 x_handle_click(ev);
+                                wake_up();
                         }
                         break;
                 case KeyPress:
@@ -855,8 +856,10 @@ gboolean x_mainloop_fd_dispatch(GSource *source, GSourceFunc callback,
                             && settings.close_ks.mask == state) {
                                 if (displayed) {
                                         notification *n = g_queue_peek_head(displayed);
-                                        if (n)
+                                        if (n) {
                                                 notification_close(n, 2);
+                                                wake_up();
+                                        }
                                 }
                         }
                         if (settings.history_ks.str
@@ -864,18 +867,21 @@ gboolean x_mainloop_fd_dispatch(GSource *source, GSourceFunc callback,
                                              0) == settings.history_ks.sym
                             && settings.history_ks.mask == state) {
                                 history_pop();
+                                wake_up();
                         }
                         if (settings.close_all_ks.str
                             && XLookupKeysym(&ev.xkey,
                                              0) == settings.close_all_ks.sym
                             && settings.close_all_ks.mask == state) {
                                 move_all_to_history();
+                                wake_up();
                         }
                         if (settings.context_ks.str
                             && XLookupKeysym(&ev.xkey,
                                              0) == settings.context_ks.sym
                             && settings.context_ks.mask == state) {
                                 context_menu();
+                                wake_up();
                         }
                         break;
                 case FocusIn:

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -1015,6 +1015,17 @@ void x_setup(void)
                                             &xctx.geometry.x, &xctx.geometry.y,
                                             &xctx.geometry.w, &xctx.geometry.h);
 
+        /* calculate maximum notification count and push information to queue */
+        if (xctx.geometry.h == 0) {
+                queues_displayed_limit(0);
+        } else if (xctx.geometry.h == 1) {
+                queues_displayed_limit(1);
+        } else if (settings.indicate_hidden) {
+                queues_displayed_limit(xctx.geometry.h - 1);
+        } else {
+                queues_displayed_limit(xctx.geometry.h);
+        }
+
         xctx.screensaver_info = XScreenSaverAllocInfo();
 
         init_screens();


### PR DESCRIPTION
Ok, I'm done with the queue refactoring.

- Every part about accessing a `GQueue` is now handled in `queues.c`.
- All methods handling a queue are prefixed with `queues_` to resemble the namespace.
- The three queues have unique names `waiting`, `displayed`, `history`.
- All stuff in `notification_init` about closing notifications is removed
    - to `dbus.c`: command pause/resume interpretation
    - to `queues.c`: duplicates stacking

The refactoring about splitting `notification_init` is still to be done, but not part of this PR.

Mostly, I have split the stuff into two commits (the first one plain moving code from `file.c` to `queues.c` and the second one renaming/refactoring).

All commits compile without warnings.

Albeit most of the commits are plain refactoring, two commits stand out and may need further testing:

- `Force management of queues to queues.c`
- `Remove command handling from notification_init `
- `Move id assignment to separate function in queues.c`