### PR TITLE
Fix makefile not recompiling on header change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.o
+*.d
 *.gcda
 *.gcno
 *.gcov


### PR DESCRIPTION
We currently do not keep track of header files in our Makefile so if one
is changed it can lead to multiple incompatible binary files being
linked. Instead we now create dependency lists for each source file and
recompile them if the need arises.

Fixes #594