### PR TITLE
Handle execvp error in open_browser

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -115,8 +115,7 @@ void open_browser(const char *in)
                 if (browser_pid2) {
                         exit(0);
                 } else {
-                        char *browser_cmd =
-                            string_append(settings.browser, url, " ");
+                        char *browser_cmd = g_strconcat(settings.browser, " ", url, NULL);
                         char **cmd = g_strsplit(browser_cmd, " ", 0);
                         execvp(cmd[0], cmd);
                         // execvp won't return if it's successful

--- a/src/menu.c
+++ b/src/menu.c
@@ -119,6 +119,12 @@ void open_browser(const char *in)
                             string_append(settings.browser, url, " ");
                         char **cmd = g_strsplit(browser_cmd, " ", 0);
                         execvp(cmd[0], cmd);
+                        // execvp won't return if it's successful
+                        // so, if we're here, it's definitely an error
+                        fprintf(stderr, "Warning: failed to execute '%s': %s\n",
+                                        settings.browser,
+                                        strerror(errno));
+                        exit(EXIT_FAILURE);
                 }
         }
 }

--- a/src/menu.c
+++ b/src/menu.c
@@ -243,6 +243,10 @@ void context_menu(void)
                         exit(EXIT_FAILURE);
                 }
                 execvp(settings.dmenu_cmd[0], settings.dmenu_cmd);
+                fprintf(stderr, "Warning: failed to execute '%s': %s\n",
+                                settings.dmenu,
+                                strerror(errno));
+                exit(EXIT_FAILURE);
         } else {
                 close(child_io[0]);
                 close(parent_io[1]);


### PR DESCRIPTION
The execvp function usually doesn't return and exits by itself. But,
when having an error, it returns. As a faulty browser setting could
trigger this, dunst has to handle this, as the forked child wants to
access the X11 server too, resulting in XIO errors.

Fixes #476