### PR TITLE
Allow rules to override icon size via set_max_icon_size

### DIFF
--- a/src/dbus.c
+++ b/src/dbus.c
@@ -238,15 +238,6 @@ static struct notification *dbus_message_to_notification(const gchar *sender, GV
                 g_variant_unref(dict_value);
         }
 
-        dict_value = g_variant_lookup_value(hints, "image-data", G_VARIANT_TYPE("(iiibiiay)"));
-        if (!dict_value)
-                dict_value = g_variant_lookup_value(hints, "image_data", G_VARIANT_TYPE("(iiibiiay)"));
-        if (!dict_value)
-                dict_value = g_variant_lookup_value(hints, "icon_data", G_VARIANT_TYPE("(iiibiiay)"));
-        if (dict_value) {
-                notification_icon_replace_data(n, dict_value);
-                g_variant_unref(dict_value);
-        }
 
         /* Check for transient hints
          *
@@ -293,6 +284,20 @@ static struct notification *dbus_message_to_notification(const gchar *sender, GV
         g_free(actions); // the strv is only a shallow copy
 
         notification_init(n);
+
+        // TODO: inefficient because notification_init above will
+        // probably set / rescale the default icon since icon /
+        // iconname aren't yet set.
+        dict_value = g_variant_lookup_value(hints, "image-data", G_VARIANT_TYPE("(iiibiiay)"));
+        if (!dict_value)
+                dict_value = g_variant_lookup_value(hints, "image_data", G_VARIANT_TYPE("(iiibiiay)"));
+        if (!dict_value)
+                dict_value = g_variant_lookup_value(hints, "icon_data", G_VARIANT_TYPE("(iiibiiay)"));
+        if (dict_value) {
+                notification_icon_replace_data(n, dict_value);
+                g_variant_unref(dict_value);
+        }
+
         return n;
 }
 

--- a/src/icon.c
+++ b/src/icon.c
@@ -110,20 +110,20 @@ cairo_surface_t *gdk_pixbuf_to_cairo_surface(GdkPixbuf *pixbuf)
         return icon_surface;
 }
 
-GdkPixbuf *icon_pixbuf_scale(GdkPixbuf *pixbuf)
+GdkPixbuf *icon_pixbuf_scale(GdkPixbuf *pixbuf, int max_size)
 {
         ASSERT_OR_RET(pixbuf, NULL);
 
         int w = gdk_pixbuf_get_width(pixbuf);
         int h = gdk_pixbuf_get_height(pixbuf);
         int larger = w > h ? w : h;
-        if (settings.max_icon_size && larger > settings.max_icon_size) {
-                int scaled_w = settings.max_icon_size;
-                int scaled_h = settings.max_icon_size;
+        if (max_size && larger > max_size) {
+                int scaled_w = max_size;
+                int scaled_h = max_size;
                 if (w >= h)
-                        scaled_h = (settings.max_icon_size * h) / w;
+                        scaled_h = (max_size * h) / w;
                 else
-                        scaled_w = (settings.max_icon_size * w) / h;
+                        scaled_w = (max_size * w) / h;
 
                 GdkPixbuf *scaled = gdk_pixbuf_scale_simple(
                                 pixbuf,

--- a/src/icon.h
+++ b/src/icon.h
@@ -17,7 +17,7 @@ cairo_surface_t *gdk_pixbuf_to_cairo_surface(GdkPixbuf *pixbuf);
  *         necessary, it returns the same pixbuf. Transfers full
  *         ownership of the reference.
  */
-GdkPixbuf *icon_pixbuf_scale(GdkPixbuf *pixbuf);
+GdkPixbuf *icon_pixbuf_scale(GdkPixbuf *pixbuf, int max_size);
 
 /** Retrieve an icon by its full filepath.
  *

--- a/src/notification.c
+++ b/src/notification.c
@@ -252,7 +252,7 @@ void notification_icon_replace_path(struct notification *n, const char *new_icon
         g_clear_pointer(&n->icon_id, g_free);
 
         n->icon = icon_get_for_name(new_icon, &n->icon_id);
-        n->icon = icon_pixbuf_scale(n->icon);
+        n->icon = icon_pixbuf_scale(n->icon, n->max_icon_size);
 }
 
 void notification_icon_replace_data(struct notification *n, GVariant *new_icon)
@@ -264,7 +264,7 @@ void notification_icon_replace_data(struct notification *n, GVariant *new_icon)
         g_clear_pointer(&n->icon_id, g_free);
 
         n->icon = icon_get_for_data(new_icon, &n->icon_id);
-        n->icon = icon_pixbuf_scale(n->icon);
+        n->icon = icon_pixbuf_scale(n->icon, n->max_icon_size);
 }
 
 /* see notification.h */
@@ -310,6 +310,7 @@ struct notification *notification_create(void)
         n->first_render = true;
         n->markup = settings.markup;
         n->format = settings.format;
+        n->max_icon_size = settings.max_icon_size;
 
         n->timestamp = time_monotonic_now();
 
@@ -358,6 +359,7 @@ void notification_init(struct notification *n)
         }
         if (!n->icon && !n->iconname)
                 notification_icon_replace_path(n, settings.icons[n->urgency]);
+        n->max_icon_size = settings.max_icon_size;
 
         /* Color hints */
         struct notification_colors defcolors;

--- a/src/notification.h
+++ b/src/notification.h
@@ -53,6 +53,7 @@ struct notification {
                                       May be a hash for a raw icon or a name/path for a regular app icon. */
         char *iconname;          /**< plain icon information (may be a path or just a name)
                                       Use this to compare the icon name with rules.*/
+        int max_icon_size;       /**< maximum pixel size of width and height of icon. */
 
         gint64 start;      /**< begin of current display */
         gint64 timestamp;  /**< arrival time */

--- a/src/rules.c
+++ b/src/rules.c
@@ -50,6 +50,9 @@ void rule_apply(struct rule *r, struct notification *n)
                 g_free(n->stack_tag);
                 n->stack_tag = g_strdup(r->set_stack_tag);
         }
+        if (r->set_max_icon_size) {
+                n->max_icon_size = r->set_max_icon_size;
+        }
 }
 
 /*

--- a/src/rules.h
+++ b/src/rules.h
@@ -36,6 +36,7 @@ struct rule {
         const char *script;
         enum behavior_fullscreen fullscreen;
         char *set_stack_tag;
+        int set_max_icon_size;
 };
 
 extern GSList *rules;

--- a/src/settings.c
+++ b/src/settings.c
@@ -740,6 +740,7 @@ void load_settings(char *cmdline_config_path)
                 }
                 r->script = ini_get_path(cur_section, "script", NULL);
                 r->set_stack_tag = ini_get_string(cur_section, "set_stack_tag", r->set_stack_tag);
+                r->set_max_icon_size = ini_get_int(cur_section, "set_max_icon_size", r->set_max_icon_size);
         }
 
 #ifndef STATIC_CONFIG


### PR DESCRIPTION
This PR isn't ready yet, it has the following deficiencies:

- [ ] No documentation changes
- [ ] No tests
- [ ] Initialization of icon pixbuf is ugly and inefficient because I think it will now get done twice - once in `notification_init` and again after the call to `notification_init` in `dbus_message_to_notification`.  The reason the involved code moved is so that the call to `notification_icon_replace_data` would run after the rules, and so see the overridden max icon size.

I'm putting it up to get feedback as to whether this should be added to dunst, and possibly if a different name should be used (just `max_icon_size`?)

Motivation for this change in my case is that I'd like most icons to be 64 pixels, but prefer 256 pixel icons for spotify, since it uses the album art for the icon.