### PR TITLE
Optimize icons

### DIFF
--- a/src/dbus.c
+++ b/src/dbus.c
@@ -267,13 +267,12 @@ static void on_notify(GDBusConnection *connection,
         n->category = category;
         n->dbus_client = g_strdup(sender);
         n->transient = transient;
-        if (actions->count > 0) {
-                n->actions = actions;
-        } else {
-                n->actions = NULL;
-                g_strfreev(actions->actions);
-                g_free(actions);
+
+        if (actions->count < 1) {
+                actions_free(actions);
+                actions = NULL;
         }
+        n->actions = actions;
 
         for (int i = 0; i < ColLast; i++) {
                 n->color_strings[i] = NULL;

--- a/src/notification.c
+++ b/src/notification.c
@@ -164,6 +164,19 @@ int notification_is_duplicate(const notification *a, const notification *b)
 }
 
 /*
+ * Free a #RawImage
+ * @i: (nullable): pointer to #RawImage
+ */
+void rawimage_free(RawImage *i)
+{
+        if (!i)
+                return;
+
+        g_free(i->data);
+        g_free(i);
+}
+
+/*
  * Free the memory used by the given notification.
  */
 void notification_free(notification *n)
@@ -184,11 +197,7 @@ void notification_free(notification *n)
                 g_free(n->actions->dmenu_str);
         }
 
-        if (n->raw_icon) {
-                if (n->raw_icon->data)
-                        g_free(n->raw_icon->data);
-                g_free(n->raw_icon);
-        }
+        rawimage_free(n->raw_icon);
 
         g_free(n);
 }

--- a/src/notification.c
+++ b/src/notification.c
@@ -164,6 +164,20 @@ int notification_is_duplicate(const notification *a, const notification *b)
 }
 
 /*
+ * Free the actions element
+ * @a: (nullable): Pointer to #Actions
+ */
+void actions_free(Actions *a)
+{
+        if (!a)
+                return;
+
+        g_strfreev(a->actions);
+        g_free(a->dmenu_str);
+        g_free(a);
+}
+
+/*
  * Free a #RawImage
  * @i: (nullable): pointer to #RawImage
  */
@@ -192,11 +206,7 @@ void notification_free(notification *n)
         g_free(n->text_to_render);
         g_free(n->urls);
 
-        if (n->actions) {
-                g_strfreev(n->actions->actions);
-                g_free(n->actions->dmenu_str);
-        }
-
+        actions_free(n->actions);
         rawimage_free(n->raw_icon);
 
         g_free(n);

--- a/src/notification.h
+++ b/src/notification.h
@@ -63,6 +63,7 @@ typedef struct _notification {
 
 notification *notification_create(void);
 void notification_init(notification *n);
+void rawimage_free(RawImage *i);
 void notification_free(notification *n);
 int notification_cmp(const void *a, const void *b);
 int notification_cmp_data(const void *a, const void *b, void *data);

--- a/src/notification.h
+++ b/src/notification.h
@@ -62,6 +62,7 @@ typedef struct _notification {
 
 notification *notification_create(void);
 void notification_init(notification *n);
+void actions_free(Actions *a);
 void rawimage_free(RawImage *i);
 void notification_free(notification *n);
 int notification_cmp(const void *a, const void *b);

--- a/src/notification.h
+++ b/src/notification.h
@@ -33,7 +33,6 @@ typedef struct _notification {
         char *appname;
         char *summary;
         char *body;
-        bool icon_overridden;
         char *icon;
         RawImage *raw_icon;
         char *msg;            /* formatted message */

--- a/src/rules.c
+++ b/src/rules.c
@@ -25,7 +25,8 @@ void rule_apply(rule_t *r, notification *n)
         if (r->new_icon) {
                 g_free(n->icon);
                 n->icon = g_strdup(r->new_icon);
-                n->icon_overridden = true;
+                rawimage_free(n->raw_icon);
+                n->raw_icon = NULL;
         }
         if (r->fg)
                 n->color_strings[ColFG] = r->fg;

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -425,7 +425,7 @@ static colored_layout *r_init_shared(cairo_t *c, notification *n)
 
         GdkPixbuf *pixbuf = NULL;
 
-        if (n->raw_icon && !n->icon_overridden &&
+        if (n->raw_icon &&
             settings.icon_position != icons_off) {
 
                 pixbuf = get_pixbuf_from_raw_image(n->raw_icon);


### PR DESCRIPTION
## Saving memory

- Adds separate methods to free the `RawImage` and `Actions` structs
    - Found memory leak in `Actions` (the memory of the actual `Actions` sctruct is not freed)
- Optimizing out `icon_overridden`
    - when `icon_overridden` is set, `raw_icon` is never used.
    - so freeing raw_icon saves additional memory and also saves the information of `icon_overridden`