### PR TITLE
Add valgrind to travis configuration and check for leaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,14 @@ addons:
       - libcairo2-dev
       - libnotify-dev
       - libgtk-3-dev
+      - valgrind
 dist: trusty
 sudo: false
 language: c
 before_install:
   - pip install --user cpp-coveralls
 script:
-  - CFLAGS="-fprofile-arcs -ftest-coverage -Werror" make all dunstify test
+  - CFLAGS="-fprofile-arcs -ftest-coverage -Werror" make all dunstify test-valgrind
   - coveralls
 compiler:
   - gcc

--- a/.valgrind.suppressions
+++ b/.valgrind.suppressions
@@ -1,0 +1,10 @@
+{
+   xdgBaseDir_leak
+   # see https://github.com/devnev/libxdg-basedir/pull/6
+   Memcheck:Leak
+   fun:malloc
+   ...
+   fun:xdgInitHandle
+   ...
+   fun:main
+}

--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,19 @@ dunst: ${OBJ} main.o
 dunstify: dunstify.o
 	${CC} ${CFLAGS} -o $@ dunstify.o ${LDFLAGS}
 
-.PHONY: test
+.PHONY: test test-valgrind
 test: test/test
 	cd test && ./test
+
+test-valgrind: test/test
+	cd ./test \
+		&& valgrind \
+			--suppressions=../.valgrind.suppressions \
+			--leak-check=full \
+			--show-leak-kinds=definite \
+			--errors-for-leak-kinds=definite \
+			--error-exitcode=123 \
+			./test
 
 test/test: ${OBJ} ${TEST_OBJ}
 	${CC} ${CFLAGS} -o $@ ${TEST_OBJ} ${OBJ} ${LDFLAGS}

--- a/src/utils.c
+++ b/src/utils.c
@@ -29,9 +29,9 @@ char *string_replace_at(char *buf, int pos, int len, const char *repl)
                 tmp = buf;
         } else {
                 tmp = g_malloc(size);
+                memcpy(tmp, buf, pos);
         }
 
-        memcpy(tmp, buf, pos);
         memcpy(tmp + pos, repl, repl_len);
         memmove(tmp + pos + repl_len, buf + pos + len, buf_len - (pos + len) + 1);
 


### PR DESCRIPTION
So, while we're already starting to improve our testsuite, I'd like to throw this one in, too.

It checks for definite leaks now in our testsuite, and more important, it'll fail if any leaks are found.

For this, we have to ignore that small xdg basedir leak and then tell valgrind to exit with an error code, when a definite leak shows up.