### PR TITLE
Changes DBus name owner flag from None to Replace

### DIFF
--- a/src/dbus.c
+++ b/src/dbus.c
@@ -591,7 +591,7 @@ int dbus_init(void)
 
         owner_id = g_bus_own_name(G_BUS_TYPE_SESSION,
                                   FDN_NAME,
-                                  G_BUS_NAME_OWNER_FLAGS_NONE,
+                                  G_BUS_NAME_OWNER_FLAGS_REPLACE,
                                   dbus_cb_bus_acquired,
                                   dbus_cb_name_acquired,
                                   dbus_cb_name_lost,


### PR DESCRIPTION
As some desktop environments do not support swapping out
their notification daemon
(https://gitlab.gnome.org/GNOME/gnome-shell/issues/99)
we need to use G_BUS_NAME_OWNER_FLAGS_REPLACE flag that
allows Dunst to take org.freedesktop.Notifications name
for itself.