### PR TITLE
Expose do_action as a keyboard shortcut

### DIFF
--- a/config.h
+++ b/config.h
@@ -101,6 +101,10 @@ struct settings defaults = {
         .code = 0,.sym = NoSymbol,.is_valid = false
 },                              /* ignore this */
 
+.do_action_ks = {.str = "none",
+        .code = 0,.sym = NoSymbol,.is_valid = false
+},                              /* ignore this */
+
 .mouse_left_click = MOUSE_CLOSE_CURRENT,
 
 .mouse_middle_click = MOUSE_DO_ACTION,

--- a/docs/dunst.pod
+++ b/docs/dunst.pod
@@ -529,6 +529,12 @@ B<command line flag>: -context_key <key>
 
 Specifies the keyboard shortcut that opens the context menu.
 
+=item B<do_action>
+
+B<command line flag>: -do_action_key <key>
+
+Specifies the keyboard shortcut that invokes the current action or context menu.
+
 =back
 
 =head2 Urgency sections

--- a/dunstrc
+++ b/dunstrc
@@ -272,6 +272,11 @@
     # Context menu.
     context = ctrl+shift+period
 
+    # Do action.
+    # * do_action: If the notification has exactly one action, or one is marked as default,
+    #              invoke it. If there are multiple and no default, open the context menu.
+    do_action = ctrl+shift+comma
+
 [urgency_low]
     # IMPORTANT: colors have to be defined in quotation marks.
     # Otherwise the "#" and following would be interpreted as a comment.

--- a/src/menu.c
+++ b/src/menu.c
@@ -362,4 +362,14 @@ static gpointer context_menu_thread(gpointer data)
 
         return NULL;
 }
+
+void shortcut_do_action(void)
+{
+        for (const GList *iter = queues_get_displayed(); iter;
+             iter = iter->next) {
+                struct notification *n = iter->data;
+                notification_do_action(n);
+                return;
+        }
+}
 /* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/menu.h
+++ b/src/menu.h
@@ -20,5 +20,10 @@ void regex_teardown(void);
  */
 void context_menu(void);
 
+/**
+ * Do action using the keyboard shortcut.
+ */
+void shortcut_do_action(void);
+
 #endif
 /* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/settings.c
+++ b/src/settings.c
@@ -666,6 +666,12 @@ void load_settings(char *cmdline_config_path)
                 "Shortcut for context menu"
         );
 
+        settings.do_action_ks.str = option_get_string(
+                "shortcuts",
+                "do_action", "-do_action_key", defaults.do_action_ks.str,
+                "Shortcut for invoking the action or context menu"
+        );
+
         settings.print_notifications = cmdline_get_bool(
                 "-print", false,
                 "Print notifications to cmdline (DEBUG)"

--- a/src/settings.h
+++ b/src/settings.h
@@ -83,6 +83,7 @@ struct settings {
         struct keyboard_shortcut close_all_ks;
         struct keyboard_shortcut history_ks;
         struct keyboard_shortcut context_ks;
+        struct keyboard_shortcut do_action_ks;
         bool force_xinerama;
         int corner_radius;
         enum mouse_action mouse_left_click;

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -329,6 +329,13 @@ gboolean x_mainloop_fd_dispatch(GSource *source, GSourceFunc callback, gpointer 
                                 context_menu();
                                 wake_up();
                         }
+                        if (settings.do_action_ks.str
+                            && XLookupKeysym(&ev.xkey,
+                                             0) == settings.do_action_ks.sym
+                            && settings.do_action_ks.mask == state) {
+                                shortcut_do_action();
+                                wake_up();
+                        }
                         break;
                 case CreateNotify:
                         LOG_D("XEvent: processing 'CreateNotify'");
@@ -514,6 +521,7 @@ void x_setup(void)
         x_shortcut_init(&settings.close_all_ks);
         x_shortcut_init(&settings.history_ks);
         x_shortcut_init(&settings.context_ks);
+        x_shortcut_init(&settings.do_action_ks);
 
         x_shortcut_grab(&settings.close_ks);
         x_shortcut_ungrab(&settings.close_ks);
@@ -523,6 +531,8 @@ void x_setup(void)
         x_shortcut_ungrab(&settings.history_ks);
         x_shortcut_grab(&settings.context_ks);
         x_shortcut_ungrab(&settings.context_ks);
+        x_shortcut_grab(&settings.do_action_ks);
+        x_shortcut_ungrab(&settings.do_action_ks);
 
         xctx.screensaver_info = XScreenSaverAllocInfo();
 
@@ -718,6 +728,7 @@ void x_win_show(struct window_x11 *win)
         x_shortcut_grab(&settings.close_ks);
         x_shortcut_grab(&settings.close_all_ks);
         x_shortcut_grab(&settings.context_ks);
+        x_shortcut_grab(&settings.do_action_ks);
 
         x_shortcut_setup_error_handler();
         XGrabButton(xctx.dpy,
@@ -748,6 +759,7 @@ void x_win_hide(struct window_x11 *win)
         x_shortcut_ungrab(&settings.close_ks);
         x_shortcut_ungrab(&settings.close_all_ks);
         x_shortcut_ungrab(&settings.context_ks);
+        x_shortcut_ungrab(&settings.do_action_ks);
 
         XUngrabButton(xctx.dpy, AnyButton, AnyModifier, win->xwin);
         XUnmapWindow(xctx.dpy, win->xwin);


### PR DESCRIPTION
This exposes the same do_action that a middle mouse click does on a
notification as a keyboard shortcut.

I haven't done any C in a very very long time and I have have no idea
what I'm doing :) Everything was copy pasted from one of the existing
keyboard shortcuts and to my surprise it just worked!