### PR TITLE
Enable extended patterns in fnmatch

### DIFF
--- a/docs/dunst.pod
+++ b/docs/dunst.pod
@@ -678,7 +678,9 @@ Matches only messages that were send via notify-send. If multiple filter
 expressions are present, all of them have to match for the rule to be applied
 (logical AND).
 
-Shell-like globing is supported.
+Shell-like globing is supported. For more information see fnmatch(3). Support
+for extended patterns is enabled (EXTMATCH) but I<they are only available on GNU
+libc>
 
 =item B<modifying>
 

--- a/src/rules.c
+++ b/src/rules.c
@@ -1,11 +1,20 @@
 /* copyright 2013 Sascha Kruse and contributors (see LICENSE for licensing information) */
 
+// Needed for FNM_EXTMATCH flag
+#define _GNU_SOURCE
+
 #include "rules.h"
 
 #include <fnmatch.h>
 #include <glib.h>
 
 #include "dunst.h"
+
+#ifdef FNM_EXTMATCH
+#define FNMATCH_FLAGS FNM_EXTMATCH
+#else
+#define FNMATCH_FLAGS 0
+#endif
 
 GSList *rules = NULL;
 
@@ -84,7 +93,7 @@ struct rule *rule_new(void)
 
 static inline bool rule_field_matches_string(const char *value, const char *pattern)
 {
-        return !pattern || (value && !fnmatch(pattern, value, 0));
+        return !pattern || (value && !fnmatch(pattern, value, FNMATCH_FLAGS));
 }
 
 /*


### PR DESCRIPTION
I wanted to add a compilation warning but apparently `#warning` is a gcc specific extension. Not sure how else we could indicate if this is enabled or not.

Fixes #645
Fixes #658