### PR TITLE
Drop libdbus dependency

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -21,8 +21,7 @@ CPPFLAGS_DEBUG := -DDEBUG_BUILD
 CFLAGS_DEBUG   := -O0
 LDFLAGS_DEBUG  :=
 
-pkg_config_packs := dbus-1 \
-                    gio-2.0 \
+pkg_config_packs := gio-2.0 \
                     gdk-pixbuf-2.0 \
                     "glib-2.0 >= 2.36" \
                     pangocairo \


### PR DESCRIPTION
libdbus was originally dropped with
820cfe73158b875ff6c0a00d646c7952c4cdb623 but it was never removed from
the dependency list.