### PR TITLE
Build dunst also as a git submodule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 include config.mk
 
 VERSION := "1.3.0-non-git"
-ifneq ($(wildcard ./.git/.),)
+ifneq ($(wildcard ./.git/),)
 VERSION := $(shell git describe --tags)
 endif
 


### PR DESCRIPTION
Git submodules have the property to have .git symlinked into the main
.git folder. On a symlink, the traling dot of a wildcard doesn't work.

Verify it via:

```
git init testrepo
cd testrepo
git submodule add https://github.com/dunst-project/dunst dunst
cd dunst
make
./dunst -v
git pull https://github.com/bebehei/dunst submodules
make clean
make
./dunst -v
```

Fixes the `-non-git` version number from @febs.