### PR TITLE
Fix handling of case where notification decode failure occurs

### DIFF
--- a/src/dbus.c
+++ b/src/dbus.c
@@ -301,10 +301,12 @@ static void dbus_cb_Notify(
 {
         struct notification *n = dbus_message_to_notification(sender, parameters);
         if (!n) {
+                LOG_W("A notification failed to decode.");
                 g_dbus_method_invocation_return_dbus_error(
                                 invocation,
-                                "Cannot decode notification!",
-                                "");
+                                FDN_IFAC".Error",
+                                "Cannot decode notification!");
+                return;
         }
 
         int id = queues_notification_insert(n);


### PR DESCRIPTION
I'm not sure whether this case can happen in the wild, but if
artifically exercising the condition, I noticed it behaves
poorly. Specifically:

* The error_name parameter must be a valid D-Bus error name. It seems
  conventional to set this to "org.freedesktop.Notifications.Error".
  Without this change, the following error is thrown:

  CRITICAL: g_dbus_method_invocation_return_dbus_error: assertion 'error_name != NULL && g_dbus_is_name (error_name)' failed

* Previously execution would continue even though the notification did
  not decode, causing essentially a null pointer exception later.
  Adds a return for this case.

* With those two things fixed, this case seems relatively silent -
  "notify-send" invocations succeed even if the condition for the if
  is "true". So, I added a warning log to indicate that this case is
  occurring