### PR TITLE
Don't emit NotificationClosed signal on redisplayed notifications

### DIFF
--- a/src/dbus.c
+++ b/src/dbus.c
@@ -298,7 +298,7 @@ static void on_notify(GDBusConnection *connection,
 
         // The message got discarded
         if (id == 0) {
-                notification_closed(n, 2);
+                signal_notification_closed(n, 2);
                 notification_free(n);
         }
 
@@ -331,7 +331,7 @@ static void on_get_server_information(GDBusConnection *connection,
         g_dbus_connection_flush(connection, NULL, NULL, NULL);
 }
 
-void notification_closed(notification *n, enum reason reason)
+void signal_notification_closed(notification *n, enum reason reason)
 {
         if (reason < REASON_MIN || REASON_MAX < reason) {
                 fprintf(stderr, "ERROR: Closing notification with reason '%d' not supported. "
@@ -362,7 +362,7 @@ void notification_closed(notification *n, enum reason reason)
 
 }
 
-void action_invoked(notification *n, const char *identifier)
+void signal_action_invoked(notification *n, const char *identifier)
 {
         GVariant *body = g_variant_new("(us)", n->id, identifier);
         GError *err = NULL;

--- a/src/dbus.h
+++ b/src/dbus.h
@@ -17,8 +17,8 @@ enum reason {
 int initdbus(void);
 void dbus_tear_down(int id);
 /* void dbus_poll(int timeout); */
-void notification_closed(notification *n, enum reason reason);
-void action_invoked(notification *n, const char *identifier);
+void signal_notification_closed(notification *n, enum reason reason);
+void signal_action_invoked(notification *n, const char *identifier);
 
 #endif
 /* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/menu.c
+++ b/src/menu.c
@@ -157,7 +157,7 @@ void invoke_action(const char *action)
         }
 
         if (invoked && action_identifier) {
-                action_invoked(invoked, action_identifier);
+                signal_action_invoked(invoked, action_identifier);
         }
 }
 

--- a/src/notification.c
+++ b/src/notification.c
@@ -558,12 +558,12 @@ void notification_do_action(notification *n)
 {
         if (n->actions) {
                 if (n->actions->count == 2) {
-                        action_invoked(n, n->actions->actions[0]);
+                        signal_action_invoked(n, n->actions->actions[0]);
                         return;
                 }
                 for (int i = 0; i < n->actions->count; i += 2) {
                         if (strcmp(n->actions->actions[i], "default") == 0) {
-                                action_invoked(n, n->actions->actions[i]);
+                                signal_action_invoked(n, n->actions->actions[i]);
                                 return;
                         }
                 }

--- a/src/queues.c
+++ b/src/queues.c
@@ -115,7 +115,7 @@ static bool queues_stack_duplicate(notification *n)
 
                         n->dup_count = orig->dup_count;
 
-                        notification_closed(orig, 1);
+                        signal_notification_closed(orig, 1);
 
                         notification_free(orig);
                         return true;
@@ -138,7 +138,7 @@ static bool queues_stack_duplicate(notification *n)
 
                         n->dup_count = orig->dup_count;
 
-                        notification_closed(orig, 1);
+                        signal_notification_closed(orig, 1);
 
                         notification_free(orig);
                         return true;
@@ -205,7 +205,7 @@ int queues_notification_close_id(int id, enum reason reason)
         }
 
         if (target) {
-                notification_closed(target, reason);
+                signal_notification_closed(target, reason);
                 queues_history_push(target);
         }
 

--- a/src/queues.c
+++ b/src/queues.c
@@ -205,7 +205,9 @@ int queues_notification_close_id(int id, enum reason reason)
         }
 
         if (target) {
-                signal_notification_closed(target, reason);
+                //Don't notify clients if notification was pulled from history
+                if (!target->redisplayed)
+                        signal_notification_closed(target, reason);
                 queues_history_push(target);
         }
 


### PR DESCRIPTION
The `notification_closed` function is called even when a notification has
been pulled from history and re-emits the `NotificationClosed` signal,
this can confuse clients since it's not accounted for in the spec.