### PR TITLE
Buildstack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ addons:
 dist: trusty
 sudo: false
 language: c
-script: CFLAGS=-Werror make && make test
+script: CFLAGS=-Werror make all dunstify test
 compiler:
     - gcc
     - clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ addons:
 dist: trusty
 sudo: false
 language: c
-script: make && make test
+script: CFLAGS=-Werror make && make test
 compiler:
     - gcc
     - clang

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,6 @@ test-clean:
 	rm -f test/test test/*.o
 
 dunstify: dunstify.o
-	${CC} ${CFLAGS} -o $@ dunstify.o $(shell pkg-config --libs --cflags glib-2.0 libnotify gdk-3.0)
+	${CC} ${CFLAGS} -o $@ dunstify.o ${LDFLAGS}
 
 .PHONY: all clean dist install uninstall

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,17 @@ ifneq ($(wildcard ./.git/.),)
 VERSION := $(shell git describe --tags)
 endif
 
-CFLAGS += -I.
-LDFLAGS += -L.
+LIBS := $(shell pkg-config --libs   ${pkg_config_packs})
+INCS := $(shell pkg-config --cflags ${pkg_config_packs})
+
+ifneq (clean, $(MAKECMDGOALS))
+ifeq ($(and $(INCS),$(LIBS)),)
+$(error "pkg-config failed!")
+endif
+endif
+
+CFLAGS += -I. ${INCS}
+LDFLAGS+= -L. ${LIBS}
 
 SRC := $(sort $(shell find src/ -name '*.c'))
 OBJ := ${SRC:.c=.o}

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,11 @@ TEST_OBJ := $(TEST_SRC:.c=.o)
 
 all: doc dunst service
 
+debug: CFLAGS   += ${CFLAGS_DEBUG}
+debug: LDFLAGS  += ${LDFLAGS_DEBUG}
+debug: CPPFLAGS += ${CPPFLAGS_DEBUG}
+debug: all
+
 .c.o:
 	${CC} -o $@ -c $< ${CFLAGS}
 

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ OBJ := ${SRC:.c=.o}
 TEST_SRC := $(sort $(shell find test/ -name '*.c'))
 TEST_OBJ := $(TEST_SRC:.c=.o)
 
+.PHONY: all debug
 all: doc dunst service
 
 debug: CFLAGS   += ${CFLAGS_DEBUG}
@@ -43,20 +44,24 @@ dunst: ${OBJ} main.o
 dunstify: dunstify.o
 	${CC} ${CFLAGS} -o $@ dunstify.o ${LDFLAGS}
 
+.PHONY: test
 test: test/test
 	cd test && ./test
 
 test/test: ${OBJ} ${TEST_OBJ}
 	${CC} ${CFLAGS} -o $@ ${TEST_OBJ} ${OBJ} ${LDFLAGS}
 
+.PHONY: doc
 doc: docs/dunst.1
 docs/dunst.1: docs/dunst.pod
 	pod2man --name=dunst -c "Dunst Reference" --section=1 --release=${VERSION} $< > $@
 
+.PHONY: service
 service:
 	@sed "s|##PREFIX##|$(PREFIX)|" org.knopwob.dunst.service.in > org.knopwob.dunst.service
 	@sed "s|##PREFIX##|$(PREFIX)|" dunst.systemd.service.in > dunst.systemd.service
 
+.PHONY: clean clean-dunst clean-dunstify clean-doc clean-tests
 clean: clean-dunst clean-dunstify clean-doc clean-tests
 
 clean-dunst:
@@ -74,6 +79,7 @@ clean-doc:
 clean-tests:
 	rm -f test/test test/*.o
 
+.PHONY: install install-dunst install-doc install-service uninstall
 install: install-dunst install-doc install-service
 
 install-dunst: dunst doc
@@ -97,5 +103,3 @@ uninstall:
 	rm -f ${DESTDIR}${PREFIX}/share/dbus-1/services/org.knopwob.dunst.service
 	rm -f ${DESTDIR}${PREFIX}/lib/systemd/user/dunst.service
 	rm -rf ${DESTDIR}${PREFIX}/share/dunst
-
-.PHONY: all clean dist install uninstall

--- a/config.mk
+++ b/config.mk
@@ -2,11 +2,6 @@
 PREFIX ?= /usr/local
 MANPREFIX = ${PREFIX}/share/man
 
-VERSION := "1.2.0-non-git"
-ifneq ($(wildcard ./.git/.),)
-VERSION := $(shell git describe --tags)
-endif
-
 # Warning: This is deprecated behavior
 # uncomment to disable parsing of dunstrc
 # or use "CFLAGS=-DSTATIC_CONFIG make" to build

--- a/config.mk
+++ b/config.mk
@@ -11,6 +11,10 @@ CPPFLAGS += -D_DEFAULT_SOURCE -DVERSION=\"${VERSION}\"
 CFLAGS   += -g --std=gnu99 -pedantic -Wall -Wno-overlength-strings -Os ${STATIC} ${CPPFLAGS}
 LDFLAGS  += -lm -L${X11LIB}
 
+CPPFLAGS_DEBUG := -DDEBUG_BUILD
+CFLAGS_DEBUG   := -O0
+LDFLAGS_DEBUG  :=
+
 pkg_config_packs := dbus-1 \
                     gio-2.0 \
                     gdk-3.0 \

--- a/config.mk
+++ b/config.mk
@@ -2,23 +2,24 @@
 PREFIX ?= /usr/local
 MANPREFIX = ${PREFIX}/share/man
 
-# Warning: This is deprecated behavior
 # uncomment to disable parsing of dunstrc
 # or use "CFLAGS=-DSTATIC_CONFIG make" to build
-#STATIC= -DSTATIC_CONFIG
-
-PKG_CONFIG:=$(shell which pkg-config)
-ifeq (${PKG_CONFIG}, ${EMPTY})
-$(error "Failed to find pkg-config, please make sure it is installed")
-endif
+#STATIC= -DSTATIC_CONFIG # Warning: This is deprecated behavior
 
 # flags
 CPPFLAGS += -D_DEFAULT_SOURCE -DVERSION=\"${VERSION}\"
 CFLAGS   += -g --std=gnu99 -pedantic -Wall -Wno-overlength-strings -Os ${STATIC} ${CPPFLAGS}
+LDFLAGS  += -lm -L${X11LIB}
 
-pkg_config_packs := dbus-1 x11 xscrnsaver \
-                    "glib-2.0 >= 2.36" gio-2.0 \
-                    pangocairo gdk-3.0 xrandr xinerama
+pkg_config_packs := dbus-1 \
+                    gio-2.0 \
+                    gdk-3.0 \
+                    "glib-2.0 >= 2.36" \
+                    pangocairo \
+                    x11 \
+                    xinerama \
+                    xrandr \
+                    xscrnsaver
 
 # check if we need libxdg-basedir
 ifeq (,$(findstring STATIC_CONFIG,$(CFLAGS)))
@@ -30,16 +31,4 @@ endif
 # dunstify also needs libnotify
 ifneq (,$(findstring dunstify,${MAKECMDGOALS}))
 	pkg_config_packs += libnotify
-endif
-
-# includes and libs
-INCS := $(shell ${PKG_CONFIG} --cflags ${pkg_config_packs})
-CFLAGS += ${INCS}
-LDFLAGS += -lm -L${X11LIB} -lXss $(shell ${PKG_CONFIG} --libs ${pkg_config_packs})
-
-# only make this an fatal error when where not cleaning
-ifneq (clean, $(MAKECMDGOALS))
-ifeq (${INCS}, ${EMPTY})
-$(error "pkg-config failed, see errors above")
-endif
 endif

--- a/config.mk
+++ b/config.mk
@@ -32,6 +32,11 @@ else
 $(warning STATIC_CONFIG is deprecated behavior. It will get removed in future releases)
 endif
 
+# dunstify also needs libnotify
+ifneq (,$(findstring dunstify,${MAKECMDGOALS}))
+	pkg_config_packs += libnotify
+endif
+
 # includes and libs
 INCS := $(shell ${PKG_CONFIG} --cflags ${pkg_config_packs})
 CFLAGS += ${INCS}


### PR DESCRIPTION
To improve code quality, treat warnings in travis now as fatal. This forces better code quality in PRs. Additionally dunstify is built there.

Introduces two build types (debug/release). This will become quite handy when we introduce logging and have a macro for debug messages, which gets activeted by setting a flag.

The makefile got restructured to have clearer structure and splitting of `config.mk` and `Makefile`.