### PR TITLE
Prepare release v1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,33 @@
 # Dunst changelog
 
-## Unreleased
+## 1.3.0 - 2017-12-26
 
 ### Added
-- `ellipsize` option to control how long lines should be ellipsized when `word_wrap` is set to `false`
+- `ellipsize` option to control how long lines should be ellipsized when `word_wrap` is set to `false` (#374)
+- A beginning tilde of a path is now expanded to the home of the current user (#351)
+- The image-path hint is now respected, as GApplications send their icon only via this link (#447)
+- If dunst can't acquire the DBus name, dunst prints the PID of the process holding the name (#458 #460)
 
 ### Fixed
-- `new_icon` rule being ignored on notifications that had a raw icon
-- Do not replace format strings, which are in notification content
-- DBus related memory leaks closed:
+- `new_icon` rule being ignored on notifications that had a raw icon (#423)
+- Do not replace format strings, which are in notification content (#322 #365)
+- DBus related memory leaks closed: (#397)
   On the DBus connection, all hints never got freed. For raw icons, dunst saved them three times.
+- Dunst crashed on X11 servers with RandR support less than 1.5. (#413 #364)
+- Dunst silently read the default config file, if -conf did not specify a valid file (#452)
 
 ## Changed
-- transient hints are now handled
+- transient hints are now handled (#343 #310)
   An additional rule option (`match_transient` and `set_transient`) is added
   to optionally reset the transient setting
+- Timeouts are now calculated in microseconds with GLib's `g_get_monotonic_time()` (#379 #291)
+- `icon_folders` is renamed to `icon_path` (#170)
+- `config.def.h` and `config.h` got merged (#371)
+- The dependency on GTK3+ had been removed. Instead of GTK3+, dunst requires now gdk-pixbuf,
+  which had been a transient dependency before. (#334 #376)
+- The `_GNU_SOURCE` macros had been removed to make dunst portable to nonGNU systems (#403)
+- Replacing notifications does not require a full redraw and replaces flickerless (#415)
+- Internal refactorings of the notification queue handling. (#411)
 
 ## 1.2.0 - 2017-07-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 - The `_GNU_SOURCE` macros had been removed to make dunst portable to nonGNU systems (#403)
 - Replacing notifications does not require a full redraw and replaces flickerless (#415)
 - Internal refactorings of the notification queue handling. (#411)
+- Dunst does now install the systemd and dbus service files into their proper location given
+  by pkg-config. Use `SERVICEDIR_(DBUS|SYSTEMD)` params to overwrite them. (#463)
 
 ## 1.2.0 - 2017-07-12
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 include config.mk
 
-VERSION := "1.2.0-non-git"
+VERSION := "1.3.0-non-git"
 ifneq ($(wildcard ./.git/.),)
 VERSION := $(shell git describe --tags)
 endif

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ sudo make install
 - `SERVICEDIR_SYSTEMD=<PATH>`: The path to put the systemd user service file. Unused, if `SYSTEMD=0`. (Default: detected via `pkg-config`)
 - `SERVICEDIR_DBUS=<PATH>`: The path to put the dbus service file. (Default: detected via `pkg-config`)
 
+**Make sure to run all make calls with the same parameter set. So when building with `make PREFIX=/usr`, you have to install it with `make PREFIX=/usr install`, too.**
+
 Checkout the [wiki][wiki] for more information.
 
 ## Bug reports

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,4 +1,53 @@
 ===================================================================================
+Release Notes For v1.3.0
+===================================================================================
+
+Version 1.3 is supposed to be fully backwards compatible with 1.2.
+
+For users:
+
+* Behavioral changes
+
+  Dunst respects the timeout in milliseconds now. Notifications with a one second
+  timeout are not shown up to three seconds.
+
+  Transient notifications are now timing out properly also when in idle and are not
+  saved in history.
+
+  A prefixed tilde to path option (browser, dmenu, script) is interpreted as the
+  home folder of the user.
+
+* Configuration Options
+
+  `icon_folders` got deprecated and renamed to `icon_path`. `icon_folders` is still
+  supported, but will get removed in future.
+
+  The option `ellpsize` got introduced. It controls where to ellipsize the text of
+  an overlong notification if `word_wrap = no`.
+
+  For transient notifications, there are the rules `set_transient` and
+  `match_transient` to configure the behavior of the notification.
+
+For maintainers:
+
+* Dependencies
+
+  The GTK3+ dependency got removed. Instead of this, gdk-pixbuf is required
+  explicitly. This had been a transient dependency before.
+
+  In the Makefile, libxrandr is now specified to require its version minimum to 1.5.
+  The dependency on libxrandr >= 1.5 is not new. Dunst 1.2.0 required it too, but
+  there was no active check for it.
+
+* Portability
+
+  GNU-specific functions have been disabled to make dunst portable to nongnu libc's.
+
+
+For more details, consider [CHANGELOG.md].
+
+
+===================================================================================
 Release Notes For v1.2.0
 ===================================================================================
 

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -39,6 +39,18 @@ For maintainers:
   The dependency on libxrandr >= 1.5 is not new. Dunst 1.2.0 required it too, but
   there was no active check for it.
 
+* Installation process
+
+	The internals of dunst's make installation process have slightly changed. The
+	install routine won't install the service files for DBus and systemd in a hardcoded
+	subdirectory of $PREFIX. It'll now query the `dbus-1` and `systemd` pkg-config
+	packages for those paths and will put it there.
+
+	To overwrite the pkg-config values, you can manually specify another path.
+	Use `SERVICEDIR_(DBUS|SYSTEMD)` vars as parameters to your make calls.
+
+	For all introduced variables, see [the README.md].
+
 * Portability
 
   GNU-specific functions have been disabled to make dunst portable to nongnu libc's.


### PR DESCRIPTION
As all remaining issues on the `1.3` milestone get closed via their associated PR, I started here to write the changelog and release notes for it.