### PR TITLE
Fix X11 memoryleak for round corners

### DIFF
--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -141,6 +141,7 @@ static void x_win_round_corners(window_x11 *win, const int rad)
 
         XShapeCombineMask(xctx.dpy, win->xwin, ShapeBounding, 0, 0, mask, ShapeSet);
 
+        XFreeGC(xctx.dpy, shape_gc);
         XFreePixmap(xctx.dpy, mask);
 
         XShapeSelectInput(xctx.dpy,


### PR DESCRIPTION
From https://github.com/dunst-project/dunst/pull/420#issuecomment-343612682 in the review:

> With this PR, dunst is damn slow [...]

At this point, I couldn't pin down the problem to my hardware/setup or to the dunst PR. But now, as `xrestop` showed, we didn't free the `GC`s, which made the X process sluggish.

---

Relevant discussion: https://github.com/dunst-project/dunst/commit/a0f21f5c266b76b46f3b994b4ef6a0ca2909c475#commitcomment-29257834