### PR TITLE
Do not expand config.mk variables on assignment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,8 @@ $(error "$(PKG_CONFIG) failed!")
 endif
 endif
 
-CFLAGS += -I. ${INCS}
-LDFLAGS+= -L. ${LIBS}
+CFLAGS  := ${DEFAULT_CPPFLAGS} ${CPPFLAGS} ${DEFAULT_CFLAGS} ${CFLAGS} -I. ${INCS}
+LDFLAGS := ${DEFAULT_LDFLAGS} ${LDFLAGS} -L. ${LIBS}
 
 SRC := $(sort $(shell find src/ -name '*.c'))
 OBJ := ${SRC:.c=.o}
@@ -53,7 +53,7 @@ TEST_OBJ := $(TEST_SRC:.c=.o)
 .PHONY: all debug
 all: doc dunst service
 
-debug: CFLAGS   += ${CFLAGS_DEBUG}
+debug: CFLAGS   += ${CPPFLAGS_DEBUG} ${CFLAGS_DEBUG}
 debug: LDFLAGS  += ${LDFLAGS_DEBUG}
 debug: CPPFLAGS += ${CPPFLAGS_DEBUG}
 debug: all

--- a/config.mk
+++ b/config.mk
@@ -13,9 +13,9 @@ PKG_CONFIG ?= pkg-config
 #STATIC= -DSTATIC_CONFIG # Warning: This is deprecated behavior
 
 # flags
-CPPFLAGS += -D_DEFAULT_SOURCE -DVERSION=\"${VERSION}\"
-CFLAGS   := -g --std=gnu99 -pedantic -Wall -Wno-overlength-strings -Os ${STATIC} ${CPPFLAGS} ${CFLAGS}
-LDFLAGS  := -lm ${LDFLAGS}
+DEFAULT_CPPFLAGS = -D_DEFAULT_SOURCE -DVERSION=\"${VERSION}\"
+DEFAULT_CFLAGS   = -g --std=gnu99 -pedantic -Wall -Wno-overlength-strings -Os ${STATIC}
+DEFAULT_LDFLAGS  = -lm
 
 CPPFLAGS_DEBUG := -DDEBUG_BUILD
 CFLAGS_DEBUG   := -O0


### PR DESCRIPTION
Fix a bug introduced in 678ea70 where since the CFLAGS variable was
simply expanded it ignored the VERSION variable which was initialized
later.

Unfortunately there is no way to prepend a value to a recursively
expanded variable so instead we have to split the hardcoded compiler
flags into separate variables and combine them all later in the
makefile.

Fixes #500