### PR TITLE
Fix dunstify installation

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -48,6 +48,4 @@ $(warning STATIC_CONFIG is deprecated behavior. It will get removed in future re
 endif
 
 # dunstify also needs libnotify
-ifneq (,$(findstring dunstify,${MAKECMDGOALS}))
-	pkg_config_packs += libnotify
-endif
+pkg_config_packs += libnotify


### PR DESCRIPTION
As it turns out, not every distribution link (lib)notify by default, so I didnt catch that earlier. I separate install and install-dunstify again because autoconf checks if string "dunstify" is applied as a make argument and then add libnotify to pkg_config_pack.

It would be awesome if someone could update the wiki page on this topic.

I am kinda new to C "building"/autoconf so I didnt fully understand respectively underestimated my change, sorry for that.