### PR TITLE
Make run static to not export it

### DIFF
--- a/src/dunst.c
+++ b/src/dunst.c
@@ -42,13 +42,14 @@ GMainLoop *mainloop = NULL;
 GSList *rules = NULL;
 
 /* misc funtions */
+static gboolean run(void *data);
 
 void wake_up(void)
 {
         run(NULL);
 }
 
-gboolean run(void *data)
+static gboolean run(void *data)
 {
         queues_check_timeouts(x_is_idle());
         queues_update();

--- a/src/dunst.h
+++ b/src/dunst.h
@@ -19,7 +19,6 @@
 extern GSList *rules;
 extern const char *colors[3][3];
 
-gboolean run(void *data);
 void wake_up(void);
 
 int dunst_main(int argc, char *argv[]);


### PR DESCRIPTION
This enforces to call wake_up in other files and not run(NULL).