### PR TITLE
Add a tip to the docs about how to skip initial display

### DIFF
--- a/docs/dunst.pod
+++ b/docs/dunst.pod
@@ -645,6 +645,10 @@ together. The default stack_stag value is set from the string hints
 "synchronous", "private-synchronous", "x-canonical-private-synchronous", and
 "x-dunst-stack-tag".
 
+If you want to skip display of a notification, but still have it in
+history, setting 'timeout' to "1ms" will essentially skip initial
+display.
+
 =back
 
 =head2 SCRIPTING


### PR DESCRIPTION
My usecase is that I don't want to get notified for every new song
that plays (it's distracting), but I do want to bring them up via the
notification history.