### PR TITLE
Set Locale in dunstify

### DIFF
--- a/dunstify.c
+++ b/dunstify.c
@@ -1,5 +1,6 @@
 #include <glib.h>
 #include <libnotify/notify.h>
+#include <locale.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
@@ -252,6 +253,7 @@ void add_hint(NotifyNotification *n, char *str)
 
 int main(int argc, char *argv[])
 {
+    setlocale(LC_ALL, "");
     #if !GLIB_CHECK_VERSION(2,35,0)
         g_type_init();
     #endif


### PR DESCRIPTION
If specifying --icon with UTF-8 characters, the g_option_context_parse
fails with an invalid byte conversion. The solution is to set the locale
explicitly.

For more info, see the GLib issue tracker:
https://bugzilla.gnome.org/show_bug.cgi?id=737137

Fixes #443