### PR TITLE
Escape the summary

### DIFF
--- a/src/notification.c
+++ b/src/notification.c
@@ -381,7 +381,7 @@ static void notification_format_message(notification *n)
                                 &n->msg,
                                 &substr,
                                 n->summary,
-                                n->markup);
+                                MARKUP_NO);
                         break;
                 case 'b':
                         notification_replace_single_field(


### PR DESCRIPTION
According to the notification spec, only the body shall contain markup.
Therefore HTML symbols should get escaped in the summary, too.

Fixes #497 