### PR TITLE
Dbus test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,12 +57,6 @@ workflows:
             - misc-doxygen
             - Alpine
       - compileandtest:
-          name: Ubuntu 14.04
-          distro: ubuntu-trusty
-          requires:
-            - misc-doxygen
-            - Alpine
-      - compileandtest:
           name: Ubuntu 16.04
           distro: ubuntu-xenial
           requires:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
       - libnotify-dev
       - libgtk-3-dev
       - valgrind
-dist: trusty
+dist: xenial
 sudo: false
 language: c
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,5 +35,3 @@ matrix:
       after_success:
         - coveralls
     - compiler: clang
-      after_success:
-        - coveralls --gcov llvm-cov --gcov-options gcov

--- a/config.mk
+++ b/config.mk
@@ -23,7 +23,7 @@ LDFLAGS_DEBUG  :=
 
 pkg_config_packs := gio-2.0 \
                     gdk-pixbuf-2.0 \
-                    "glib-2.0 >= 2.36" \
+                    "glib-2.0 >= 2.44" \
                     pangocairo \
                     x11 \
                     xinerama \

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -451,7 +451,7 @@ static void dbus_cb_name_acquired(GDBusConnection *connection,
  * If name or vendor specified, the name and vendor
  * will get additionally get via the FDN GetServerInformation method
  *
- * @param connection The dbus connection
+ * @param connection The DBus connection
  * @param pid The place to report the PID to
  * @param name The place to report the name to, if not required set to NULL
  * @param vendor The place to report the vendor to, if not required set to NULL
@@ -459,9 +459,9 @@ static void dbus_cb_name_acquired(GDBusConnection *connection,
  * @returns `true` on success, otherwise `false`
  */
 static bool dbus_get_fdn_daemon_info(GDBusConnection  *connection,
-                                    int   *pid,
-                                    char **name,
-                                    char **vendor)
+                                     guint   *pid,
+                                     char   **name,
+                                     char   **vendor)
 {
         g_return_val_if_fail(pid, false);
         g_return_val_if_fail(connection, false);
@@ -542,17 +542,19 @@ static bool dbus_get_fdn_daemon_info(GDBusConnection  *connection,
                 return false;
         }
 
-        g_variant_get(pidinfo, "(u)", &pid);
-
         g_object_unref(proxy_fdn);
         g_object_unref(proxy_dbus);
         g_free(owner);
         if (daemoninfo)
                 g_variant_unref(daemoninfo);
-        if (pidinfo)
-                g_variant_unref(pidinfo);
 
-        return true;
+        if (pidinfo) {
+                g_variant_get(pidinfo, "(u)", &pid);
+                g_variant_unref(pidinfo);
+                return true;
+        } else {
+                return false;
+        }
 }
 
 
@@ -562,7 +564,7 @@ static void dbus_cb_name_lost(GDBusConnection *connection,
 {
         if (connection) {
                 char *name;
-                int pid;
+                unsigned int pid;
                 if (dbus_get_fdn_daemon_info(connection, &pid, &name, NULL)) {
                         DIE("Cannot acquire '"FDN_NAME"': "
                             "Name is acquired by '%s' with PID '%d'.", name, pid);

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -488,7 +488,7 @@ static bool dbus_get_fdn_daemon_info(GDBusConnection  *connection,
                 return false;
         }
 
-        GVariant *daemoninfo;
+        GVariant *daemoninfo = NULL;
         if (name || vendor) {
                 daemoninfo = g_dbus_proxy_call_sync(
                                      proxy_fdn,

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -394,9 +394,9 @@ static const GDBusInterfaceVTable interface_vtable = {
         handle_method_call
 };
 
-static void on_bus_acquired(GDBusConnection *connection,
-                            const gchar *name,
-                            gpointer user_data)
+static void dbus_cb_bus_acquired(GDBusConnection *connection,
+                                 const gchar *name,
+                                 gpointer user_data)
 {
         guint registration_id;
 
@@ -415,9 +415,9 @@ static void on_bus_acquired(GDBusConnection *connection,
         }
 }
 
-static void on_name_acquired(GDBusConnection *connection,
-                             const gchar *name,
-                             gpointer user_data)
+static void dbus_cb_name_acquired(GDBusConnection *connection,
+                                  const gchar *name,
+                                  gpointer user_data)
 {
         dbus_conn = connection;
 }
@@ -533,9 +533,9 @@ static bool dbus_get_fdn_daemon_info(GDBusConnection  *connection,
 }
 
 
-static void on_name_lost(GDBusConnection *connection,
-                         const gchar *name,
-                         gpointer user_data)
+static void dbus_cb_name_lost(GDBusConnection *connection,
+                              const gchar *name,
+                              gpointer user_data)
 {
         if (connection) {
                 char *name;
@@ -598,9 +598,9 @@ int dbus_init(void)
         owner_id = g_bus_own_name(G_BUS_TYPE_SESSION,
                                   FDN_NAME,
                                   G_BUS_NAME_OWNER_FLAGS_NONE,
-                                  on_bus_acquired,
-                                  on_name_acquired,
-                                  on_name_lost,
+                                  dbus_cb_bus_acquired,
+                                  dbus_cb_name_acquired,
+                                  dbus_cb_name_lost,
                                   NULL,
                                   NULL);
 

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -71,23 +71,19 @@ static const char *stack_tag_hints[] = {
         "x-canonical-private-synchronous",
         "x-dunst-stack-tag"
 };
+#define DBUS_METHOD(name) static void dbus_cb_##name( \
+                        GDBusConnection *connection, \
+                        const gchar *sender, \
+                        GVariant *parameters, \
+                        GDBusMethodInvocation *invocation)
 
-static void on_get_capabilities(GDBusConnection *connection,
-                                const gchar *sender,
-                                const GVariant *parameters,
-                                GDBusMethodInvocation *invocation);
-static void on_notify(GDBusConnection *connection,
-                      const gchar *sender,
-                      GVariant *parameters,
-                      GDBusMethodInvocation *invocation);
-static void on_close_notification(GDBusConnection *connection,
-                                  const gchar *sender,
-                                  GVariant *parameters,
-                                  GDBusMethodInvocation *invocation);
-static void on_get_server_information(GDBusConnection *connection,
-                                      const gchar *sender,
-                                      const GVariant *parameters,
-                                      GDBusMethodInvocation *invocation);
+#define CALL_METHOD(name) dbus_cb_##name(connection, sender, parameters, invocation)
+
+DBUS_METHOD(Notify);
+DBUS_METHOD(CloseNotification);
+DBUS_METHOD(GetCapabilities);
+DBUS_METHOD(GetServerInformation);
+
 static struct raw_image *get_raw_image_from_data_hint(GVariant *icon_data);
 
 void handle_method_call(GDBusConnection *connection,
@@ -100,13 +96,13 @@ void handle_method_call(GDBusConnection *connection,
                         gpointer user_data)
 {
         if (STR_EQ(method_name, "GetCapabilities")) {
-                on_get_capabilities(connection, sender, parameters, invocation);
+                CALL_METHOD(GetCapabilities);
         } else if (STR_EQ(method_name, "Notify")) {
-                on_notify(connection, sender, parameters, invocation);
+                CALL_METHOD(Notify);
         } else if (STR_EQ(method_name, "CloseNotification")) {
-                on_close_notification(connection, sender, parameters, invocation);
+                CALL_METHOD(CloseNotification);
         } else if (STR_EQ(method_name, "GetServerInformation")) {
-                on_get_server_information(connection, sender, parameters, invocation);
+                CALL_METHOD(GetServerInformation);
         } else {
                 LOG_M("Unknown method name: '%s' (sender: '%s').",
                       method_name,
@@ -114,10 +110,11 @@ void handle_method_call(GDBusConnection *connection,
         }
 }
 
-static void on_get_capabilities(GDBusConnection *connection,
-                                const gchar *sender,
-                                const GVariant *parameters,
-                                GDBusMethodInvocation *invocation)
+static void dbus_cb_GetCapabilities(
+                GDBusConnection *connection,
+                const gchar *sender,
+                GVariant *parameters,
+                GDBusMethodInvocation *invocation)
 {
         GVariantBuilder *builder;
         GVariant *value;
@@ -273,10 +270,11 @@ static struct notification *dbus_message_to_notification(const gchar *sender, GV
         return n;
 }
 
-static void on_notify(GDBusConnection *connection,
-                      const gchar *sender,
-                      GVariant *parameters,
-                      GDBusMethodInvocation *invocation)
+static void dbus_cb_Notify(
+                GDBusConnection *connection,
+                const gchar *sender,
+                GVariant *parameters,
+                GDBusMethodInvocation *invocation)
 {
         struct notification *n = dbus_message_to_notification(sender, parameters);
         if (!n) {
@@ -301,10 +299,11 @@ static void on_notify(GDBusConnection *connection,
         wake_up();
 }
 
-static void on_close_notification(GDBusConnection *connection,
-                                  const gchar *sender,
-                                  GVariant *parameters,
-                                  GDBusMethodInvocation *invocation)
+static void dbus_cb_CloseNotification(
+                GDBusConnection *connection,
+                const gchar *sender,
+                GVariant *parameters,
+                GDBusMethodInvocation *invocation)
 {
         guint32 id;
         g_variant_get(parameters, "(u)", &id);
@@ -314,10 +313,11 @@ static void on_close_notification(GDBusConnection *connection,
         g_dbus_connection_flush(connection, NULL, NULL, NULL);
 }
 
-static void on_get_server_information(GDBusConnection *connection,
-                                      const gchar *sender,
-                                      const GVariant *parameters,
-                                      GDBusMethodInvocation *invocation)
+static void dbus_cb_GetServerInformation(
+                GDBusConnection *connection,
+                const gchar *sender,
+                GVariant *parameters,
+                GDBusMethodInvocation *invocation)
 {
         GVariant *value;
 

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -549,7 +549,7 @@ static bool dbus_get_fdn_daemon_info(GDBusConnection  *connection,
                 g_variant_unref(daemoninfo);
 
         if (pidinfo) {
-                g_variant_get(pidinfo, "(u)", &pid);
+                g_variant_get(pidinfo, "(u)", pid);
                 g_variant_unref(pidinfo);
                 return true;
         } else {

--- a/src/notification.h
+++ b/src/notification.h
@@ -36,12 +36,6 @@ struct raw_image {
         unsigned char *data;
 };
 
-struct actions {
-        char **actions;
-        char *dmenu_str;
-        gsize count;
-};
-
 typedef struct _notification_private NotificationPrivate;
 
 struct notification_colors {
@@ -69,7 +63,7 @@ struct notification {
         gint64 timestamp;  /**< arrival time */
         gint64 timeout;    /**< time to display */
 
-        struct actions *actions;
+        GHashTable *actions;
 
         enum markup_mode markup;
         const char *format;
@@ -126,13 +120,6 @@ void notification_ref(struct notification *n);
  * @param n: the notification to sanitize
  */
 void notification_init(struct notification *n);
-
-/**
- * Free the actions structure
- *
- * @param a (nullable): Pointer to #actions
- */
-void actions_free(struct actions *a);
 
 /**
  * Free a #raw_image

--- a/test/dbus.c
+++ b/test/dbus.c
@@ -145,6 +145,18 @@ TEST test_dbus_teardown(void)
         PASS();
 }
 
+TEST test_invalid_notification(void)
+{
+        GVariant *faulty = g_variant_new_boolean(true);
+
+        ASSERT(NULL == dbus_message_to_notification(":123", faulty));
+        ASSERT(NULL == dbus_invoke("Notify", faulty));
+
+        g_variant_unref(faulty);
+        PASS();
+}
+
+
 TEST test_basic_notification(void)
 {
         struct dbus_notification *n = dbus_notification_new();
@@ -210,6 +222,7 @@ gpointer run_threaded_tests(gpointer data)
         RUN_TEST(test_dbus_init);
 
         RUN_TEST(test_basic_notification);
+        RUN_TEST(test_invalid_notification);
         RUN_TESTp(test_server_caps, MARKUP_FULL);
         RUN_TESTp(test_server_caps, MARKUP_STRIP);
         RUN_TESTp(test_server_caps, MARKUP_NO);

--- a/test/dbus.c
+++ b/test/dbus.c
@@ -130,11 +130,11 @@ TEST test_dbus_init(void)
 {
         owner_id = dbus_init();
         uint waiting = 0;
-        while (!dbus_conn && waiting < 20) {
+        while (!dbus_conn && waiting < 2000) {
                 usleep(500);
                 waiting++;
         }
-        ASSERTm("After 10ms, there is still no dbus connection available.",
+        ASSERTm("After 1s, there is still no dbus connection available.",
                 dbus_conn);
         PASS();
 }

--- a/test/dbus.c
+++ b/test/dbus.c
@@ -388,6 +388,39 @@ TEST test_hint_progress(void)
         PASS();
 }
 
+TEST test_hint_icons(void)
+{
+        struct notification *n;
+        struct dbus_notification *n_dbus;
+        const char *iconname = "NEWICON";
+
+        gsize len = queues_length_waiting();
+
+        n_dbus = dbus_notification_new();
+        n_dbus->app_name = "dunstteststack";
+        n_dbus->app_icon = "NONE";
+        n_dbus->summary = "test_hint_icons";
+        n_dbus->body = "Summary of it";
+
+        g_hash_table_insert(n_dbus->hints,
+                            g_strdup("image-path"),
+                            g_variant_ref_sink(g_variant_new_string(iconname)));
+
+        guint id;
+        ASSERT(dbus_notification_fire(n_dbus, &id));
+        ASSERT(id != 0);
+
+        ASSERT_EQ(queues_length_waiting(), len+1);
+
+        n = queues_debug_find_notification_by_id(id);
+
+        ASSERT_STR_EQ(iconname, n->icon);
+
+        dbus_notification_free(n_dbus);
+
+        PASS();
+}
+
 TEST test_server_caps(enum markup_mode markup)
 {
         GVariant *reply;
@@ -504,6 +537,7 @@ gpointer run_threaded_tests(gpointer data)
         RUN_TEST(test_invalid_notification);
         RUN_TEST(test_hint_transient);
         RUN_TEST(test_hint_progress);
+        RUN_TEST(test_hint_icons);
         RUN_TEST(test_dbus_notify_colors);
         RUN_TESTp(test_server_caps, MARKUP_FULL);
         RUN_TESTp(test_server_caps, MARKUP_STRIP);

--- a/test/dbus.c
+++ b/test/dbus.c
@@ -1,0 +1,208 @@
+#define wake_up wake_up_void
+#include "../src/dbus.c"
+#include "greatest.h"
+
+#include <assert.h>
+#include <gio/gio.h>
+
+void wake_up_void(void) {  }
+
+GVariant *dbus_invoke(const char *method, GVariant *params)
+{
+        GDBusConnection *connection_client;
+        GVariant *retdata;
+        GError *error = NULL;
+
+        connection_client = g_bus_get_sync(G_BUS_TYPE_SESSION, NULL, NULL);
+        retdata = g_dbus_connection_call_sync(
+                                connection_client,
+                                FDN_NAME,
+                                FDN_PATH,
+                                FDN_IFAC,
+                                method,
+                                params,
+                                NULL,
+                                G_DBUS_CALL_FLAGS_NONE,
+                                -1,
+                                NULL,
+                                &error);
+        if (error) {
+                printf("Error while calling GTestDBus instance: %s\n", error->message);
+                g_error_free(error);
+        }
+
+        g_object_unref(connection_client);
+
+        return retdata;
+}
+
+struct dbus_notification {
+        const char* app_name;
+        guint replaces_id;
+        const char* app_icon;
+        const char* summary;
+        const char* body;
+        GHashTable *actions;
+        GHashTable *hints;
+        int expire_timeout;
+};
+
+void g_free_variant_value(gpointer tofree)
+{
+        g_variant_unref((GVariant*) tofree);
+}
+
+struct dbus_notification *dbus_notification_new(void)
+{
+        struct dbus_notification *n = g_malloc0(sizeof(struct dbus_notification));
+        n->expire_timeout = -1;
+        n->replaces_id = 0;
+        n->actions = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
+        n->hints = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free_variant_value);
+        return n;
+}
+
+void dbus_notification_free(struct dbus_notification *n)
+{
+        g_hash_table_unref(n->hints);
+        g_hash_table_unref(n->actions);
+        g_free(n);
+}
+
+bool dbus_notification_fire(struct dbus_notification *n, uint *id)
+{
+        assert(n);
+        assert(id);
+        GVariantBuilder b;
+        GVariantType *t;
+
+        gpointer p_key;
+        gpointer p_value;
+        GHashTableIter iter;
+
+        t = g_variant_type_new("(susssasa{sv}i)");
+        g_variant_builder_init(&b, t);
+        g_variant_type_free(t);
+
+        g_variant_builder_add(&b, "s", n->app_name);
+        g_variant_builder_add(&b, "u", n->replaces_id);
+        g_variant_builder_add(&b, "s", n->app_icon);
+        g_variant_builder_add(&b, "s", n->summary);
+        g_variant_builder_add(&b, "s", n->body);
+
+        // Add the actions
+        t = g_variant_type_new("as");
+        g_variant_builder_open(&b, t);
+        g_hash_table_iter_init(&iter, n->actions);
+        while (g_hash_table_iter_next(&iter, &p_key, &p_value)) {
+                g_variant_builder_add(&b, "s", (char*)p_key);
+                g_variant_builder_add(&b, "s", (char*)p_value);
+        }
+        g_variant_builder_close(&b);
+        g_variant_type_free(t);
+
+        // Add the hints
+        t = g_variant_type_new("a{sv}");
+        g_variant_builder_open(&b, t);
+        g_hash_table_iter_init(&iter, n->hints);
+        while (g_hash_table_iter_next(&iter, &p_key, &p_value)) {
+                g_variant_builder_add(&b, "{sv}", (char*)p_key, (GVariant*)p_value);
+        }
+        g_variant_builder_close(&b);
+        g_variant_type_free(t);
+
+        g_variant_builder_add(&b, "i", n->expire_timeout);
+
+        GVariant *reply = dbus_invoke("Notify", g_variant_builder_end(&b));
+        if (reply) {
+                g_variant_get(reply, "(u)", id);
+                g_variant_unref(reply);
+                return true;
+        } else {
+                return false;
+        }
+}
+
+/////// TESTS
+gint owner_id;
+
+TEST test_dbus_init(void)
+{
+        owner_id = dbus_init();
+        uint waiting = 0;
+        while (!dbus_conn && waiting < 20) {
+                usleep(500);
+                waiting++;
+        }
+        ASSERTm("After 10ms, there is still no dbus connection available.",
+                dbus_conn);
+        PASS();
+}
+
+TEST test_dbus_teardown(void)
+{
+        dbus_teardown(owner_id);
+        PASS();
+}
+
+TEST test_basic_notification(void)
+{
+        struct dbus_notification *n = dbus_notification_new();
+        gsize len = queues_length_waiting();
+        n->app_name = "dunstteststack";
+        n->app_icon = "NONE";
+        n->summary = "Headline";
+        n->body = "Text";
+        g_hash_table_insert(n->actions, g_strdup("actionid"), g_strdup("Print this text"));
+        g_hash_table_insert(n->hints,
+                            g_strdup("x-dunst-stack-tag"),
+                            g_variant_ref_sink(g_variant_new_string("volume")));
+
+        n->replaces_id = 10;
+
+        guint id;
+        ASSERT(dbus_notification_fire(n, &id));
+        ASSERT(id != 0);
+
+        ASSERT_EQ(queues_length_waiting(), len+1);
+        dbus_notification_free(n);
+        PASS();
+}
+// TESTS END
+
+GMainLoop *loop;
+GThread *thread_tests;
+
+gpointer run_threaded_tests(gpointer data)
+{
+        RUN_TEST(test_dbus_init);
+
+        RUN_TEST(test_basic_notification);
+
+        RUN_TEST(test_dbus_teardown);
+        g_main_loop_quit(loop);
+        return NULL;
+}
+
+SUITE(suite_dbus)
+{
+        GTestDBus *dbus_bus;
+        g_test_dbus_unset();
+        queues_init();
+
+        loop = g_main_loop_new(NULL, false);
+
+        dbus_bus = g_test_dbus_new(G_TEST_DBUS_NONE);
+        g_test_dbus_up(dbus_bus);
+
+        thread_tests = g_thread_new("testexecutor", run_threaded_tests, loop);
+        g_main_loop_run(loop);
+
+        queues_teardown();
+        g_test_dbus_down(dbus_bus);
+        g_object_unref(dbus_bus);
+        g_thread_unref(thread_tests);
+        g_main_loop_unref(loop);
+}
+
+/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/test/dbus.c
+++ b/test/dbus.c
@@ -159,6 +159,9 @@ bool dbus_notification_fire(struct dbus_notification *n, uint *id)
                 g_variant_builder_add(&b, "s", (char*)p_key);
                 g_variant_builder_add(&b, "s", (char*)p_value);
         }
+        // Add an invalid appendix to cover odd numbered action arrays
+        // Shouldn't interfere with normal testing
+        g_variant_builder_add(&b, "s", "invalid appendix");
         g_variant_builder_close(&b);
         g_variant_type_free(t);
 

--- a/test/dbus.c
+++ b/test/dbus.c
@@ -268,6 +268,17 @@ TEST test_server_caps(enum markup_mode markup)
         PASS();
 }
 
+TEST assert_methodlists_sorted(void)
+{
+        for (size_t i = 0; i+1 < G_N_ELEMENTS(methods_fdn); i++) {
+                ASSERT(0 > strcmp(
+                                methods_fdn[i].method_name,
+                                methods_fdn[i+1].method_name));
+        }
+
+        PASS();
+}
+
 
 // TESTS END
 
@@ -285,6 +296,8 @@ gpointer run_threaded_tests(gpointer data)
         RUN_TESTp(test_server_caps, MARKUP_FULL);
         RUN_TESTp(test_server_caps, MARKUP_STRIP);
         RUN_TESTp(test_server_caps, MARKUP_NO);
+
+        RUN_TEST(assert_methodlists_sorted);
 
         RUN_TEST(test_dbus_teardown);
         g_main_loop_quit(loop);

--- a/test/dbus.c
+++ b/test/dbus.c
@@ -421,6 +421,39 @@ TEST test_hint_icons(void)
         PASS();
 }
 
+TEST test_hint_category(void)
+{
+        struct notification *n;
+        struct dbus_notification *n_dbus;
+        const char *category = "VOLUME";
+
+        gsize len = queues_length_waiting();
+
+        n_dbus = dbus_notification_new();
+        n_dbus->app_name = "dunstteststack";
+        n_dbus->app_icon = "NONE";
+        n_dbus->summary = "test_hint_category";
+        n_dbus->body = "Summary of it";
+
+        g_hash_table_insert(n_dbus->hints,
+                            g_strdup("category"),
+                            g_variant_ref_sink(g_variant_new_string(category)));
+
+        guint id;
+        ASSERT(dbus_notification_fire(n_dbus, &id));
+        ASSERT(id != 0);
+
+        ASSERT_EQ(queues_length_waiting(), len+1);
+
+        n = queues_debug_find_notification_by_id(id);
+
+        ASSERT_STR_EQ(category, n->category);
+
+        dbus_notification_free(n_dbus);
+
+        PASS();
+}
+
 TEST test_server_caps(enum markup_mode markup)
 {
         GVariant *reply;
@@ -538,6 +571,7 @@ gpointer run_threaded_tests(gpointer data)
         RUN_TEST(test_hint_transient);
         RUN_TEST(test_hint_progress);
         RUN_TEST(test_hint_icons);
+        RUN_TEST(test_hint_category);
         RUN_TEST(test_dbus_notify_colors);
         RUN_TESTp(test_server_caps, MARKUP_FULL);
         RUN_TESTp(test_server_caps, MARKUP_STRIP);

--- a/test/dbus.c
+++ b/test/dbus.c
@@ -362,6 +362,29 @@ TEST test_close_and_signal(void)
         PASS();
 }
 
+TEST test_get_fdn_daemon_info(void)
+{
+        unsigned int pid_is;
+        pid_t pid_should;
+        char *name, *vendor;
+        GDBusConnection *conn;
+
+        pid_should = getpid();
+        conn = g_bus_get_sync(G_BUS_TYPE_SESSION, NULL, NULL);
+
+        ASSERT(dbus_get_fdn_daemon_info(conn, &pid_is, &name, &vendor));
+
+        ASSERT_EQ_FMT(pid_should, pid_is, "%d");
+        ASSERT_STR_EQ("dunst", name);
+        ASSERT_STR_EQ("knopwob", vendor);
+
+        g_free(name);
+        g_free(vendor);
+
+        g_object_unref(conn);
+        PASS();
+}
+
 TEST assert_methodlists_sorted(void)
 {
         for (size_t i = 0; i+1 < G_N_ELEMENTS(methods_fdn); i++) {
@@ -382,6 +405,8 @@ GThread *thread_tests;
 gpointer run_threaded_tests(gpointer data)
 {
         RUN_TEST(test_dbus_init);
+
+        RUN_TEST(test_get_fdn_daemon_info);
 
         RUN_TEST(test_empty_notification);
         RUN_TEST(test_basic_notification);

--- a/test/dbus.c
+++ b/test/dbus.c
@@ -158,6 +158,19 @@ TEST test_invalid_notification(void)
         PASS();
 }
 
+TEST test_empty_notification(void)
+{
+        struct dbus_notification *n = dbus_notification_new();
+        gsize len = queues_length_waiting();
+
+        guint id;
+        ASSERT(dbus_notification_fire(n, &id));
+        ASSERT(id != 0);
+
+        ASSERT_EQ(queues_length_waiting(), len+1);
+        dbus_notification_free(n);
+        PASS();
+}
 
 TEST test_basic_notification(void)
 {
@@ -265,6 +278,7 @@ gpointer run_threaded_tests(gpointer data)
 {
         RUN_TEST(test_dbus_init);
 
+        RUN_TEST(test_empty_notification);
         RUN_TEST(test_basic_notification);
         RUN_TEST(test_invalid_notification);
         RUN_TEST(test_dbus_notify_colors);

--- a/test/queues.c
+++ b/test/queues.c
@@ -6,6 +6,23 @@
 #include "greatest.h"
 #include "queues.h"
 
+struct notification *queues_debug_find_notification_by_id(int id)
+{
+        assert(id > 0);
+
+        GQueue *allqueues[] = { displayed, waiting, history };
+        for (int i = 0; i < sizeof(allqueues)/sizeof(GQueue*); i++) {
+                for (GList *iter = g_queue_peek_head_link(allqueues[i]); iter;
+                     iter = iter->next) {
+                        struct notification *cur = iter->data;
+                        if (cur->id == id)
+                                return cur;
+                }
+        }
+
+        return NULL;
+}
+
 TEST test_queue_length(void)
 {
         queues_init();

--- a/test/queues.h
+++ b/test/queues.h
@@ -50,5 +50,8 @@ static inline struct notification *test_notification(const char *name, gint64 ti
         return n;
 }
 
+/* Retrieve a notification by its id. Solely for debugging purposes */
+struct notification *queues_debug_find_notification_by_id(int id);
+
 #endif
 /* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/test/test.c
+++ b/test/test.c
@@ -19,6 +19,7 @@ SUITE_EXTERN(suite_queues);
 SUITE_EXTERN(suite_dunst);
 SUITE_EXTERN(suite_log);
 SUITE_EXTERN(suite_menu);
+SUITE_EXTERN(suite_dbus);
 
 GREATEST_MAIN_DEFS();
 
@@ -44,6 +45,7 @@ int main(int argc, char *argv[]) {
         RUN_SUITE(suite_dunst);
         RUN_SUITE(suite_log);
         RUN_SUITE(suite_menu);
+        RUN_SUITE(suite_dbus);
         GREATEST_MAIN_END();
 
         base = NULL;


### PR DESCRIPTION
By accident, I stumbled over [`GTestDBus`](https://developer.gnome.org/gio/stable/GTestDBus.html), which gives you the ability to spawn a complete new DBus bus, which doesn't interfere with the normal session bus.

So for testing the `dbus.c` flie, this is perfect.

Also, I've changed the super weird `actions` field into a normal hashmap (because that's it what the actions actually are!).