### PR TITLE
Added: support for round corners

### DIFF
--- a/config.h
+++ b/config.h
@@ -41,6 +41,7 @@ settings_t defaults = {
 .ignore_newline = false,
 .line_height = 0,            /* if line height < font height, it will be raised to font height */
 .notification_height = 0,    /* if notification height < font height and padding, it will be raised */
+.corner_radius = 0,
 
 .separator_height = 2,       /* height of the separator line between two notifications */
 .padding = 0,

--- a/config.mk
+++ b/config.mk
@@ -28,6 +28,7 @@ pkg_config_packs := dbus-1 \
                     pangocairo \
                     x11 \
                     xinerama \
+                    xext \
                     "xrandr >= 1.5" \
                     xscrnsaver
 

--- a/docs/dunst.pod
+++ b/docs/dunst.pod
@@ -460,6 +460,18 @@ By enabling this setting dunst will not be able to detect when a monitor is
 connected or disconnected which might break follow mode if the screen layout
 changes.
 
+=item B<corner_radius> (default: 0)
+
+Define the corner radius in pixels. A corner radius of 0 will result in
+rectangular shaped notifications.
+
+By enabling this setting the outer border and the frame will be shaped.
+If you have multiple notifications, the whole window is shaped, not every
+single notification.
+
+To avoid the corners clipping the icon or text the corner radius will be
+automatically lowered to half of the notification height if it exceeds it.
+
 =back
 
 =head2 Shortcut section

--- a/dunstrc
+++ b/dunstrc
@@ -207,6 +207,13 @@
     # debug: all less than unimportant stuff
     verbosity = mesg
 
+    # Define the corner radius of the notification window
+    # in pixel size. If the radius is 0, you have no rounded
+    # corners.
+    # The radius will be automatically lowered if it exceeds half of the
+    # notification height to avoid clipping text and/or icons.
+    corner_radius = 0
+
     ### Legacy
 
     # Use the Xinerama extension instead of RandR for multi-monitor support.

--- a/src/draw.c
+++ b/src/draw.c
@@ -393,94 +393,58 @@ static int layout_get_height(colored_layout *cl)
         return MAX(h, h_icon);
 }
 
+/**
+ * Create a path on the given cairo context to draw the background of a notification.
+ * The top corners will get rounded by `corner_radius`, if `first` is set.
+ * Respectably the same for `last` with the bottom corners.
+ */
 static void draw_rounded_rect(cairo_t *c, int x, int y, int width, int height, int corner_radius, bool first, bool last)
 {
         const float degrees = M_PI / 180.0;
 
-        if (first && last) {
-                cairo_new_sub_path(c);
-                cairo_arc(c,
-                          x + width - corner_radius,
-                          y + corner_radius,
-                          corner_radius,
-                          -90 * degrees,
-                          0 * degrees);
+        cairo_new_sub_path(c);
+
+        if (last) {
+                // bottom right
                 cairo_arc(c,
                           x + width - corner_radius,
                           y + height - corner_radius,
                           corner_radius,
-                          0 * degrees,
-                          90 * degrees);
+                          degrees * 0,
+                          degrees * 90);
+                // bottom left
                 cairo_arc(c,
                           x + corner_radius,
                           y + height - corner_radius,
                           corner_radius,
-                          90 * degrees,
-                          180 * degrees);
-                cairo_arc(c,
-                          x + corner_radius,
-                          y + corner_radius,
-                          corner_radius,
-                          180 * degrees,
-                          270 * degrees);
-                cairo_close_path(c);
-        } else if (first) {
-                cairo_new_sub_path(c);
-                cairo_arc(c,
-                          x + width - corner_radius,
-                          y + corner_radius,
-                          corner_radius,
-                          -90 * degrees,
-                          0 * degrees);
-                cairo_arc(c,
-                          x + width,
-                          y + height,
-                          0,
-                          0,
-                          0);
-                cairo_arc(c,
-                          x,
-                          y + height,
-                          0,
-                          0,
-                          0);
-                cairo_arc(c,
-                          x + corner_radius,
-                          y + corner_radius,
-                          corner_radius,
-                          180 * degrees,
-                          270 * degrees);
-                cairo_close_path(c);
-        } else if (last) {
-                cairo_new_sub_path(c);
-                cairo_arc(c,
-                          x + width,
-                          y,
-                          0,
-                          0,
-                          0);
-                cairo_arc(c,
-                          x + width - corner_radius,
-                          y + height - corner_radius,
-                          corner_radius,
-                          0 * degrees,
-                          90 * degrees);
-                cairo_arc(c,
-                          x + corner_radius,
-                          y + height - corner_radius,
-                          corner_radius,
-                          90 * degrees,
-                          180 * degrees);
-                cairo_arc(c,
-                          x,
-                          y,
-                          0,
-                          180 * degrees,
-                          270 * degrees);
-                cairo_close_path(c);
+                          degrees * 90,
+                          degrees * 180);
         } else {
-                cairo_rectangle(c, x, y, width, height);
+                cairo_line_to(c, x + width, y + height);
+                cairo_line_to(c, x,         y + height);
         }
+
+        if (first) {
+                // top left
+                cairo_arc(c,
+                          x + corner_radius,
+                          y + corner_radius,
+                          corner_radius,
+                          degrees * 180,
+                          degrees * 270);
+                // top right
+                cairo_arc(c,
+                          x + width - corner_radius,
+                          y + corner_radius,
+                          corner_radius,
+                          degrees * 270,
+                          degrees * 360);
+        } else {
+                cairo_line_to(c, x,         y);
+                cairo_line_to(c, x + width, y);
+        }
+
+        cairo_close_path(c);
 }
 
 static cairo_surface_t *render_background(cairo_surface_t *srf,

--- a/src/settings.c
+++ b/src/settings.c
@@ -368,6 +368,12 @@ void load_settings(char *cmdline_config_path)
                 "Transparency. range 0-100"
         );
 
+        settings.corner_radius = option_get_int(
+                "global",
+                "corner_radius", "-corner_radius", defaults.corner_radius,
+                "Window corner radius"
+        );
+
         {
                 char *c = option_get_string(
                         "global",

--- a/src/settings.h
+++ b/src/settings.h
@@ -84,6 +84,7 @@ typedef struct _settings {
         keyboard_shortcut history_ks;
         keyboard_shortcut context_ks;
         bool force_xinerama;
+        int corner_radius;
 } settings_t;
 
 extern settings_t settings;

--- a/src/x11/x.h
+++ b/src/x11/x.h
@@ -31,6 +31,8 @@ struct dimensions {
         int y;
         int w;
         int h;
+
+        int corner_radius;
 };
 
 typedef struct _xctx {


### PR DESCRIPTION
As requested in issue [#358](https://github.com/dunst-project/dunst/issues/358) here's the support for round corners via the x11 shape extension. 