### PR TITLE
Raise the maximum value of the progress hint

### DIFF
--- a/src/notification.c
+++ b/src/notification.c
@@ -324,7 +324,7 @@ void notification_init(notification *n)
                 n->colors[ColFrame] = g_strdup(xctx.colors[ColFrame][n->urgency]);
 
         /* Sanitize misc hints */
-        if (n->progress < 0 || n->progress > 100)
+        if (n->progress < 0)
                 n->progress = -1;
 
         /* Process rules */


### PR DESCRIPTION
The progress hint is mostly used for progress bars but as discussed in
 #437 there are cases where values > 100 make sense.

Fixes #437