### PR TITLE
Support image-path hint

### DIFF
--- a/src/dbus.c
+++ b/src/dbus.c
@@ -204,6 +204,13 @@ static void on_notify(GDBusConnection *connection,
                                                 g_variant_unref(dict_value);
                                         }
 
+                                        dict_value = g_variant_lookup_value(content, "image-path", G_VARIANT_TYPE_STRING);
+                                        if (dict_value) {
+                                                g_free(icon);
+                                                icon = g_variant_dup_string(dict_value, NULL);
+                                                g_variant_unref(dict_value);
+                                        }
+
                                         dict_value = g_variant_lookup_value(content, "image-data", G_VARIANT_TYPE("(iiibiiay)"));
                                         if (!dict_value)
                                                 dict_value = g_variant_lookup_value(content, "image_data", G_VARIANT_TYPE("(iiibiiay)"));


### PR DESCRIPTION
As GApplications expose their icon via image-path hint and not via the
actual app_icon field, GApplication icons haven't been displayed before.

According to the notification spec, image-path hint should also override
the app_icon as follows:

1. image-data hint
2. image-path hint
3. app_icon parameter