### PR TITLE
Add configurable path variables for services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,16 +8,29 @@ ifneq ($(wildcard ./.git/.),)
 VERSION := $(shell git describe --tags)
 endif
 
+ifeq (,${SYSTEMD})
+# Check for systemctl to avoid discrepancies on systems, where
+# systemd is installed, but systemd.pc is in another package 
+systemctl := $(shell command -v systemctl >/dev/null && echo systemctl)
+ifeq (systemctl,${systemctl})
+SYSTEMD := 1
+else
+SYSTEMD := 0
+endif
+endif
+
 SERVICEDIR_DBUS ?= $(shell pkg-config dbus-1 --variable=session_bus_services_dir)
 SERVICEDIR_DBUS := ${SERVICEDIR_DBUS}
 ifeq (,${SERVICEDIR_DBUS})
 $(error "Failed to query pkg-config for package 'dbus-1'!")
 endif
 
+ifneq (0,${SYSTEMD})
 SERVICEDIR_SYSTEMD ?= $(shell pkg-config systemd --variable=systemduserunitdir)
 SERVICEDIR_SYSTEMD := ${SERVICEDIR_SYSTEMD}
 ifeq (,${SERVICEDIR_SYSTEMD})
 $(error "Failed to query pkg-config for package 'systemd'!")
+endif
 endif
 
 LIBS := $(shell pkg-config --libs   ${pkg_config_packs})
@@ -78,10 +91,15 @@ doc: docs/dunst.1
 docs/dunst.1: docs/dunst.pod
 	pod2man --name=dunst -c "Dunst Reference" --section=1 --release=${VERSION} $< > $@
 
-.PHONY: service
-service:
+.PHONY: service service-dbus service-systemd
+service: service-dbus
+service-dbus:
 	@sed "s|##PREFIX##|$(PREFIX)|" org.knopwob.dunst.service.in > org.knopwob.dunst.service
+ifneq (0,${SYSTEMD})
+service: service-systemd
+service-systemd:
 	@sed "s|##PREFIX##|$(PREFIX)|" dunst.systemd.service.in > dunst.systemd.service
+endif
 
 .PHONY: clean clean-dunst clean-dunstify clean-doc clean-tests
 clean: clean-dunst clean-dunstify clean-doc clean-tests
@@ -101,7 +119,10 @@ clean-doc:
 clean-tests:
 	rm -f test/test test/*.o
 
-.PHONY: install install-dunst install-doc install-service uninstall
+.PHONY: install install-dunst install-doc \
+        install-service install-service-dbus install-service-systemd \
+        uninstall \
+        uninstall-service uninstall-service-dbus uninstall-service-systemd
 install: install-dunst install-doc install-service
 
 install-dunst: dunst doc
@@ -114,13 +135,26 @@ install-doc:
 	mkdir -p ${DESTDIR}${PREFIX}/share/dunst
 	install -m644 dunstrc ${DESTDIR}${PREFIX}/share/dunst
 
-install-service: service
+install-service: service install-service-dbus
+install-service-dbus:
 	install -Dm644 org.knopwob.dunst.service ${DESTDIR}${SERVICEDIR_DBUS}/org.knopwob.dunst.service
+ifneq (0,${SYSTEMD})
+install-service: install-service-systemd
+install-service-systemd:
 	install -Dm644 dunst.systemd.service ${DESTDIR}${SERVICEDIR_SYSTEMD}/dunst.service
+endif
 
-uninstall:
+uninstall: uninstall-service
 	rm -f ${DESTDIR}${PREFIX}/bin/dunst
 	rm -f ${DESTDIR}${MANPREFIX}/man1/dunst.1
-	rm -f ${DESTDIR}${SERVICEDIR_DBUS}/org.knopwob.dunst.service
-	rm -f ${DESTDIR}${SERVICEDIR_SYSTEMD}/dunst.service
 	rm -rf ${DESTDIR}${PREFIX}/share/dunst
+
+uninstall-service: uninstall-service-dbus
+uninstall-service-dbus:
+	rm -f ${DESTDIR}${SERVICEDIR_DBUS}/org.knopwob.dunst.service
+
+ifneq (0,${SYSTEMD})
+uninstall-service: uninstall-service-systemd
+uninstall-service-systemd:
+	rm -f ${DESTDIR}${SERVICEDIR_SYSTEMD}/dunst.service
+endif

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,18 @@ ifneq ($(wildcard ./.git/.),)
 VERSION := $(shell git describe --tags)
 endif
 
+SERVICEDIR_DBUS ?= $(shell pkg-config dbus-1 --variable=session_bus_services_dir)
+SERVICEDIR_DBUS := ${SERVICEDIR_DBUS}
+ifeq (,${SERVICEDIR_DBUS})
+$(error "Failed to query pkg-config for package 'dbus-1'!")
+endif
+
+SERVICEDIR_SYSTEMD ?= $(shell pkg-config systemd --variable=systemduserunitdir)
+SERVICEDIR_SYSTEMD := ${SERVICEDIR_SYSTEMD}
+ifeq (,${SERVICEDIR_SYSTEMD})
+$(error "Failed to query pkg-config for package 'systemd'!")
+endif
+
 LIBS := $(shell pkg-config --libs   ${pkg_config_packs})
 INCS := $(shell pkg-config --cflags ${pkg_config_packs})
 
@@ -103,13 +115,12 @@ install-doc:
 	install -m644 dunstrc ${DESTDIR}${PREFIX}/share/dunst
 
 install-service: service
-	mkdir -p ${DESTDIR}${PREFIX}/share/dbus-1/services/
-	install -m644 org.knopwob.dunst.service ${DESTDIR}${PREFIX}/share/dbus-1/services
-	install -Dm644 dunst.systemd.service ${DESTDIR}${PREFIX}/lib/systemd/user/dunst.service
+	install -Dm644 org.knopwob.dunst.service ${DESTDIR}${SERVICEDIR_DBUS}/org.knopwob.dunst.service
+	install -Dm644 dunst.systemd.service ${DESTDIR}${SERVICEDIR_SYSTEMD}/dunst.service
 
 uninstall:
 	rm -f ${DESTDIR}${PREFIX}/bin/dunst
 	rm -f ${DESTDIR}${MANPREFIX}/man1/dunst.1
-	rm -f ${DESTDIR}${PREFIX}/share/dbus-1/services/org.knopwob.dunst.service
-	rm -f ${DESTDIR}${PREFIX}/lib/systemd/user/dunst.service
+	rm -f ${DESTDIR}${SERVICEDIR_DBUS}/org.knopwob.dunst.service
+	rm -f ${DESTDIR}${SERVICEDIR_SYSTEMD}/dunst.service
 	rm -rf ${DESTDIR}${PREFIX}/share/dunst

--- a/Makefile
+++ b/Makefile
@@ -126,14 +126,11 @@ clean-tests:
 install: install-dunst install-doc install-service
 
 install-dunst: dunst doc
-	mkdir -p ${DESTDIR}${PREFIX}/bin
-	install -m755 dunst ${DESTDIR}${PREFIX}/bin
-	mkdir -p ${DESTDIR}${MANPREFIX}/man1
-	install -m644 docs/dunst.1 ${DESTDIR}${MANPREFIX}/man1
+	install -Dm755 dunst ${DESTDIR}${PREFIX}/bin/dunst
+	install -Dm644 docs/dunst.1 ${DESTDIR}${MANPREFIX}/man1/dunst.1
 
 install-doc:
-	mkdir -p ${DESTDIR}${PREFIX}/share/dunst
-	install -m644 dunstrc ${DESTDIR}${PREFIX}/share/dunst
+	install -Dm644 dunstrc ${DESTDIR}${PREFIX}/share/dunst/dunstrc
 
 install-service: service install-service-dbus
 install-service-dbus:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@
 Dunst is a highly configurable and lightweight notification daemon.
 
 
-## Compiling
+## Installation
+
+### Dependencies
 
 Dunst has a number of build dependencies that must be present before attempting configuration. The names are different depending on [distribution](https://github.com/dunst-project/dunst/wiki/Dependencies):
 
@@ -24,6 +26,23 @@ Dunst has a number of build dependencies that must be present before attempting 
 - glib
 - pango/cairo
 - libgtk-3-dev
+
+### Building
+
+```
+git clone https://github.com/dunst-project/dunst.git
+cd dunst
+make
+sudo make install
+```
+
+### Make parameters
+
+- `PREFIX=<PATH>`: Set the prefix of the installation. (Default: `/usr/local`)
+- `MANPREFIX=<PATH>`: Set the prefix of the manpage. (Default: `${PREFIX}/share/man`)
+- `SYSTEMD=(0|1)`: Enable/Disable the systemd unit. (Default: detected via `pkg-config`)
+- `SERVICEDIR_SYSTEMD=<PATH>`: The path to put the systemd user service file. Unused, if `SYSTEMD=0`. (Default: detected via `pkg-config`)
+- `SERVICEDIR_DBUS=<PATH>`: The path to put the dbus service file. (Default: detected via `pkg-config`)
 
 Checkout the [wiki][wiki] for more information.
 

--- a/config.mk
+++ b/config.mk
@@ -2,6 +2,10 @@
 PREFIX ?= /usr/local
 MANPREFIX = ${PREFIX}/share/man
 
+# Disable systemd service file installation,
+# if you don't want to use systemd albeit installed
+#SYSTEMD ?= 0
+
 # uncomment to disable parsing of dunstrc
 # or use "CFLAGS=-DSTATIC_CONFIG make" to build
 #STATIC= -DSTATIC_CONFIG # Warning: This is deprecated behavior


### PR DESCRIPTION
Setting PREFIX to a location different to /usr, the install routine
fails to install the systemd and dbus service files. These are
installed, but in the PREFIX directory and not /usr. DBus and systemd
usually only read their files from /usr/ and ignore files in /usr/local.

Now by default, we're asking pkg-config, where to install it. Mostly,
this will be /usr and this conflicts the FHS. But it's the user's intent
to install dunst and (possibly) override the package manager's files
belonging to dunst.

At the current point, even DBus ignores the PREFIX and installs its
systemd service file to the location specified by pkg-config.