### PR TITLE
Distinguish DBus connection and name acquired error

### DIFF
--- a/src/dbus.c
+++ b/src/dbus.c
@@ -418,7 +418,11 @@ static void on_name_lost(GDBusConnection *connection,
                          const gchar *name,
                          gpointer user_data)
 {
-        fprintf(stderr, "Name Lost. Is Another notification daemon running?\n");
+        if (connection)
+                fprintf(stderr, "Cannot acquire 'org.freedesktop.Notifications'."
+                                "Is Another notification daemon running?\n");
+        else
+                fprintf(stderr, "Cannot connect to DBus.\n");
         exit(1);
 }
 


### PR DESCRIPTION
Distinguish between a failure to connect to DBus and a failure to
connect to the actual FDN DBus path.

This is possible, because `on_name_acquired` gets its DBus connection
passed as a parameter. If this parameter is NULL, there is no connection
established and the DBus name is not lost, because another notification
daemon is running.

Fixes #451 