### PR TITLE
Implement x-canonical-private-synchronous hint

### DIFF
--- a/docs/dunst.pod
+++ b/docs/dunst.pod
@@ -611,9 +611,9 @@ matched.
 =item B<filtering>
 
 Notifications can be matched for any of the following attributes: appname,
-summary, body, icon, category, match_transient and msg_urgency where each is
-the respective notification attribute to be matched and 'msg_urgency' is the
-urgency of the notification, it is named so to not conflict with trying to
+summary, body, icon, category, match_transient, msg_urgency, and stack_tag where
+each is the respective notification attribute to be matched and 'msg_urgency' is
+the urgency of the notification, it is named so to not conflict with trying to
 modify the urgency.
 
 To define a matching rule simply assign the specified value to the value that
@@ -630,15 +630,20 @@ Shell-like globing is supported.
 =item B<modifying>
 
 The following attributes can be overridden: timeout, urgency, foreground,
-background, frame_color, new_icon, set_transient, format, fullscreen where,
-as with the filtering attributes, each one corresponds to the respective
-notification attribute to be modified.
+background, frame_color, new_icon, set_transient, format, fullscreen,
+set_stack_tag where, as with the filtering attributes, each one corresponds to
+the respective notification attribute to be modified.
 
 As with filtering, to make a rule modify an attribute simply assign it in the
 rule definition.
 
 If the format is set to an empty string, the notification will not be
 suppressed.
+
+Notifications with the same non-empty stack_tag value will be stacked
+together. The default stack_stag value is set from the string hints
+"synchronous", "private-synchronous", "x-canonical-private-synchronous", and
+"x-dunst-stack-tag".
 
 =back
 

--- a/dunstrc
+++ b/dunstrc
@@ -147,10 +147,10 @@
     # Ignore newlines '\n' in notifications.
     ignore_newline = no
 
-    # Merge multiple notifications with the same content
+    # Stack together notifications with the same content
     stack_duplicates = true
 
-    # Hide the count of merged notifications with the same content
+    # Hide the count of stacked notifications with the same content
     hide_duplicate_count = false
 
     # Display indicators for URLs (U) and actions (A).
@@ -299,7 +299,8 @@
 # override settings for certain messages.
 # Messages can be matched by "appname", "summary", "body", "icon", "category",
 # "msg_urgency" and you can override the "timeout", "urgency", "foreground",
-# "background", "frame_color", "new_icon" and "format", "fullscreen".
+# "background", "frame_color", "new_icon" and "format", "fullscreen",
+# "stack_tag".
 # Shell-like globbing will get expanded.
 #
 # SCRIPTING
@@ -364,5 +365,9 @@
 #    appname = Pidgin
 #    summary = *twitter.com*
 #    urgency = normal
+#
+#[stack-volumes]
+#    appname = "some_volume_notifiers"
+#    set_stack_tag = "volume"
 #
 # vim: ft=cfg

--- a/src/notification.c
+++ b/src/notification.c
@@ -66,6 +66,7 @@ void notification_print(const struct notification *n)
         printf("\tframe: %s\n", n->colors[ColFrame]);
         printf("\tfullscreen: %s\n", enum_to_string_fullscreen(n->fullscreen));
         printf("\tprogress: %d\n", n->progress);
+        printf("\tstack_tag: %s\n", (n->stack_tag ? n->stack_tag : ""));
         printf("\tid: %d\n", n->id);
         if (n->urls) {
                 char *urls = string_replace_all("\n", "\t\t\n", g_strdup(n->urls));
@@ -251,6 +252,7 @@ void notification_unref(struct notification *n)
         g_free(n->colors[ColFG]);
         g_free(n->colors[ColBG]);
         g_free(n->colors[ColFrame]);
+        g_free(n->stack_tag);
 
         actions_free(n->actions);
         rawimage_free(n->raw_icon);

--- a/src/notification.h
+++ b/src/notification.h
@@ -70,6 +70,8 @@ struct notification {
         const char *script;
         char *colors[3];
 
+        char *stack_tag;    /**< stack notifications by tag */
+
         /* Hints */
         bool transient;     /**< timeout albeit user is idle */
         int progress;       /**< percentage (-1: undefined) */

--- a/src/rules.c
+++ b/src/rules.c
@@ -47,6 +47,10 @@ void rule_apply(struct rule *r, struct notification *n)
                 n->format = r->format;
         if (r->script)
                 n->script = r->script;
+        if (r->set_stack_tag) {
+                g_free(n->stack_tag);
+                n->stack_tag = g_strdup(r->set_stack_tag);
+        }
 }
 
 /*
@@ -73,6 +77,7 @@ void rule_init(struct rule *r)
         r->body = NULL;
         r->icon = NULL;
         r->category = NULL;
+        r->stack_tag = NULL;
         r->msg_urgency = URG_NONE;
         r->timeout = -1;
         r->urgency = URG_NONE;
@@ -86,6 +91,7 @@ void rule_init(struct rule *r)
         r->bg = NULL;
         r->fc = NULL;
         r->format = NULL;
+        r->set_stack_tag = NULL;
 }
 
 /*
@@ -93,11 +99,12 @@ void rule_init(struct rule *r)
  */
 bool rule_matches_notification(struct rule *r, struct notification *n)
 {
-        return   ( (!r->appname  || (n->appname  && !fnmatch(r->appname,  n->appname, 0)))
-                && (!r->summary  || (n->summary  && !fnmatch(r->summary,  n->summary, 0)))
-                && (!r->body     || (n->body     && !fnmatch(r->body,     n->body, 0)))
-                && (!r->icon     || (n->icon     && !fnmatch(r->icon,     n->icon, 0)))
-                && (!r->category || (n->category && !fnmatch(r->category, n->category, 0)))
+        return   ( (!r->appname   || (n->appname   && !fnmatch(r->appname,   n->appname, 0)))
+                && (!r->summary   || (n->summary   && !fnmatch(r->summary,   n->summary, 0)))
+                && (!r->body      || (n->body      && !fnmatch(r->body,      n->body, 0)))
+                && (!r->icon      || (n->icon      && !fnmatch(r->icon,      n->icon, 0)))
+                && (!r->category  || (n->category  && !fnmatch(r->category,  n->category, 0)))
+                && (!r->stack_tag || (n->stack_tag && !fnmatch(r->stack_tag, n->stack_tag, 0)))
                 && (r->match_transient == -1 || (r->match_transient == n->transient))
                 && (r->msg_urgency == URG_NONE || r->msg_urgency == n->urgency));
 }

--- a/src/rules.h
+++ b/src/rules.h
@@ -16,6 +16,7 @@ struct rule {
         char *body;
         char *icon;
         char *category;
+        char *stack_tag;
         int msg_urgency;
 
         /* actions */
@@ -32,6 +33,7 @@ struct rule {
         const char *format;
         const char *script;
         enum behavior_fullscreen fullscreen;
+        char *set_stack_tag;
 };
 
 extern GSList *rules;

--- a/src/settings.c
+++ b/src/settings.c
@@ -368,7 +368,7 @@ void load_settings(char *cmdline_config_path)
         settings.hide_duplicate_count = option_get_bool(
                 "global",
                 "hide_duplicate_count", "-hide_duplicate_count", false,
-                "Hide the count of merged notifications with the same content"
+                "Hide the count of stacked notifications with the same content"
         );
 
         settings.sticky_history = option_get_bool(
@@ -444,7 +444,7 @@ void load_settings(char *cmdline_config_path)
         settings.stack_duplicates = option_get_bool(
                 "global",
                 "stack_duplicates", "-stack_duplicates", true,
-                "Merge multiple notifications with the same content"
+                "Stack together notifications with the same content"
         );
 
         settings.startup_notification = option_get_bool(
@@ -785,6 +785,7 @@ void load_settings(char *cmdline_config_path)
                 r->body = ini_get_string(cur_section, "body", r->body);
                 r->icon = ini_get_string(cur_section, "icon", r->icon);
                 r->category = ini_get_string(cur_section, "category", r->category);
+                r->stack_tag = ini_get_string(cur_section, "stack_tag", r->stack_tag);
                 r->timeout = ini_get_time(cur_section, "timeout", r->timeout);
 
                 {
@@ -819,6 +820,7 @@ void load_settings(char *cmdline_config_path)
                         g_free(c);
                 }
                 r->script = ini_get_path(cur_section, "script", NULL);
+                r->set_stack_tag = ini_get_string(cur_section, "set_stack_tag", r->set_stack_tag);
         }
 
 #ifndef STATIC_CONFIG


### PR DESCRIPTION
I took a shot at implementing a trivial "x-canonical-private-synchronous" ( #159 ).

I implemented it as simple string equivalent to a "--replace-id". I'm not
sure if there should be more to it (according to the [canonical spec](https://wiki.ubuntu.com/NotifyOSD) ?).

I did not handle ~~`x-canonical-`~~ [`private-synchronous`](https://github.com/dunst-project/dunst/issues/159#issuecomment-327675997) because I didn't want to add more non-standardized hints than necessary.

I couldn't wait for an official implem, just happy to share my take on it.
