### PR TITLE
Implement #392, take 2

### DIFF
--- a/.valgrind.suppressions
+++ b/.valgrind.suppressions
@@ -28,6 +28,26 @@
    ...
 }
 
+# same as above, but as occurs in CI environment
+{
+   rsvg_error_handle_close2
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:g_malloc
+   fun:g_slice_alloc
+   fun:g_error_new_valist
+   fun:g_set_error
+   obj:*/librsvg-2.so*
+   obj:*/librsvg-2.so*
+   obj:*/loaders/libpixbufloader-svg.so
+   obj:*/libgdk_pixbuf-2.0.so*
+   fun:gdk_pixbuf_loader_close
+   fun:gdk_pixbuf_get_file_info
+   fun:get_pixbuf_from_file
+   ...
+}
+
 # rsvg_error_writehandler got fixed in
 # - GNOME/librsvg@7b4cc9b
 # (2018-11-12, first tags: v2.45.0, v2.44.9)

--- a/.valgrind.suppressions
+++ b/.valgrind.suppressions
@@ -20,10 +20,10 @@
    fun:g_error_new_valist
    fun:g_set_error
    obj:*/librsvg-2.so*
-   obj:*/librsvg-2.so*
+   fun:rsvg_handle_close
    obj:*/loaders/libpixbufloader-svg.so
-   obj:*/libgdk_pixbuf-2.0.so*
-   fun:gdk_pixbuf_new_from_file
+   fun:gdk_pixbuf_loader_close
+   fun:gdk_pixbuf_get_file_info
    fun:get_pixbuf_from_file
    ...
 }
@@ -45,7 +45,8 @@
    fun:rsvg_handle_write
    obj:*/loaders/libpixbufloader-svg.so
    obj:*/libgdk_pixbuf-2.0.so*
-   fun:gdk_pixbuf_new_from_file
+   fun:gdk_pixbuf_loader_close
+   fun:gdk_pixbuf_get_file_info
    fun:get_pixbuf_from_file
    ...
 }

--- a/config.h
+++ b/config.h
@@ -65,6 +65,7 @@ struct settings defaults = {
 
 .browser = "/usr/bin/firefox",
 
+.min_icon_size = 0,
 .max_icon_size = 0,
 
 /* paths to default icons */

--- a/docs/dunst.pod
+++ b/docs/dunst.pod
@@ -384,14 +384,28 @@ ACTIONS below for further details.
 Defines the position of the icon in the notification window. Setting it to off
 disables icons.
 
+=item B<min_icon_size> (default: 0)
+
+Defines the minimum size in pixels for the icons.
+If the icon is larger than or equal to the specified value it won't be affected.
+If it's smaller then it will be scaled up so that the smaller axis is equivalent
+to the specified size.
+
+Set to 0 to disable icon upscaling. (default)
+
+If B<icon_position> is set to off, this setting is ignored.
+
 =item B<max_icon_size> (default: 0)
 
 Defines the maximum size in pixels for the icons.
-If the icon is smaller than the specified value it won't be affected.
+If the icon is smaller than or equal to the specified value it won't be affected.
 If it's larger then it will be scaled down so that the larger axis is equivalent
 to the specified size.
 
-Set to 0 to disable icon scaling. (default)
+Set to 0 to disable icon downscaling. (default)
+
+If both B<min_icon_size> and B<max_icon_size> are enabled, the latter
+gets the last say.
 
 If B<icon_position> is set to off, this setting is ignored.
 

--- a/dunstrc
+++ b/dunstrc
@@ -162,6 +162,11 @@
     # Align icons left/right/off
     icon_position = off
 
+    # Scale small icons up to this size, set to 0 to disable. Helpful
+    # for e.g. small files or high-dpi screens. In case of conflict,
+    # max_icon_size takes precedence over this.
+    min_icon_size = 0
+
     # Scale larger icons down to this size, set to 0 to disable
     max_icon_size = 32
 

--- a/src/icon.c
+++ b/src/icon.c
@@ -177,7 +177,6 @@ GdkPixbuf *get_pixbuf_from_file(const char *filename)
         if (!gdk_pixbuf_get_file_info (path, &w, &h)) {
                 LOG_W("Failed to load image info for %s", filename);
                 g_free(path);
-                g_error_free(error);
                 return NULL;
         }
         icon_size_clamp(&w, &h);

--- a/src/icon.c
+++ b/src/icon.c
@@ -175,6 +175,7 @@ GdkPixbuf *get_pixbuf_from_file(const char *filename)
 
         if (!gdk_pixbuf_get_file_info (path, &w, &h)) {
                 LOG_W("Failed to load image info for %s", filename);
+                g_free(path);
                 g_error_free(error);
                 return NULL;
         }

--- a/src/icon.c
+++ b/src/icon.c
@@ -115,6 +115,7 @@ cairo_surface_t *gdk_pixbuf_to_cairo_surface(GdkPixbuf *pixbuf)
  *
  * @param w a pointer to the image width, to be modified in-place
  * @param h a pointer to the image height, to be modified in-place
+ * @return TRUE if the dimensions were updated, FALSE if they were left unchanged
  */
 static bool icon_size_clamp(int *w, int *h) {
         int _w = *w, _h = *h;
@@ -155,11 +156,11 @@ static GdkPixbuf *icon_pixbuf_scale(GdkPixbuf *pixbuf)
         int h = gdk_pixbuf_get_height(pixbuf);
 
         if (icon_size_clamp(&w, &h)) {
-                GdkPixbuf *scaled;
-                scaled = gdk_pixbuf_scale_simple(pixbuf,
-                                                 w,
-                                                 h,
-                                                 GDK_INTERP_BILINEAR);
+                GdkPixbuf *scaled = gdk_pixbuf_scale_simple(
+                                pixbuf,
+                                w,
+                                h,
+                                GDK_INTERP_BILINEAR);
                 g_object_unref(pixbuf);
                 pixbuf = scaled;
         }

--- a/src/icon.c
+++ b/src/icon.c
@@ -116,19 +116,23 @@ GdkPixbuf *icon_pixbuf_scale(GdkPixbuf *pixbuf)
 
         int w = gdk_pixbuf_get_width(pixbuf);
         int h = gdk_pixbuf_get_height(pixbuf);
-        int larger = w > h ? w : h;
+        int landscape = w > h;
+        int orig_larger = landscape ? w : h;
+        double larger = orig_larger;
+        double smaller = landscape ? h : w;
+        if (settings.min_icon_size && smaller < settings.min_icon_size) {
+                larger = larger / smaller * settings.min_icon_size;
+                smaller = settings.min_icon_size;
+        }
         if (settings.max_icon_size && larger > settings.max_icon_size) {
-                int scaled_w = settings.max_icon_size;
-                int scaled_h = settings.max_icon_size;
-                if (w >= h)
-                        scaled_h = (settings.max_icon_size * h) / w;
-                else
-                        scaled_w = (settings.max_icon_size * w) / h;
-
-                GdkPixbuf *scaled = gdk_pixbuf_scale_simple(
-                                pixbuf,
-                                scaled_w,
-                                scaled_h,
+                smaller = smaller / larger * settings.max_icon_size;
+                larger = settings.max_icon_size;
+        }
+        if ((int) larger != orig_larger) {
+                GdkPixbuf *scaled;
+                scaled = gdk_pixbuf_scale_simple(pixbuf,
+                                (int) (landscape ? larger : smaller),
+                                (int) (landscape ? smaller : larger),
                                 GDK_INTERP_BILINEAR);
                 g_object_unref(pixbuf);
                 pixbuf = scaled;

--- a/src/icon.h
+++ b/src/icon.h
@@ -8,18 +8,7 @@
 
 cairo_surface_t *gdk_pixbuf_to_cairo_surface(GdkPixbuf *pixbuf);
 
-/**
- * Scales the given GdkPixbuf if necessary according to the settings.
- *
- * @param pixbuf (nullable) The pixbuf, which may be too big.
- *                          Takes ownership of the reference.
- * @return the scaled version of the pixbuf. If scaling wasn't
- *         necessary, it returns the same pixbuf. Transfers full
- *         ownership of the reference.
- */
-GdkPixbuf *icon_pixbuf_scale(GdkPixbuf *pixbuf);
-
-/** Retrieve an icon by its full filepath.
+/** Retrieve an icon by its full filepath, scaled according to settings.
  *
  * @param filename A string representing a readable file path
  *
@@ -28,7 +17,7 @@ GdkPixbuf *icon_pixbuf_scale(GdkPixbuf *pixbuf);
  */
 GdkPixbuf *get_pixbuf_from_file(const char *filename);
 
-/** Retrieve an icon by its name sent via the notification bus
+/** Retrieve an icon by its name sent via the notification bus, scaled according to settings
  *
  * @param iconname A string describing a `file://` URL, an arbitary filename
  *                 or an icon name, which then gets searched for in the
@@ -39,7 +28,7 @@ GdkPixbuf *get_pixbuf_from_file(const char *filename);
  */
 GdkPixbuf *get_pixbuf_from_icon(const char *iconname);
 
-/** Read an icon from disk and convert it to a GdkPixbuf.
+/** Read an icon from disk and convert it to a GdkPixbuf, scaled according to settings
  *
  * The returned id will be a unique identifier. To check if two given
  * GdkPixbufs are equal, it's sufficient to just compare the id strings.
@@ -54,7 +43,7 @@ GdkPixbuf *get_pixbuf_from_icon(const char *iconname);
  */
 GdkPixbuf *icon_get_for_name(const char *name, char **id);
 
-/** Convert a GVariant like described in GdkPixbuf
+/** Convert a GVariant like described in GdkPixbuf, scaled according to settings
  *
  * The returned id will be a unique identifier. To check if two given
  * GdkPixbufs are equal, it's sufficient to just compare the id strings.

--- a/src/notification.c
+++ b/src/notification.c
@@ -252,7 +252,6 @@ void notification_icon_replace_path(struct notification *n, const char *new_icon
         g_clear_pointer(&n->icon_id, g_free);
 
         n->icon = icon_get_for_name(new_icon, &n->icon_id);
-        n->icon = icon_pixbuf_scale(n->icon);
 }
 
 void notification_icon_replace_data(struct notification *n, GVariant *new_icon)
@@ -264,7 +263,6 @@ void notification_icon_replace_data(struct notification *n, GVariant *new_icon)
         g_clear_pointer(&n->icon_id, g_free);
 
         n->icon = icon_get_for_data(new_icon, &n->icon_id);
-        n->icon = icon_pixbuf_scale(n->icon);
 }
 
 /* see notification.h */

--- a/src/settings.c
+++ b/src/settings.c
@@ -423,6 +423,12 @@ void load_settings(char *cmdline_config_path)
                 g_free(c);
         }
 
+        settings.min_icon_size = option_get_int(
+                "global",
+                "min_icon_size", "-min_icon_size", defaults.min_icon_size,
+                "Scale smaller icons up to this size, set to 0 to disable. If max_icon_size also specified, that has the final say."
+        );
+
         settings.max_icon_size = option_get_int(
                 "global",
                 "max_icon_size", "-max_icon_size", defaults.max_icon_size,

--- a/src/settings.h
+++ b/src/settings.h
@@ -75,6 +75,7 @@ struct settings {
         char *browser;
         char **browser_cmd;
         enum icon_position icon_position;
+        int min_icon_size;
         int max_icon_size;
         char *icon_path;
         enum follow_mode f_mode;

--- a/test/dbus.c
+++ b/test/dbus.c
@@ -6,6 +6,7 @@
 #include <gdk-pixbuf/gdk-pixbuf.h>
 #include <gio/gio.h>
 
+#include "helpers.h"
 #include "queues.h"
 
 extern const char *base;
@@ -252,33 +253,13 @@ bool dbus_notification_fire(struct dbus_notification *n, uint *id)
 
 void dbus_notification_set_raw_image(struct dbus_notification *n_dbus, const char *path)
 {
-        GdkPixbuf *pb = gdk_pixbuf_new_from_file(path, NULL);
-
-        if (!pb)
+        GVariant *hint = notification_setup_raw_image(path);
+        if (!hint)
                 return;
-
-        GVariant *hint_data = g_variant_new_from_data(
-                                G_VARIANT_TYPE("ay"),
-                                gdk_pixbuf_read_pixels(pb),
-                                gdk_pixbuf_get_byte_length(pb),
-                                TRUE,
-                                (GDestroyNotify) g_object_unref,
-                                g_object_ref(pb));
-
-        GVariant *hint = g_variant_new(
-                                "(iiibii@ay)",
-                                gdk_pixbuf_get_width(pb),
-                                gdk_pixbuf_get_height(pb),
-                                gdk_pixbuf_get_rowstride(pb),
-                                gdk_pixbuf_get_has_alpha(pb),
-                                gdk_pixbuf_get_bits_per_sample(pb),
-                                gdk_pixbuf_get_n_channels(pb),
-                                hint_data);
 
         g_hash_table_insert(n_dbus->hints,
                             g_strdup("image-data"),
                             g_variant_ref_sink(hint));
-        g_object_unref(pb);
 }
 
 /////// TESTS

--- a/test/helpers.c
+++ b/test/helpers.c
@@ -1,0 +1,35 @@
+#include <gdk-pixbuf/gdk-pixbuf.h>
+
+#include "helpers.h"
+
+GVariant *notification_setup_raw_image(const char *path)
+{
+        GdkPixbuf *pb = gdk_pixbuf_new_from_file(path, NULL);
+
+        if (!pb)
+                return NULL;
+
+        GVariant *hint_data = g_variant_new_from_data(
+                                G_VARIANT_TYPE("ay"),
+                                gdk_pixbuf_read_pixels(pb),
+                                gdk_pixbuf_get_byte_length(pb),
+                                TRUE,
+                                (GDestroyNotify) g_object_unref,
+                                g_object_ref(pb));
+
+        GVariant *hint = g_variant_new(
+                                "(iiibii@ay)",
+                                gdk_pixbuf_get_width(pb),
+                                gdk_pixbuf_get_height(pb),
+                                gdk_pixbuf_get_rowstride(pb),
+                                gdk_pixbuf_get_has_alpha(pb),
+                                gdk_pixbuf_get_bits_per_sample(pb),
+                                gdk_pixbuf_get_n_channels(pb),
+                                hint_data);
+
+        g_object_unref(pb);
+
+        return hint;
+}
+
+/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/test/helpers.h
+++ b/test/helpers.h
@@ -1,0 +1,9 @@
+#ifndef DUNST_TEST_HELPERS_H
+#define DUNST_TEST_HELPERS_H
+
+#include <glib.h>
+
+GVariant *notification_setup_raw_image(const char *path);
+
+#endif
+/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/test/icon.c
+++ b/test/icon.c
@@ -113,6 +113,61 @@ TEST test_get_pixbuf_from_icon_fileuri(void)
         PASS();
 }
 
+TEST test_icon_size_clamp_too_small(void)
+{
+        int w = 12, h = 24;
+        bool resized = icon_size_clamp(&w, &h);
+        ASSERT(resized);
+        ASSERT_EQ(w, 16);
+        ASSERT_EQ(h, 32);
+
+        PASS();
+}
+
+TEST test_icon_size_clamp_not_necessary(void)
+{
+        int w = 20, h = 30;
+        bool resized = icon_size_clamp(&w, &h);
+        ASSERT(!resized);
+        ASSERT_EQ(w, 20);
+        ASSERT_EQ(h, 30);
+
+        PASS();
+}
+
+TEST test_icon_size_clamp_too_big(void)
+{
+        int w = 75, h = 150;
+        bool resized = icon_size_clamp(&w, &h);
+        ASSERT(resized);
+        ASSERT_EQ(w, 50);
+        ASSERT_EQ(h, 100);
+
+        PASS();
+}
+
+TEST test_icon_size_clamp_too_small_then_too_big(void)
+{
+        int w = 8, h = 80;
+        bool resized = icon_size_clamp(&w, &h);
+        ASSERT(resized);
+        ASSERT_EQ(w, 10);
+        ASSERT_EQ(h, 100);
+
+        PASS();
+}
+
+TEST test_get_pixbuf_from_icon_both_is_scaled(void)
+{
+        GdkPixbuf *pixbuf = get_pixbuf_from_icon("onlypng");
+        ASSERT(pixbuf);
+        ASSERT_EQ(gdk_pixbuf_get_width(pixbuf), 16);
+        ASSERT_EQ(gdk_pixbuf_get_height(pixbuf), 16);
+        g_clear_pointer(&pixbuf, g_object_unref);
+
+        PASS();
+}
+
 SUITE(suite_icon)
 {
         settings.icon_path = g_strconcat(
@@ -129,6 +184,31 @@ SUITE(suite_icon)
         RUN_TEST(test_get_pixbuf_from_icon_onlypng);
         RUN_TEST(test_get_pixbuf_from_icon_filename);
         RUN_TEST(test_get_pixbuf_from_icon_fileuri);
+        RUN_TEST(test_icon_size_clamp_not_necessary);
+
+        settings.min_icon_size = 16;
+        settings.max_icon_size = 100;
+
+        RUN_TEST(test_get_pixbuf_from_icon_both_is_scaled);
+        RUN_TEST(test_icon_size_clamp_too_small);
+        RUN_TEST(test_icon_size_clamp_not_necessary);
+        RUN_TEST(test_icon_size_clamp_too_big);
+        RUN_TEST(test_icon_size_clamp_too_small_then_too_big);
+
+        settings.min_icon_size = 16;
+        settings.max_icon_size = 0;
+
+        RUN_TEST(test_icon_size_clamp_too_small);
+        RUN_TEST(test_icon_size_clamp_not_necessary);
+
+        settings.min_icon_size = 0;
+        settings.max_icon_size = 100;
+
+        RUN_TEST(test_icon_size_clamp_not_necessary);
+        RUN_TEST(test_icon_size_clamp_too_big);
+
+        settings.min_icon_size = 0;
+        settings.max_icon_size = 0;
 
         g_clear_pointer(&settings.icon_path, g_free);
 }


### PR DESCRIPTION
New attempt at #392, with [great ideas from @tsipinakis](https://github.com/dunst-project/dunst/issues/392#issuecomment-558519183) taken into account. Have still not attempted to test/take into account any DPI-related functionality, so cannot say yet how/if it will affect the outcome. 

Do you want more tests for the scaling functionality? Current tests pass.

Implementation details: I moved the scaling responsibility to the lowest functions in the call hierarchy involved in loading the images - both when loading from disk and from the notification message so responsibilities are clearer code-wise. Made some functions static that are no longer needed elsewhere.