### PR TITLE
[X11refactor] Remove color field from xctx

### DIFF
--- a/config.h
+++ b/config.h
@@ -4,12 +4,12 @@ settings_t defaults = {
 
 .font = "-*-terminus-medium-r-*-*-16-*-*-*-*-*-*-*",
 .markup = MARKUP_NO,
-.normbgcolor = "#1793D1",
-.normfgcolor = "#DDDDDD",
-.critbgcolor = "#ffaaaa",
-.critfgcolor = "#000000",
-.lowbgcolor = "#aaaaff",
-.lowfgcolor = "#000000",
+.colors_norm.bg = "#1793D1",
+.colors_norm.fg = "#DDDDDD",
+.colors_crit.bg = "#ffaaaa",
+.colors_crit.fg = "#000000",
+.colors_low.bg = "#aaaaff",
+.colors_low.fg = "#000000",
 .format = "%s %b",         /* default format */
 
 .timeouts = { 10*G_USEC_PER_SEC, 10*G_USEC_PER_SEC, 0 }, /* low, normal, critical */

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -285,8 +285,8 @@ static notification *dbus_message_to_notification(const gchar *sender, GVariant 
         }
         n->actions = actions;
 
-        n->colors[ColFG] = fgcolor;
-        n->colors[ColBG] = bgcolor;
+        n->colors.fg = fgcolor;
+        n->colors.bg = bgcolor;
 
         notification_init(n);
         return n;

--- a/src/dunst.h
+++ b/src/dunst.h
@@ -11,11 +11,6 @@
 
 #define PERR(msg, errnum) printf("(%d) %s : %s\n", __LINE__, (msg), (strerror(errnum)))
 
-#define ColLast 3
-#define ColFrame 2
-#define ColFG 1
-#define ColBG 0
-
 extern GSList *rules;
 extern const char *colors[3][3];
 

--- a/src/notification.c
+++ b/src/notification.c
@@ -21,7 +21,6 @@
 #include "rules.h"
 #include "settings.h"
 #include "utils.h"
-#include "x11/x.h"
 
 static void notification_extract_urls(notification *n);
 static void notification_format_message(notification *n);
@@ -316,12 +315,26 @@ void notification_init(notification *n)
                 n->icon = g_strdup(settings.icons[n->urgency]);
 
         /* Color hints */
+        NotificationColors defcolors;
+        switch (n->urgency) {
+                case URG_LOW:
+                        defcolors = settings.colors_low;
+                        break;
+                case URG_NORM:
+                        defcolors = settings.colors_norm;
+                        break;
+                case URG_CRIT:
+                        defcolors = settings.colors_crit;
+                        break;
+                default:
+                        g_error("Unhandled urgency type: %d", n->urgency);
+        }
         if (!n->colors.fg)
-                n->colors.fg = g_strdup(xctx.colors[ColFG][n->urgency]);
+                n->colors.fg = g_strdup(defcolors.fg);
         if (!n->colors.bg)
-                n->colors.bg = g_strdup(xctx.colors[ColBG][n->urgency]);
+                n->colors.bg = g_strdup(defcolors.bg);
         if (!n->colors.frame)
-                n->colors.frame = g_strdup(xctx.colors[ColFrame][n->urgency]);
+                n->colors.frame = g_strdup(defcolors.frame);
 
         /* Sanitize misc hints */
         if (n->progress < 0)

--- a/src/notification.c
+++ b/src/notification.c
@@ -44,9 +44,9 @@ void notification_print(notification *n)
         printf("\turgency: %s\n", notification_urgency_to_string(n->urgency));
         printf("\ttransient: %d\n", n->transient);
         printf("\tformatted: '%s'\n", n->msg);
-        printf("\tfg: %s\n", n->colors[ColFG]);
-        printf("\tbg: %s\n", n->colors[ColBG]);
-        printf("\tframe: %s\n", n->colors[ColFrame]);
+        printf("\tfg: %s\n", n->colors.fg);
+        printf("\tbg: %s\n", n->colors.bg);
+        printf("\tframe: %s\n", n->colors.frame);
         printf("\tid: %d\n", n->id);
         if (n->urls) {
                 char *urls = string_replace_all("\n", "\t\t\n", g_strdup(n->urls));
@@ -216,9 +216,9 @@ void notification_free(notification *n)
         g_free(n->category);
         g_free(n->text_to_render);
         g_free(n->urls);
-        g_free(n->colors[ColFG]);
-        g_free(n->colors[ColBG]);
-        g_free(n->colors[ColFrame]);
+        g_free(n->colors.fg);
+        g_free(n->colors.bg);
+        g_free(n->colors.frame);
 
         actions_free(n->actions);
         rawimage_free(n->raw_icon);
@@ -316,12 +316,12 @@ void notification_init(notification *n)
                 n->icon = g_strdup(settings.icons[n->urgency]);
 
         /* Color hints */
-        if (!n->colors[ColFG])
-                n->colors[ColFG] = g_strdup(xctx.colors[ColFG][n->urgency]);
-        if (!n->colors[ColBG])
-                n->colors[ColBG] = g_strdup(xctx.colors[ColBG][n->urgency]);
-        if (!n->colors[ColFrame])
-                n->colors[ColFrame] = g_strdup(xctx.colors[ColFrame][n->urgency]);
+        if (!n->colors.fg)
+                n->colors.fg = g_strdup(xctx.colors[ColFG][n->urgency]);
+        if (!n->colors.bg)
+                n->colors.bg = g_strdup(xctx.colors[ColBG][n->urgency]);
+        if (!n->colors.frame)
+                n->colors.frame = g_strdup(xctx.colors[ColFrame][n->urgency]);
 
         /* Sanitize misc hints */
         if (n->progress < 0)

--- a/src/notification.h
+++ b/src/notification.h
@@ -34,6 +34,12 @@ typedef struct _actions {
         gsize count;
 } Actions;
 
+typedef struct _notification_colors {
+        char *frame;
+        char *bg;
+        char *fg;
+} NotificationColors;
+
 typedef struct _notification {
         int id;
         char *dbus_client;
@@ -56,7 +62,7 @@ typedef struct _notification {
         enum markup_mode markup;
         const char *format;
         const char *script;
-        char *colors[3];
+        NotificationColors colors;
 
         /* Hints */
         bool transient;     /* timeout albeit user is idle */

--- a/src/notification.h
+++ b/src/notification.h
@@ -2,6 +2,13 @@
 #ifndef DUNST_NOTIFICATION_H
 #define DUNST_NOTIFICATION_H
 
+//TODO: Remove cyclic dependency
+typedef struct _notification_colors {
+        char *frame;
+        char *bg;
+        char *fg;
+} NotificationColors;
+
 #include <glib.h>
 #include <stdbool.h>
 
@@ -33,12 +40,6 @@ typedef struct _actions {
         char *dmenu_str;
         gsize count;
 } Actions;
-
-typedef struct _notification_colors {
-        char *frame;
-        char *bg;
-        char *fg;
-} NotificationColors;
 
 typedef struct _notification {
         int id;

--- a/src/rules.c
+++ b/src/rules.c
@@ -29,12 +29,12 @@ void rule_apply(rule_t *r, notification *n)
                 n->raw_icon = NULL;
         }
         if (r->fg) {
-                g_free(n->colors[ColFG]);
-                n->colors[ColFG] = g_strdup(r->fg);
+                g_free(n->colors.fg);
+                n->colors.fg = g_strdup(r->fg);
         }
         if (r->bg) {
-                g_free(n->colors[ColBG]);
-                n->colors[ColBG] = g_strdup(r->bg);
+                g_free(n->colors.bg);
+                n->colors.bg = g_strdup(r->bg);
         }
         if (r->format)
                 n->format = r->format;

--- a/src/settings.c
+++ b/src/settings.c
@@ -485,19 +485,19 @@ void load_settings(char *cmdline_config_path)
                 );
 
         }
-        settings.lowbgcolor = option_get_string(
+        settings.colors_low.bg = option_get_string(
                 "urgency_low",
-                "background", "-lb", defaults.lowbgcolor,
+                "background", "-lb", defaults.colors_low.bg,
                 "Background color for notifications with low urgency"
         );
 
-        settings.lowfgcolor = option_get_string(
+        settings.colors_low.fg = option_get_string(
                 "urgency_low",
-                "foreground", "-lf", defaults.lowfgcolor,
+                "foreground", "-lf", defaults.colors_low.fg,
                 "Foreground color for notifications with low urgency"
         );
 
-        settings.lowframecolor = option_get_string(
+        settings.colors_low.frame = option_get_string(
                 "urgency_low",
                 "frame_color", "-lfr", NULL,
                 "Frame color for notifications with low urgency"
@@ -515,19 +515,19 @@ void load_settings(char *cmdline_config_path)
                 "Icon for notifications with low urgency"
         );
 
-        settings.normbgcolor = option_get_string(
+        settings.colors_norm.bg = option_get_string(
                 "urgency_normal",
-                "background", "-nb", defaults.normbgcolor,
+                "background", "-nb", defaults.colors_norm.bg,
                 "Background color for notifications with normal urgency"
         );
 
-        settings.normfgcolor = option_get_string(
+        settings.colors_norm.fg = option_get_string(
                 "urgency_normal",
-                "foreground", "-nf", defaults.normfgcolor,
+                "foreground", "-nf", defaults.colors_norm.fg,
                 "Foreground color for notifications with normal urgency"
         );
 
-        settings.normframecolor = option_get_string(
+        settings.colors_norm.frame = option_get_string(
                 "urgency_normal",
                 "frame_color", "-nfr", NULL,
                 "Frame color for notifications with normal urgency"
@@ -545,19 +545,19 @@ void load_settings(char *cmdline_config_path)
                 "Icon for notifications with normal urgency"
         );
 
-        settings.critbgcolor = option_get_string(
+        settings.colors_crit.bg = option_get_string(
                 "urgency_critical",
-                "background", "-cb", defaults.critbgcolor,
+                "background", "-cb", defaults.colors_crit.bg,
                 "Background color for notifications with critical urgency"
         );
 
-        settings.critfgcolor = option_get_string(
+        settings.colors_crit.fg = option_get_string(
                 "urgency_critical",
-                "foreground", "-cf", defaults.critfgcolor,
+                "foreground", "-cf", defaults.colors_crit.fg,
                 "Foreground color for notifications with ciritical urgency"
         );
 
-        settings.critframecolor = option_get_string(
+        settings.colors_crit.frame = option_get_string(
                 "urgency_critical",
                 "frame_color", "-cfr", NULL,
                 "Frame color for notifications with critical urgency"

--- a/src/settings.c
+++ b/src/settings.c
@@ -499,7 +499,7 @@ void load_settings(char *cmdline_config_path)
 
         settings.colors_low.frame = option_get_string(
                 "urgency_low",
-                "frame_color", "-lfr", NULL,
+                "frame_color", "-lfr", settings.frame_color ? settings.frame_color : defaults.colors_low.frame,
                 "Frame color for notifications with low urgency"
         );
 
@@ -529,7 +529,7 @@ void load_settings(char *cmdline_config_path)
 
         settings.colors_norm.frame = option_get_string(
                 "urgency_normal",
-                "frame_color", "-nfr", NULL,
+                "frame_color", "-nfr", settings.frame_color ? settings.frame_color : defaults.colors_norm.frame,
                 "Frame color for notifications with normal urgency"
         );
 
@@ -559,7 +559,7 @@ void load_settings(char *cmdline_config_path)
 
         settings.colors_crit.frame = option_get_string(
                 "urgency_critical",
-                "frame_color", "-cfr", NULL,
+                "frame_color", "-cfr", settings.frame_color ? settings.frame_color : defaults.colors_crit.frame,
                 "Frame color for notifications with critical urgency"
         );
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -13,6 +13,8 @@ enum separator_color { FOREGROUND, AUTO, FRAME, CUSTOM };
 enum follow_mode { FOLLOW_NONE, FOLLOW_MOUSE, FOLLOW_KEYBOARD };
 enum markup_mode { MARKUP_NULL, MARKUP_NO, MARKUP_STRIP, MARKUP_FULL };
 
+#include "notification.h"
+
 typedef struct _settings {
         bool print_notifications;
         bool per_monitor_dpi;
@@ -20,15 +22,9 @@ typedef struct _settings {
         bool stack_duplicates;
         bool hide_duplicate_count;
         char *font;
-        char *normbgcolor;
-        char *normfgcolor;
-        char *normframecolor;
-        char *critbgcolor;
-        char *critfgcolor;
-        char *critframecolor;
-        char *lowbgcolor;
-        char *lowfgcolor;
-        char *lowframecolor;
+        NotificationColors colors_low;
+        NotificationColors colors_norm;
+        NotificationColors colors_crit;
         char *format;
         gint64 timeouts[3];
         char *icons[3];

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -1013,24 +1013,24 @@ void x_setup(void)
         x_shortcut_grab(&settings.context_ks);
         x_shortcut_ungrab(&settings.context_ks);
 
-        xctx.colors[ColFG][URG_LOW] = settings.lowfgcolor;
-        xctx.colors[ColFG][URG_NORM] = settings.normfgcolor;
-        xctx.colors[ColFG][URG_CRIT] = settings.critfgcolor;
+        xctx.colors[ColFG][URG_LOW] = settings.colors_low.fg;
+        xctx.colors[ColFG][URG_NORM] = settings.colors_norm.fg;
+        xctx.colors[ColFG][URG_CRIT] = settings.colors_crit.fg;
 
-        xctx.colors[ColBG][URG_LOW] = settings.lowbgcolor;
-        xctx.colors[ColBG][URG_NORM] = settings.normbgcolor;
-        xctx.colors[ColBG][URG_CRIT] = settings.critbgcolor;
+        xctx.colors[ColBG][URG_LOW] = settings.colors_low.bg;
+        xctx.colors[ColBG][URG_NORM] = settings.colors_norm.bg;
+        xctx.colors[ColBG][URG_CRIT] = settings.colors_crit.bg;
 
-        if (settings.lowframecolor)
-                xctx.colors[ColFrame][URG_LOW] = settings.lowframecolor;
+        if (settings.colors_low.frame)
+                xctx.colors[ColFrame][URG_LOW] = settings.colors_low.frame;
         else
                 xctx.colors[ColFrame][URG_LOW] = settings.frame_color;
-        if (settings.normframecolor)
-                xctx.colors[ColFrame][URG_NORM] = settings.normframecolor;
+        if (settings.colors_norm.frame)
+                xctx.colors[ColFrame][URG_NORM] = settings.colors_norm.frame;
         else
                 xctx.colors[ColFrame][URG_NORM] = settings.frame_color;
-        if (settings.critframecolor)
-                xctx.colors[ColFrame][URG_CRIT] = settings.critframecolor;
+        if (settings.colors_crit.frame)
+                xctx.colors[ColFrame][URG_CRIT] = settings.colors_crit.frame;
         else
                 xctx.colors[ColFrame][URG_CRIT] = settings.frame_color;
 

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -1013,27 +1013,6 @@ void x_setup(void)
         x_shortcut_grab(&settings.context_ks);
         x_shortcut_ungrab(&settings.context_ks);
 
-        xctx.colors[ColFG][URG_LOW] = settings.colors_low.fg;
-        xctx.colors[ColFG][URG_NORM] = settings.colors_norm.fg;
-        xctx.colors[ColFG][URG_CRIT] = settings.colors_crit.fg;
-
-        xctx.colors[ColBG][URG_LOW] = settings.colors_low.bg;
-        xctx.colors[ColBG][URG_NORM] = settings.colors_norm.bg;
-        xctx.colors[ColBG][URG_CRIT] = settings.colors_crit.bg;
-
-        if (settings.colors_low.frame)
-                xctx.colors[ColFrame][URG_LOW] = settings.colors_low.frame;
-        else
-                xctx.colors[ColFrame][URG_LOW] = settings.frame_color;
-        if (settings.colors_norm.frame)
-                xctx.colors[ColFrame][URG_NORM] = settings.colors_norm.frame;
-        else
-                xctx.colors[ColFrame][URG_NORM] = settings.frame_color;
-        if (settings.colors_crit.frame)
-                xctx.colors[ColFrame][URG_CRIT] = settings.colors_crit.frame;
-        else
-                xctx.colors[ColFrame][URG_CRIT] = settings.frame_color;
-
         /* parse and set xctx.geometry and monitor position */
         if (settings.geom[0] == '-') {
                 xctx.geometry.negative_width = true;

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -485,9 +485,9 @@ static colored_layout *r_init_shared(cairo_t *c, notification *n)
                 cl->icon = NULL;
         }
 
-        cl->fg = x_string_to_color_t(n->colors[ColFG]);
-        cl->bg = x_string_to_color_t(n->colors[ColBG]);
-        cl->frame = x_string_to_color_t(n->colors[ColFrame]);
+        cl->fg = x_string_to_color_t(n->colors.fg);
+        cl->bg = x_string_to_color_t(n->colors.bg);
+        cl->frame = x_string_to_color_t(n->colors.frame);
 
         cl->n = n;
 

--- a/src/x11/x.h
+++ b/src/x11/x.h
@@ -29,7 +29,6 @@ typedef struct _xctx {
         Window win;
         bool visible;
         dimension_t geometry;
-        const char *colors[3][3];
         XScreenSaverInfo *screensaver_info;
         dimension_t window_dim;
         unsigned long sep_custom_col;


### PR DESCRIPTION
From https://github.com/dunst-project/dunst/issues/477#issuecomment-357219608

> * Separate X11 with the rest of the codebase as much as possible (_eyeing those `xctx` accesses in `notification.c`_).

Looking close at the `xctx.colors` fields, these turn out to be duplicates and are not required. If handled in the settings lookup properly, there is no necessity at all to have the `colors` field and the coupling of `notification.c` and `x.c` can get removed.