### PR TITLE
Coveralls & travis build fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,14 +18,22 @@ addons:
 dist: trusty
 sudo: false
 language: c
+
 before_install:
   - pip install --user cpp-coveralls
+
 script:
   - CFLAGS="-fprofile-arcs -ftest-coverage -Werror" make all dunstify test-valgrind doc-doxygen
-  - coveralls
-compiler:
-  - gcc
-  - clang
+
+matrix:
+  include:
+    - compiler: gcc
+      after_success:
+        - coveralls
+    - compiler: clang
+      after_success:
+        - coveralls --gcov llvm-cov --gcov-options gcov
+
 notifications:
   irc:
     channels:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
   include:
     - compiler: gcc
       after_success:
-        - coveralls
+        - coveralls --exclude 'test'
     - compiler: clang
       after_success:
-        - coveralls --gcov llvm-cov --gcov-options gcov
+        - coveralls --exclude 'test' --gcov llvm-cov --gcov-options gcov

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,9 @@ before_install:
   - pip install --user cpp-coveralls
 
 script:
-  - CFLAGS="-fprofile-arcs -ftest-coverage -Werror" make all dunstify test-valgrind doc-doxygen
+  - CFLAGS="-Werror" make all dunstify test-valgrind doc-doxygen
+  - make clean
+  - CFLAGS="-Werror -fprofile-arcs -ftest-coverage -O0" make test
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,10 +35,3 @@ matrix:
     - compiler: clang
       after_success:
         - coveralls --gcov llvm-cov --gcov-options gcov
-
-notifications:
-  irc:
-    channels:
-      - "chat.freenode.net#dunst"
-    on_success: change
-    on_failure: always

--- a/config.mk
+++ b/config.mk
@@ -15,7 +15,7 @@ PKG_CONFIG ?= pkg-config
 # flags
 CPPFLAGS += -D_DEFAULT_SOURCE -DVERSION=\"${VERSION}\"
 CFLAGS   += -g --std=gnu99 -pedantic -Wall -Wno-overlength-strings -Os ${STATIC} ${CPPFLAGS}
-LDFLAGS  += -lm -L${X11LIB}
+LDFLAGS  += -lm
 
 CPPFLAGS_DEBUG := -DDEBUG_BUILD
 CFLAGS_DEBUG   := -O0

--- a/config.mk
+++ b/config.mk
@@ -14,8 +14,8 @@ PKG_CONFIG ?= pkg-config
 
 # flags
 CPPFLAGS += -D_DEFAULT_SOURCE -DVERSION=\"${VERSION}\"
-CFLAGS   += -g --std=gnu99 -pedantic -Wall -Wno-overlength-strings -Os ${STATIC} ${CPPFLAGS}
-LDFLAGS  += -lm
+CFLAGS   := -g --std=gnu99 -pedantic -Wall -Wno-overlength-strings -Os ${STATIC} ${CPPFLAGS} ${CFLAGS}
+LDFLAGS  := -lm ${LDFLAGS}
 
 CPPFLAGS_DEBUG := -DDEBUG_BUILD
 CFLAGS_DEBUG   := -O0


### PR DESCRIPTION
Various changes to the travis and coveralls build process. More info about each change is in each commits body.

The X11LIB commit might seem out of scope but it is actually required for the next commit as if CFLAGS were moved it can cause an error since there's an empty `-L` parameter in the command.