### PR TITLE
Unref GVariants after use again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 ### Fixed
 - `new_icon` rule being ignored on notifications that had a raw icon
 - Do not replace format strings, which are in notification content
+- DBus related memory leaks closed:
+  On the DBus connection, all hints never got freed. For raw icons, dunst saved them three times.
 
 ## Changed
 - transient hints are now handled

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -180,28 +180,38 @@ static void on_notify(GDBusConnection *connection,
                                 if (g_variant_is_of_type(content, G_VARIANT_TYPE_DICTIONARY)) {
 
                                         dict_value = g_variant_lookup_value(content, "urgency", G_VARIANT_TYPE_BYTE);
-                                        if (dict_value)
+                                        if (dict_value) {
                                                 urgency = g_variant_get_byte(dict_value);
+                                                g_variant_unref(dict_value);
+                                        }
 
                                         dict_value = g_variant_lookup_value(content, "fgcolor", G_VARIANT_TYPE_STRING);
-                                        if (dict_value)
+                                        if (dict_value) {
                                                 fgcolor = g_variant_dup_string(dict_value, NULL);
+                                                g_variant_unref(dict_value);
+                                        }
 
                                         dict_value = g_variant_lookup_value(content, "bgcolor", G_VARIANT_TYPE_STRING);
-                                        if (dict_value)
+                                        if (dict_value) {
                                                 bgcolor = g_variant_dup_string(dict_value, NULL);
+                                                g_variant_unref(dict_value);
+                                        }
 
                                         dict_value = g_variant_lookup_value(content, "category", G_VARIANT_TYPE_STRING);
-                                        if (dict_value)
+                                        if (dict_value) {
                                                 category = g_variant_dup_string(dict_value, NULL);
+                                                g_variant_unref(dict_value);
+                                        }
 
                                         dict_value = g_variant_lookup_value(content, "image-data", G_VARIANT_TYPE("(iiibiiay)"));
                                         if (!dict_value)
                                                 dict_value = g_variant_lookup_value(content, "image_data", G_VARIANT_TYPE("(iiibiiay)"));
                                         if (!dict_value)
                                                 dict_value = g_variant_lookup_value(content, "icon_data", G_VARIANT_TYPE("(iiibiiay)"));
-                                        if (dict_value)
+                                        if (dict_value) {
                                                 raw_icon = get_raw_image_from_data_hint(dict_value);
+                                                g_variant_unref(dict_value);
+                                        }
 
                                         /* Check for transient hints
                                          *
@@ -209,17 +219,24 @@ static void on_notify(GDBusConnection *connection,
                                          * But notify-send does not support hints of type 'boolean'.
                                          * So let's check for int and boolean until notify-send is fixed.
                                          */
-                                        if((dict_value = g_variant_lookup_value(content, "transient", G_VARIANT_TYPE_BOOLEAN)))
+                                        if((dict_value = g_variant_lookup_value(content, "transient", G_VARIANT_TYPE_BOOLEAN))) {
                                                 transient = g_variant_get_boolean(dict_value);
-                                        else if((dict_value = g_variant_lookup_value(content, "transient", G_VARIANT_TYPE_UINT32)))
+                                                g_variant_unref(dict_value);
+                                        } else if((dict_value = g_variant_lookup_value(content, "transient", G_VARIANT_TYPE_UINT32))) {
                                                 transient = g_variant_get_uint32(dict_value) > 0;
-                                        else if((dict_value = g_variant_lookup_value(content, "transient", G_VARIANT_TYPE_INT32)))
+                                                g_variant_unref(dict_value);
+                                        } else if((dict_value = g_variant_lookup_value(content, "transient", G_VARIANT_TYPE_INT32))) {
                                                 transient = g_variant_get_int32(dict_value) > 0;
+                                                g_variant_unref(dict_value);
+                                        }
 
-                                        if((dict_value = g_variant_lookup_value(content, "value", G_VARIANT_TYPE_INT32)))
+                                        if((dict_value = g_variant_lookup_value(content, "value", G_VARIANT_TYPE_INT32))) {
                                                 progress = g_variant_get_int32(dict_value);
-                                        else if((dict_value = g_variant_lookup_value(content, "value", G_VARIANT_TYPE_UINT32)))
+                                                g_variant_unref(dict_value);
+                                        } else if((dict_value = g_variant_lookup_value(content, "value", G_VARIANT_TYPE_UINT32))) {
                                                 progress = g_variant_get_uint32(dict_value);
+                                                g_variant_unref(dict_value);
+                                        }
                                 }
                                 break;
                         case 7:
@@ -399,11 +416,13 @@ static RawImage *get_raw_image_from_data_hint(GVariant *icon_data)
                        expected_len,
                        g_variant_get_size (data_variant));
                 g_free(image);
+                g_variant_unref(data_variant);
                 return NULL;
         }
 
         image->data = (guchar *) g_memdup (g_variant_get_data (data_variant),
                                 g_variant_get_size (data_variant));
+        g_variant_unref(data_variant);
 
         return image;
 }


### PR DESCRIPTION
Fixes #397 
Fixes #251 

`g_variant_lookup_value` will reference the GVariant. So we have to unref it again. This results, that every hint of the DBus message does not get freed upon `g_dbus_method_invocation_return_value`. This especially heavy for notifications sent with an attached icon.

---

Why also #251?

I see there are problems with dunst and probably this is not fixed fully. <del>I still get in the regions > 50 MB.</del> But spotify is the candidate, which sends raw icons.

(Also spotify replaces its notifications. The old notification does not get freed. This is fixed in #411)