### PR TITLE
Remove trailing spaces from MANPREFIX path

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -2,7 +2,8 @@
 PREFIX ?= /usr/local
 BINDIR ?= ${PREFIX}/bin
 DATADIR ?= ${PREFIX}/share
-MANPREFIX ?= ${DATADIR}/man # around for backwards compatibility
+# around for backwards compatibility
+MANPREFIX ?= ${DATADIR}/man
 MANDIR ?= ${MANPREFIX}
 
 DOXYGEN ?= doxygen


### PR DESCRIPTION
Variables with trailing comments include the spaces leading up to the
comment (https://www.gnu.org/software/make/manual/make.html#Flavors)
so the corresponding install command looked like
"install -Dm644 docs/dunst.1 $(DESTDIR)/usr/share/man /man1/dunst.1"