### PR TITLE
Control to print log messages during test

### DIFF
--- a/test/test.c
+++ b/test/test.c
@@ -31,8 +31,11 @@ int main(int argc, char *argv[]) {
         }
         base = dirname(prog);
 
-        // do not print out warning messages, when executing tests
-        dunst_log_init(true);
+        /* By default do not print out warning messages, when executing tests.
+         * But allow, if DUNST_TEST_LOG=1 is set in environment. */
+        const char *log = getenv("DUNST_TEST_LOG");
+        bool printlog = log && atoi(log) ? true : false;
+        dunst_log_init(!printlog);
 
         GREATEST_MAIN_BEGIN();
         RUN_SUITE(suite_utils);


### PR DESCRIPTION
The log messages are useless during general and automated testing. But while developing tests, the warning messages might be an easy debugging option to check why one's own test currently fails.