### PR TITLE
Added override_redirect option

### DIFF
--- a/config.h
+++ b/config.h
@@ -25,6 +25,7 @@ struct settings defaults = {
               .negative_width = 0,
               .width_set = 0
             },
+.override_redirect = false,  /* prevent window manager from managing this window */
 .title = "Dunst",            /* the title of dunst notification windows */
 .class = "Dunst",            /* the class of dunst notification windows */
 .shrink = false,             /* shrinking */

--- a/config.h
+++ b/config.h
@@ -25,7 +25,7 @@ struct settings defaults = {
               .negative_width = 0,
               .width_set = 0
             },
-.override_redirect = false,  /* prevent window manager from managing this window */
+.override_redirect = true,  /* prevent window manager from managing this window */
 .title = "Dunst",            /* the title of dunst notification windows */
 .class = "Dunst",            /* the class of dunst notification windows */
 .shrink = false,             /* shrinking */

--- a/docs/dunst.pod
+++ b/docs/dunst.pod
@@ -142,9 +142,9 @@ the notification on the left border of the screen while a horizontal offset of
 
 =back
 
-=item B<override_redirect> (values: [true/false], default: false)
+=item B<override_redirect> (values: [true/false], default: true)
 
-Dicates whether or not the window managers manages notifications. This should be
+Dictates whether or not the window managers manages notifications. This should be
 false if you want notifications to always be on top.
 
 =item B<indicate_hidden> (values: [true/false], default: true)

--- a/docs/dunst.pod
+++ b/docs/dunst.pod
@@ -142,6 +142,11 @@ the notification on the left border of the screen while a horizontal offset of
 
 =back
 
+=item B<override_redirect> (values: [true/false], default: false)
+
+Dicates whether or not the window managers manages notifications. This should be
+false if you want notifications to always be on top.
+
 =item B<indicate_hidden> (values: [true/false], default: true)
 
 If this is set to true, a notification indicating how many notifications are

--- a/dunstrc
+++ b/dunstrc
@@ -31,6 +31,9 @@
     # screen width minus the width defined in within the geometry option.
     geometry = "300x5-30+20"
 
+    # When true the window manager won't manage this window
+    override_redirect = false
+
     # Show how many messages are currently hidden (because of geometry).
     indicate_hidden = yes
 

--- a/dunstrc
+++ b/dunstrc
@@ -32,7 +32,7 @@
     geometry = "300x5-30+20"
 
     # When true the window manager won't manage this window
-    override_redirect = false
+    override_redirect = yes
 
     # Show how many messages are currently hidden (because of geometry).
     indicate_hidden = yes

--- a/src/settings.c
+++ b/src/settings.c
@@ -256,9 +256,9 @@ void load_settings(char *cmdline_config_path)
 
         }
 
-        settings.override_redirect = !option_get_bool(
+        settings.override_redirect = option_get_bool(
                 "global",
-                "override_redirect", "-no-override_redirect", false,
+                "override_redirect", NULL, false,
                 "Determines if notifications are managed by the window manager."
         );
 

--- a/src/settings.c
+++ b/src/settings.c
@@ -256,9 +256,9 @@ void load_settings(char *cmdline_config_path)
 
         }
 
-        settings.override_redirect = option_get_bool(
+        settings.override_redirect = !option_get_bool(
                 "global",
-                "override_redirect", "-or/-override_redirect", defaults.override_redirect,
+                "override_redirect", "-no-override_redirect", false,
                 "Determines if notifications are managed by the window manager."
         );
 

--- a/src/settings.c
+++ b/src/settings.c
@@ -256,6 +256,12 @@ void load_settings(char *cmdline_config_path)
 
         }
 
+        settings.override_redirect = option_get_bool(
+                "global",
+                "override_redirect", "-or/-override_redirect", defaults.override_redirect,
+                "Determines if notifications are managed by the window manager."
+        );
+
         settings.shrink = option_get_bool(
                 "global",
                 "shrink", "-shrink", defaults.shrink,

--- a/src/settings.h
+++ b/src/settings.h
@@ -47,6 +47,7 @@ struct settings {
         char *icons[3];
         unsigned int transparency;
         struct geometry geometry;
+        bool override_redirect;
         char *title;
         char *class;
         int shrink;

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -601,9 +601,10 @@ static void x_set_wm(Window win)
                 XInternAtom(xctx.dpy, "_NET_WM_STATE", false);
 
         data[0] = XInternAtom(xctx.dpy, "_NET_WM_STATE_ABOVE", false);
+        data[1] = XInternAtom(xctx.dpy, "_NET_WM_STATE_STICKY", false);
 
         XChangeProperty(xctx.dpy, win, net_wm_state, XA_ATOM, 32,
-                PropModeReplace, (unsigned char *) data, 1L);
+                PropModeReplace, (unsigned char *) data, 2);
 }
 
 GSource* x_win_reg_source(struct window_x11 *win)

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -751,7 +751,7 @@ void x_win_hide(struct window_x11 *win)
         x_shortcut_ungrab(&settings.context_ks);
 
         XUngrabButton(xctx.dpy, AnyButton, AnyModifier, win->xwin);
-        XUnmapWindow(xctx.dpy, win->xwin);
+        XWithdrawWindow(xctx.dpy, win->xwin, XDefaultScreen(xctx.dpy));
         XFlush(xctx.dpy);
         win->visible = false;
 }

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -643,7 +643,7 @@ struct window_x11 *x_win_create(void)
 
         root = RootWindow(xctx.dpy, DefaultScreen(xctx.dpy));
 
-        wa.override_redirect = true;
+        wa.override_redirect = settings.override_redirect;
         wa.background_pixmap = ParentRelative;
         wa.event_mask =
             ExposureMask | KeyPressMask | VisibilityChangeMask |


### PR DESCRIPTION
To get notifications to reliably be on top of other windows, dunst
should ask the window manager. However, the override_redirect explicitly
tells the window manager to no manage notifications. An option has been
added to turn this behaviour off and is now the default in the sample
dunstrc.

We now properly rely on the window manager to keep our notifications on top which should close #678, close #627.