### PR TITLE
Fix notification timeouts

### DIFF
--- a/src/dunst.c
+++ b/src/dunst.c
@@ -53,12 +53,7 @@ gboolean run(void *data)
         queues_check_timeouts(x_is_idle());
         queues_update();
 
-        static int timeout_cnt = 0;
         static gint64 next_timeout = 0;
-
-        if (data && timeout_cnt > 0) {
-                timeout_cnt--;
-        }
 
         if (!xctx.visible && queues_length_displayed() > 0) {
                 x_win_show();
@@ -78,10 +73,9 @@ gboolean run(void *data)
                 gint64 timeout_at = now + sleep;
 
                 if (sleep >= 0) {
-                        if (timeout_cnt == 0 || next_timeout < now || timeout_at < next_timeout) {
-                                g_timeout_add(sleep/1000, run, mainloop);
+                        if (next_timeout < now || timeout_at < next_timeout) {
+                                g_timeout_add(sleep/1000, run, NULL);
                                 next_timeout = timeout_at;
-                                timeout_cnt++;
                         }
                 }
         }

--- a/src/dunst.c
+++ b/src/dunst.c
@@ -78,7 +78,7 @@ gboolean run(void *data)
                 gint64 timeout_at = now + sleep;
 
                 if (sleep >= 0) {
-                        if (timeout_cnt == 0 || timeout_at < next_timeout) {
+                        if (timeout_cnt == 0 || next_timeout < now || timeout_at < next_timeout) {
                                 g_timeout_add(sleep/1000, run, mainloop);
                                 next_timeout = timeout_at;
                                 timeout_cnt++;

--- a/src/dunst.c
+++ b/src/dunst.c
@@ -60,7 +60,7 @@ gboolean run(void *data)
                 timeout_cnt--;
         }
 
-        if (queues_length_displayed() > 0 && !xctx.visible) {
+        if (!xctx.visible && queues_length_displayed() > 0) {
                 x_win_show();
         }
 
@@ -86,8 +86,12 @@ gboolean run(void *data)
                 }
         }
 
-        /* always return false to delete timers */
-        return false;
+        /* If the execution got triggered by g_timeout_add,
+         * we have to remove the timeout (which is actually a
+         * recurring interval), as we have set a new one
+         * by ourselves.
+         */
+        return G_SOURCE_REMOVE;
 }
 
 gboolean pause_signal(gpointer data)

--- a/src/dunst.h
+++ b/src/dunst.h
@@ -19,18 +19,15 @@
 extern GSList *rules;
 extern const char *color_strings[3][3];
 
-/* return id of notification */
 gboolean run(void *data);
 void wake_up(void);
 
 int dunst_main(int argc, char *argv[]);
 
-void check_timeouts(void);
 void usage(int exit_status);
 void print_version(void);
 char *extract_urls(const char *str);
 void context_menu(void);
-void wake_up(void);
 void pause_signal_handler(int sig);
 
 #endif

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -701,6 +701,8 @@ void x_win_draw(void)
         cairo_paint(cairo_ctx.context);
         cairo_show_page(cairo_ctx.context);
 
+        XFlush(xctx.dpy);
+
         cairo_destroy(c);
         cairo_surface_destroy(image_surface);
         r_free_layouts(layouts);


### PR DESCRIPTION
Notifications did not get undisplayed under certain conditions.

When sending two notifications simultaneously, both notifications get closed properly, but the shorter one gets undisplayed when  the longer one vanishes.

Fixes #433 

When sending notifications in this order: a long one, a short one and a middle one. Then there is no timeout for the middle one created, because there is an existing timeout and the timeout for the short notification fires faster. Then at the next execution of `run` (closing the short notification), `next_timeout` contains still the value of the short nofitication and is still smaller than the timeout for the middle notification. But dunst does not force to set a new timeout, as there is another existing timeout for the long notification.

Fixes #132 