### PR TITLE
XRandR DPI Online Changes

### DIFF
--- a/src/draw.c
+++ b/src/draw.c
@@ -237,7 +237,7 @@ static PangoLayout *layout_create(cairo_t *c)
         struct screen_info *screen = get_active_screen();
 
         PangoContext *context = pango_cairo_create_context(c);
-        pango_cairo_context_set_resolution(context, get_dpi_for_screen(screen));
+        pango_cairo_context_set_resolution(context, screen_dpi_get(screen));
 
         PangoLayout *layout = pango_layout_new(context);
 

--- a/src/x11/screen.c
+++ b/src/x11/screen.c
@@ -60,17 +60,13 @@ static double screen_dpi_get_from_xft(void)
                 screen_dpi_xft_cache = 0;
 
                 XrmInitialize();
-                char *xRMS = XResourceManagerString(xctx.dpy);
 
-                ASSERT_OR_RET(xRMS, screen_dpi_xft_cache);
-
-                XrmDatabase xDB = XrmGetStringDatabase(xRMS);
                 char *xrmType;
                 XrmValue xrmValue;
-
-                if (XrmGetResource(xDB, "Xft.dpi", "Xft.dpi", &xrmType, &xrmValue))
+                XrmDatabase db = XrmGetDatabase(xctx.dpy);
+                ASSERT_OR_RET(db, screen_dpi_xft_cache);
+                if (XrmGetResource(db, "Xft.dpi", "Xft.dpi", &xrmType, &xrmValue))
                         screen_dpi_xft_cache = strtod(xrmValue.addr, NULL);
-                XrmDestroyDatabase(xDB);
         }
         return screen_dpi_xft_cache;
 }

--- a/src/x11/screen.c
+++ b/src/x11/screen.c
@@ -167,15 +167,15 @@ void randr_update(void)
         XRRFreeMonitors(m);
 }
 
-void screen_check_event(XEvent event)
+bool screen_check_event(XEvent *ev)
 {
-        if (XRRUpdateConfiguration(&event)) {
+        if (XRRUpdateConfiguration(ev)) {
                 LOG_D("XEvent: processing 'RRScreenChangeNotify'");
                 randr_update();
 
-        } else {
-                LOG_D("XEvent: Ignoring '%d'", event.type);
+                return true;
         }
+        return false;
 }
 
 void xinerama_update(void)

--- a/src/x11/screen.c
+++ b/src/x11/screen.c
@@ -59,8 +59,6 @@ static double screen_dpi_get_from_xft(void)
         if (screen_dpi_xft_cache == -DBL_MAX) {
                 screen_dpi_xft_cache = 0;
 
-                XrmInitialize();
-
                 char *xrmType;
                 XrmValue xrmValue;
                 XrmDatabase db = XrmGetDatabase(xctx.dpy);

--- a/src/x11/screen.c
+++ b/src/x11/screen.c
@@ -77,12 +77,8 @@ void init_screens(void)
 void alloc_screen_ar(int n)
 {
         assert(n > 0);
-        if (n <= screens_len) return;
-
-        screens = g_realloc(screens, n * sizeof(struct screen_info));
-
-        memset(screens, 0, n * sizeof(struct screen_info));
-
+        g_free(screens);
+        screens = g_malloc0(n * sizeof(struct screen_info));
         screens_len = n;
 }
 

--- a/src/x11/screen.c
+++ b/src/x11/screen.c
@@ -25,8 +25,6 @@ int screens_len;
 
 bool dunst_follow_errored = false;
 
-int randr_event_base = 0;
-
 static int randr_major_version = 0;
 static int randr_minor_version = 0;
 
@@ -90,8 +88,8 @@ void alloc_screen_ar(int n)
 
 void randr_init(void)
 {
-        int randr_error_base = 0;
-        if (!XRRQueryExtension(xctx.dpy, &randr_event_base, &randr_error_base)) {
+        int ignored;
+        if (!XRRQueryExtension(xctx.dpy, &ignored, &ignored)) {
                 LOG_W("Could not initialize the RandR extension. "
                       "Falling back to single monitor mode.");
                 return;
@@ -145,7 +143,7 @@ static int autodetect_dpi(struct screen_info *scr)
 
 void screen_check_event(XEvent event)
 {
-        if (event.type == randr_event_base + RRScreenChangeNotify) {
+        if (XRRUpdateConfiguration(&event)) {
                 LOG_D("XEvent: processing 'RRScreenChangeNotify'");
                 randr_update();
 

--- a/src/x11/screen.c
+++ b/src/x11/screen.c
@@ -90,11 +90,11 @@ double screen_dpi_get(struct screen_info *scr)
 
 void init_screens(void)
 {
-        if (!settings.force_xinerama) {
+        if (settings.force_xinerama) {
+                xinerama_update();
+        } else {
                 randr_init();
                 randr_update();
-        } else {
-                xinerama_update();
         }
 }
 

--- a/src/x11/screen.h
+++ b/src/x11/screen.h
@@ -20,7 +20,7 @@ void init_screens(void);
 void screen_check_event(XEvent event);
 
 struct screen_info *get_active_screen(void);
-double get_dpi_for_screen(struct screen_info *scr);
+double screen_dpi_get(struct screen_info *scr);
 
 /**
  * Find the currently focused window and check if it's in

--- a/src/x11/screen.h
+++ b/src/x11/screen.h
@@ -18,7 +18,7 @@ struct screen_info {
 
 void init_screens(void);
 void screen_dpi_xft_cache_purge(void);
-void screen_check_event(XEvent event);
+bool screen_check_event(XEvent *ev);
 
 struct screen_info *get_active_screen(void);
 double screen_dpi_get(struct screen_info *scr);

--- a/src/x11/screen.h
+++ b/src/x11/screen.h
@@ -17,6 +17,7 @@ struct screen_info {
 };
 
 void init_screens(void);
+void screen_dpi_xft_cache_purge(void);
 void screen_check_event(XEvent event);
 
 struct screen_info *get_active_screen(void);

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -355,7 +355,10 @@ gboolean x_mainloop_fd_dispatch(GSource *source, GSourceFunc callback, gpointer 
                         }
                         break;
                 default:
-                        screen_check_event(ev);
+                        if (!screen_check_event(&ev)) {
+                                LOG_D("XEvent: Ignoring '%d'", ev.type);
+                        }
+
                         break;
                 }
         }

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -674,9 +674,17 @@ struct window_x11 *x_win_create(void)
 
         win->esrc = x_win_reg_source(win);
 
-        long root_event_mask = SubstructureNotifyMask;
+        /* SubstructureNotifyMask is required for receiving CreateNotify events
+         * in order to raise the window when something covers us. See #160
+         *
+         * PropertyChangeMask is requred for getting screen change events when follow_mode != none
+         *                    and it's also needed to receive
+         *                    XA_RESOURCE_MANAGER events to update the dpi when
+         *                    the xresource value is updated
+         */
+        long root_event_mask = SubstructureNotifyMask | PropertyChangeMask;
         if (settings.f_mode != FOLLOW_NONE) {
-                root_event_mask |= FocusChangeMask | PropertyChangeMask;
+                root_event_mask |= FocusChangeMask;
         }
         XSelectInput(xctx.dpy, root, root_event_mask);
 

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -471,6 +471,8 @@ void x_setup(void)
 
         init_screens();
         x_shortcut_grab(&settings.history_ks);
+
+        XrmInitialize();
 }
 
 struct geometry x_parse_geometry(const char *geom_str)


### PR DESCRIPTION
Changes DPI values online when receiving a corresponding XEvent.

To verify:

```shell
xrandr --dpi "${DPI}"
```

See the `Query the X11 screen's DPI instead of monitor` commit's description for further info.

Fixes #382