### PR TITLE
draw the window before showing it

### DIFF
--- a/src/dunst.c
+++ b/src/dunst.c
@@ -52,6 +52,7 @@ static gboolean run(void *data)
         static gint64 next_timeout = 0;
 
         if (!x_win_visible(win) && queues_length_displayed() > 0) {
+                draw();
                 x_win_show(win);
         }
 


### PR DESCRIPTION
Before this commit when using Dunst with multiple displays and
follow mode mouse/keyboard on a new notification (when no other
notifications are shown) a black window flickers up at the screen where
the last notification was shown.

By calling draw() before x_window_show the new window position will be
calculated and the window will be moved there before the window is shown
and thus remove the flickering.