### PR TITLE
Concatenated queues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 - `fullscreen` rule to hide notifications when a fullscreen window is active
+- When new notifications arrive, but display is full, important notifications don't
+  have to wait for a timeout in a displayed notification (#541)
 
 ## 1.3.2 - 2018-05-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - `fullscreen` rule to hide notifications when a fullscreen window is active
 - When new notifications arrive, but display is full, important notifications don't
   have to wait for a timeout in a displayed notification (#541)
+- `<I> more` notifications don't occupy space anymore, if there is only a single
+  notification waiting to get displayed. The notification gets displayed directly (#467)
 
 ## 1.3.2 - 2018-05-06
 

--- a/src/draw.c
+++ b/src/draw.c
@@ -26,7 +26,7 @@ typedef struct {
         char *text;
         PangoAttrList *attr;
         cairo_surface_t *icon;
-        notification *n;
+        const notification *n;
 } colored_layout;
 
 window_x11 *win;
@@ -245,7 +245,7 @@ static PangoLayout *layout_create(cairo_t *c)
         return layout;
 }
 
-static colored_layout *layout_init_shared(cairo_t *c, notification *n)
+static colored_layout *layout_init_shared(cairo_t *c, const notification *n)
 {
         colored_layout *cl = g_malloc(sizeof(colored_layout));
         cl->l = layout_create(c);
@@ -301,7 +301,7 @@ static colored_layout *layout_init_shared(cairo_t *c, notification *n)
         return cl;
 }
 
-static colored_layout *layout_derive_xmore(cairo_t *c, notification *n, int qlen)
+static colored_layout *layout_derive_xmore(cairo_t *c, const notification *n, int qlen)
 {
         colored_layout *cl = layout_init_shared(c, n);
         cl->text = g_strdup_printf("(%d more)", qlen);
@@ -350,12 +350,10 @@ static GSList *create_layouts(cairo_t *c)
         int qlen = queues_length_waiting();
         bool xmore_is_needed = qlen > 0 && settings.indicate_hidden;
 
-        notification *last = NULL;
         for (const GList *iter = queues_get_displayed();
                         iter; iter = iter->next)
         {
                 notification *n = iter->data;
-                last = n;
 
                 notification_update_text_to_render(n);
 
@@ -371,7 +369,7 @@ static GSList *create_layouts(cairo_t *c)
         if (xmore_is_needed && settings.geometry.h != 1) {
                 /* append xmore message as new message */
                 layouts = g_slist_append(layouts,
-                        layout_derive_xmore(c, last, qlen));
+                        layout_derive_xmore(c, queues_get_head_waiting(), qlen));
         }
 
         return layouts;

--- a/src/notification.c
+++ b/src/notification.c
@@ -92,6 +92,11 @@ void notification_run_script(notification *n)
         if (!n->script || strlen(n->script) < 1)
                 return;
 
+        if (n->script_run && !settings.always_run_script)
+                return;
+
+        n->script_run = true;
+
         const char *appname = n->appname ? n->appname : "";
         const char *summary = n->summary ? n->summary : "";
         const char *body = n->body ? n->body : "";
@@ -267,6 +272,8 @@ notification *notification_create(void)
 
         n->transient = false;
         n->progress = -1;
+
+        n->script_run = false;
 
         n->fullscreen = FS_SHOW;
 

--- a/src/notification.h
+++ b/src/notification.h
@@ -77,6 +77,7 @@ typedef struct _notification {
         int dup_count;          /**< amount of duplicate notifications stacked onto this */
         int displayed_height;
         enum behavior_fullscreen fullscreen; //!< The instruction what to do with it, when desktop enters fullscreen
+        bool script_run;        /**< Has the script been executed already? */
 
         /* derived fields */
         char *msg;            /**< formatted message */
@@ -139,6 +140,9 @@ int notification_is_duplicate(const notification *a, const notification *b);
 /**
  * Run the script associated with the
  * given notification.
+ *
+ * If the script of the notification has been executed already and
+ * settings.always_run_script is not set, do nothing.
  */
 void notification_run_script(notification *n);
 /**

--- a/src/queues.c
+++ b/src/queues.c
@@ -374,10 +374,7 @@ void queues_update(bool fullscreen)
                 }
 
                 n->start = time_monotonic_now();
-
-                if (!n->redisplayed && n->script) {
-                        notification_run_script(n);
-                }
+                notification_run_script(n);
 
                 g_queue_delete_link(waiting, iter);
                 g_queue_insert_sorted(displayed, n, notification_cmp_data, NULL);

--- a/src/queues.c
+++ b/src/queues.c
@@ -50,6 +50,14 @@ const GList *queues_get_displayed(void)
 }
 
 /* see queues.h */
+const notification *queues_get_head_waiting(void)
+{
+        if (waiting->length == 0)
+                return NULL;
+        return g_queue_peek_head(waiting);
+}
+
+/* see queues.h */
 unsigned int queues_length_waiting(void)
 {
         return waiting->length;

--- a/src/queues.h
+++ b/src/queues.h
@@ -26,6 +26,13 @@ void queues_init(void);
 const GList *queues_get_displayed(void);
 
 /**
+ * Get the highest notification in line
+ *
+ * @return a notification or NULL, if waiting is empty
+ */
+const notification *queues_get_head_waiting(void);
+
+/**
  * Returns the current amount of notifications,
  * which are waiting to get displayed
  */

--- a/src/queues.h
+++ b/src/queues.h
@@ -19,14 +19,6 @@
 void queues_init(void);
 
 /**
- * Set maximum notification count to display
- * and store in displayed queue
- *
- * @param limit The maximum amount
- */
-void queues_displayed_limit(unsigned int limit);
-
-/**
  * Receive the current list of displayed notifications
  *
  * @return read only list of notifications

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -516,17 +516,6 @@ struct geometry x_parse_geometry(const char *geom_str)
         geometry.negative_x = mask & XNegative;
         geometry.negative_y = mask & YNegative;
 
-        /* calculate maximum notification count and push information to queue */
-        if (geometry.h == 0) {
-                queues_displayed_limit(0);
-        } else if (geometry.h == 1) {
-                queues_displayed_limit(1);
-        } else if (settings.indicate_hidden) {
-                queues_displayed_limit(geometry.h - 1);
-        } else {
-                queues_displayed_limit(geometry.h);
-        }
-
         return geometry;
 }
 


### PR DESCRIPTION
Let important notifications seep into displayed even if the `display` queue is full.

By checking the joint of both queues, if you concatenate now the `waiting` and `display` queues, the concatenated queue is still sorted. A push to waiting and `queues_update()` should show the important notifications even if there if display is full.

Previously, this would have required a timeout of a notification in the displayed queue. Now it works immediately.

Fixes #431 
Fixes #467 