### PR TITLE
Free notification before closing

### DIFF
--- a/dunstify.c
+++ b/dunstify.c
@@ -324,6 +324,8 @@ int main(int argc, char *argv[])
        g_print("%d\n", get_id(n));
     }
 
+    g_object_unref(G_OBJECT (n));
+
     die(0);
 }
 


### PR DESCRIPTION
The notification object should actually get freed by notify_uninit. But
before freeing the notification, notify_uninit also sends the
CloseNotification signal directly, if the timeout is 0.

But the timeout of 0 should actually indicate a notification, which
never expires.

Fixes #415