### PR TITLE
Add a toggle command

### DIFF
--- a/docs/dunst.pod
+++ b/docs/dunst.pod
@@ -719,7 +719,8 @@ Example time: "1000ms" "10m"
 =head1 MISCELLANEOUS
 
 Dunst can be paused by sending a notification with a summary of
-"DUNST_COMMAND_PAUSE" and resumed with a summary of "DUNST_COMMAND_RESUME".
+"DUNST_COMMAND_PAUSE", resumed with a summary of "DUNST_COMMAND_RESUME" and
+toggled with a summary of "DUNST_COMMAND_TOGGLE".
 Alternatively you can send SIGUSR1 and SIGUSR2 to pause and unpause
 respectively. For Example:
 

--- a/src/queues.c
+++ b/src/queues.c
@@ -95,6 +95,10 @@ int queues_notification_insert(notification *n)
                 pause_displayed = false;
                 return 0;
         }
+        if (strcmp("DUNST_COMMAND_TOGGLE", n->summary) == 0) {
+                pause_displayed = !pause_displayed;
+                return 0;
+        }
 
         if (n->id == 0) {
                 n->id = ++next_notification_id;


### PR DESCRIPTION
This pull request adds a toggle command to the existing pause and resume commands. Dunst can now be toggled by sending a notification with a summary of "DUNST_COMMAND_TOGGLE".