### PR TITLE
Make extract_urls regex more portable

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -40,7 +40,7 @@ static bool regex_init(void)
                 return true;
 
         char *regex =
-            "\\b(https?://|ftps?://|news://|mailto:|file://|www\\.)"
+            "\\<(https?://|ftps?://|news://|mailto:|file://|www\\.)"
             "[-[:alnum:]_\\@;/?:&=%$.+!*\x27,~#]*"
             "(\\([-[:alnum:]_\\@;/?:&=%$.+!*\x27,~#]*\\)|[-[:alnum:]_\\@;/?:&=%$+*~])+";
         int code = regcomp(&url_regex, regex, REG_EXTENDED | REG_ICASE);


### PR DESCRIPTION
`\b` word boundary syntax doesn't work on FreeBSD which uses `[[:<:]]`, and `[[:<:]]` doesn't seem to be supported by glibc. Make extract_urls regex more portable by using `\<` for word boundary which is supported by both Linux (tested on Arch) and FreeBSD [1] (and probably by OpenBSD too [2], untested)

[1] https://www.freebsd.org/cgi/man.cgi?query=re_format&sektion=7&n=1
[2] https://man.openbsd.org/re_format.7