### PR TITLE
Use '-1' for undefined progress

### DIFF
--- a/src/dbus.c
+++ b/src/dbus.c
@@ -262,7 +262,7 @@ static void on_notify(GDBusConnection *connection,
         n->raw_icon = raw_icon;
         n->timeout = timeout < 0 ? -1 : timeout * 1000;
         n->markup = settings.markup;
-        n->progress = (progress < 0 || progress > 100) ? 0 : progress + 1;
+        n->progress = (progress < 0 || progress > 100) ? -1 : progress;
         n->urgency = urgency;
         n->category = category;
         n->dbus_client = g_strdup(sender);

--- a/src/dunst.c
+++ b/src/dunst.c
@@ -154,7 +154,7 @@ int dunst_main(int argc, char *argv[])
                 n->appname = g_strdup("dunst");
                 n->summary = g_strdup("startup");
                 n->body = g_strdup("dunst is up and running");
-                n->progress = 0;
+                n->progress = -1;
                 n->timeout = 10 * G_USEC_PER_SEC;
                 n->markup = MARKUP_NO;
                 n->urgency = LOW;

--- a/src/notification.c
+++ b/src/notification.c
@@ -359,23 +359,23 @@ void notification_init(notification *n)
                                         MARKUP_NO);
                                 break;
                         case 'p':
-                                if (n->progress)
-                                        sprintf(pg, "[%3d%%]", n->progress - 1);
+                                if (n->progress != -1)
+                                        sprintf(pg, "[%3d%%]", n->progress);
 
                                 notification_replace_single_field(
                                         &n->msg,
                                         &substr,
-                                        n->progress ? pg : "",
+                                        n->progress != -1 ? pg : "",
                                         MARKUP_NO);
                                 break;
                         case 'n':
-                                if (n->progress)
-                                        sprintf(pg, "%d", n->progress - 1);
+                                if (n->progress != -1)
+                                        sprintf(pg, "%d", n->progress);
 
                                 notification_replace_single_field(
                                         &n->msg,
                                         &substr,
-                                        n->progress ? pg : "",
+                                        n->progress != -1 ? pg : "",
                                         MARKUP_NO);
                                 break;
                         case '%':

--- a/src/notification.h
+++ b/src/notification.h
@@ -54,7 +54,7 @@ typedef struct _notification {
         bool first_render;
         bool transient;
 
-        int progress;           /* percentage + 1, 0 to hide */
+        int progress;           /* percentage (-1: undefined) */
         int history_ignore;
         const char *script;
         char *urls;


### PR DESCRIPTION
This uses `-1` for to represent unset in the progress field. Semantically it makes no sense setting the progress to `0` to have it disabled.

---

rationale:

I personally would also like to have for every field an explicit representation for "unset". In a follow up PR I want to make `notification_create` to alloc the memory and *also* set all fields the unset representation. And `notification_init` defaults them.

So the code should look like this:

```
notification *n = notification_create();
//set only needed parameters
n->summary = "asdf";
notification_init(n);
```

Currently `notification_init` overwrites some fields without checking anything.