### PR TITLE
Allow for multiple actions per mouse event

### DIFF
--- a/config.h
+++ b/config.h
@@ -103,11 +103,11 @@ struct settings defaults = {
         .code = 0,.sym = NoSymbol,.is_valid = false
 },                              /* ignore this */
 
-.mouse_left_click = MOUSE_CLOSE_CURRENT,
+.mouse_left_click = (enum mouse_action []){MOUSE_CLOSE_CURRENT, -1},
 
-.mouse_middle_click = MOUSE_DO_ACTION,
+.mouse_middle_click = (enum mouse_action []){MOUSE_DO_ACTION, -1},
 
-.mouse_right_click = MOUSE_CLOSE_ALL,
+.mouse_right_click = (enum mouse_action []){MOUSE_CLOSE_ALL, -1},
 
 };
 

--- a/dunstrc
+++ b/dunstrc
@@ -238,15 +238,17 @@
 
     ### mouse
 
-    # Defines action of mouse event
+    # Defines list of actions for each mouse event
     # Possible values are:
     # * none: Don't do anything.
     # * do_action: If the notification has exactly one action, or one is marked as default,
     #              invoke it. If there are multiple and no default, open the context menu.
     # * close_current: Close current notification.
     # * close_all: Close all notifications.
+    # These values can be strung together for each mouse event, and
+    # will be executed in sequence.
     mouse_left_click = close_current
-    mouse_middle_click = do_action
+    mouse_middle_click = do_action, close_current
     mouse_right_click = close_all
 
 # Experimental features that may or may not work correctly. Do not expect them

--- a/src/option_parser.c
+++ b/src/option_parser.c
@@ -141,6 +141,27 @@ bool string_parse_mouse_action(const char *s, enum mouse_action *ret)
         return false;
 }
 
+bool string_parse_mouse_action_list(char **s, enum mouse_action **ret)
+{
+        ASSERT_OR_RET(s, false);
+        ASSERT_OR_RET(ret, false);
+
+        int len = 0;
+        while (s[len])
+                len++;
+
+        *ret = g_malloc((len + 1) * sizeof(enum mouse_action));
+        for (int i = 0; i < len; i++) {
+                if (!string_parse_mouse_action(s[i], *ret + i)) {
+                        LOG_W("Unknown mouse action value: '%s'", s[i]);
+                        g_free(*ret);
+                        return false;
+                }
+        }
+        (*ret)[len] = -1; // sentinel end value
+        return true;
+}
+
 bool string_parse_sepcolor(const char *s, struct separator_color_data *ret)
 {
         ASSERT_OR_RET(STR_FULL(s), false);
@@ -484,7 +505,8 @@ char *cmdline_get_path(const char *key, const char *def, const char *description
                 return string_to_path(g_strdup(def));
 }
 
-char **cmdline_get_list(const char *key, const char *def, const char *description){
+char **cmdline_get_list(const char *key, const char *def, const char *description)
+{
         cmdline_usage_append(key, "list", description);
         const char *str = cmdline_get_value(key);
 

--- a/src/option_parser.c
+++ b/src/option_parser.c
@@ -150,7 +150,7 @@ bool string_parse_mouse_action_list(char **s, enum mouse_action **ret)
         while (s[len])
                 len++;
 
-        *ret = g_malloc((len + 1) * sizeof(enum mouse_action));
+        *ret = g_malloc_n((len + 1), sizeof(enum mouse_action));
         for (int i = 0; i < len; i++) {
                 if (!string_parse_mouse_action(s[i], *ret + i)) {
                         LOG_W("Unknown mouse action value: '%s'", s[i]);

--- a/src/option_parser.c
+++ b/src/option_parser.c
@@ -260,6 +260,15 @@ gint64 ini_get_time(const char *section, const char *key, gint64 def)
         return val;
 }
 
+char **ini_get_list(const char *section, const char *key, const char *def)
+{
+        const char *value = get_value(section, key);
+        if (value)
+                return string_to_array(value);
+        else
+                return string_to_array(def);
+}
+
 int ini_get_int(const char *section, const char *key, int def)
 {
         const char *value = get_value(section, key);
@@ -475,6 +484,16 @@ char *cmdline_get_path(const char *key, const char *def, const char *description
                 return string_to_path(g_strdup(def));
 }
 
+char **cmdline_get_list(const char *key, const char *def, const char *description){
+        cmdline_usage_append(key, "list", description);
+        const char *str = cmdline_get_value(key);
+
+        if (str)
+                return string_to_array(str);
+        else
+                return string_to_array(def);
+}
+
 gint64 cmdline_get_time(const char *key, gint64 def, const char *description)
 {
         cmdline_usage_append(key, "time", description);
@@ -572,6 +591,23 @@ gint64 option_get_time(const char *ini_section,
 {
         gint64 ini_val = ini_get_time(ini_section, ini_key, def);
         return cmdline_get_time(cmdline_key, ini_val, description);
+}
+
+
+char **option_get_list(const char *ini_section,
+                       const char *ini_key,
+                       const char *cmdline_key,
+                       const char *def,
+                       const char *description)
+{
+        char **val = NULL;
+        if (cmdline_key)
+                val = cmdline_get_list(cmdline_key, NULL, description);
+
+        if (val)
+                return val;
+        else
+                return ini_get_list(ini_section, ini_key, def);
 }
 
 int option_get_int(const char *ini_section,

--- a/src/option_parser.h
+++ b/src/option_parser.h
@@ -24,6 +24,7 @@ int load_ini_file(FILE *);
 char *ini_get_path(const char *section, const char *key, const char *def);
 char *ini_get_string(const char *section, const char *key, const char *def);
 gint64 ini_get_time(const char *section, const char *key, gint64 def);
+char **ini_get_list(const char *section, const char *key, const char *def);
 int ini_get_int(const char *section, const char *key, int def);
 double ini_get_double(const char *section, const char *key, double def);
 int ini_get_bool(const char *section, const char *key, int def);
@@ -34,6 +35,7 @@ void cmdline_load(int argc, char *argv[]);
 /* for all cmdline_get_* key can be either "-key" or "-key/-longkey" */
 char *cmdline_get_string(const char *key, const char *def, const char *description);
 char *cmdline_get_path(const char *key, const char *def, const char *description);
+char **cmdline_get_list(const char *key, const char *def, const char *description);
 int cmdline_get_int(const char *key, int def, const char *description);
 double cmdline_get_double(const char *key, double def, const char *description);
 int cmdline_get_bool(const char *key, int def, const char *description);
@@ -54,6 +56,11 @@ gint64 option_get_time(const char *ini_section,
                        const char *ini_key,
                        const char *cmdline_key,
                        gint64 def,
+                       const char *description);
+char **option_get_list(const char *ini_section,
+                       const char *ini_key,
+                       const char *cmdline_key,
+                       const char *def,
                        const char *description);
 int option_get_int(const char *ini_section,
                    const char *ini_key,

--- a/src/option_parser.h
+++ b/src/option_parser.h
@@ -17,6 +17,7 @@ bool string_parse_icon_position(const char *s, enum icon_position *ret);
 bool string_parse_vertical_alignment(const char *s, enum vertical_alignment *ret);
 bool string_parse_markup_mode(const char *s, enum markup_mode *ret);
 bool string_parse_mouse_action(const char *s, enum mouse_action *ret);
+bool string_parse_mouse_action_list(char **s, enum mouse_action **ret);
 bool string_parse_sepcolor(const char *s, struct separator_color_data *ret);
 bool string_parse_urgency(const char *s, enum urgency *ret);
 

--- a/src/settings.c
+++ b/src/settings.c
@@ -529,48 +529,42 @@ void load_settings(char *cmdline_config_path)
         }
 
         {
-                char *c = option_get_string(
+                char **c = option_get_list(
                         "global",
-                        "mouse_left_click", "-left_click", NULL,
+                        "mouse_left_click", "-mouse_left_click", NULL,
                         "Action of Left click event"
                 );
 
-                if (!string_parse_mouse_action(c, &settings.mouse_left_click)) {
-                        if (c)
-                                LOG_W("Unknown mouse action value: '%s'", c);
+                if (!string_parse_mouse_action_list(c, &settings.mouse_left_click)) {
                         settings.mouse_left_click = defaults.mouse_left_click;
                 }
-                g_free(c);
+                free_string_array(c);
         }
 
         {
-                char *c = option_get_string(
+                char **c = option_get_list(
                         "global",
                         "mouse_middle_click", "-mouse_middle_click", NULL,
                         "Action of middle click event"
                 );
 
-                if (!string_parse_mouse_action(c, &settings.mouse_middle_click)) {
-                        if (c)
-                                LOG_W("Unknown mouse action value: '%s'", c);
+                if (!string_parse_mouse_action_list(c, &settings.mouse_middle_click)) {
                         settings.mouse_middle_click = defaults.mouse_middle_click;
                 }
-                g_free(c);
+                free_string_array(c);
         }
 
         {
-                char *c = option_get_string(
+                char **c = option_get_list(
                         "global",
                         "mouse_right_click", "-mouse_right_click", NULL,
                         "Action of right click event"
                 );
 
-                if (!string_parse_mouse_action(c, &settings.mouse_right_click)) {
-                        if (c)
-                                LOG_W("Unknown mouse action value: '%s'", c);
+                if (!string_parse_mouse_action_list(c, &settings.mouse_right_click)) {
                         settings.mouse_right_click = defaults.mouse_right_click;
                 }
-                g_free(c);
+                free_string_array(c);
         }
 
         settings.colors_low.bg = option_get_string(

--- a/src/settings.h
+++ b/src/settings.h
@@ -88,9 +88,9 @@ struct settings {
         struct keyboard_shortcut context_ks;
         bool force_xinerama;
         int corner_radius;
-        enum mouse_action mouse_left_click;
-        enum mouse_action mouse_middle_click;
-        enum mouse_action mouse_right_click;
+        enum mouse_action *mouse_left_click;
+        enum mouse_action *mouse_middle_click;
+        enum mouse_action *mouse_right_click;
 };
 
 extern struct settings settings;

--- a/src/utils.c
+++ b/src/utils.c
@@ -14,6 +14,17 @@
 #include "log.h"
 
 /* see utils.h */
+void free_string_array(char **arr)
+{
+        if (arr){
+                for (int i = 0; arr[i]; i++){
+                        g_free(arr[i]);
+                }
+        }
+        g_free(arr);
+}
+
+/* see utils.h */
 char *string_replace_char(char needle, char replacement, char *haystack)
 {
         ASSERT_OR_RET(haystack, NULL);
@@ -133,6 +144,27 @@ void string_strip_delimited(char *str, char a, char b)
                 }
         }
         str[iwrite] = 0;
+}
+
+/* see utils.h */
+char **string_to_array(const char *string)
+{
+        char **arr = NULL;
+        if (string) {
+                char* dup = g_strdup(string);
+                char* tmp = dup;
+                int num_tokens = 0;
+                char *token = strsep(&tmp, ",");
+                while (token) {
+                        arr = g_realloc_n(arr, num_tokens + 2, sizeof(char*));
+                        arr[num_tokens] = g_strdup(g_strstrip(token));
+                        num_tokens++;
+                        token = strsep(&tmp, ",");
+                }
+                arr[num_tokens] = NULL;
+                g_free(dup);
+        }
+        return arr;
 }
 
 /* see utils.h */

--- a/src/utils.c
+++ b/src/utils.c
@@ -151,18 +151,10 @@ char **string_to_array(const char *string)
 {
         char **arr = NULL;
         if (string) {
-                char* dup = g_strdup(string);
-                char* tmp = dup;
-                int num_tokens = 0;
-                char *token = strsep(&tmp, ",");
-                while (token) {
-                        arr = g_realloc_n(arr, num_tokens + 2, sizeof(char*));
-                        arr[num_tokens] = g_strdup(g_strstrip(token));
-                        num_tokens++;
-                        token = strsep(&tmp, ",");
+                arr = g_strsplit(string, ",", 0);
+                for (int i = 0; arr[i]; i++){
+                        g_strstrip(arr[i]);
                 }
-                arr[num_tokens] = NULL;
-                g_free(dup);
         }
         return arr;
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -23,6 +23,15 @@
 #define S2US(s) (((gint64)(s)) * 1000 * 1000)
 
 /**
+ * Frees an array of strings whose last element is a NULL pointer.
+ *
+ * Assumes the last element is a NULL pointer, otherwise will result in a buffer overflow.
+
+ * @param arr The array of strings to free
+ */
+void free_string_array(char **arr);
+
+/**
  * Replaces all occurrences of the char \p needle with the char \p replacement in \p haystack.
  *
  * Does not allocate a new string.
@@ -81,6 +90,17 @@ char *string_strip_quotes(const char *value);
  * @param b Ending delimiter
  */
 void string_strip_delimited(char *str, char a, char b);
+
+/**
+ * Parse a comma-delimited string into a dynamic array of tokens
+ *
+ * The string is split on commas and strips spaces from tokens. The last element
+ * of the array is NULL in order to avoid passing around a length variable.
+ *
+ * @param string The string to convert to an array
+ * @returns The array of tokens.
+ */
+char **string_to_array(const char *string);
 
 /**
  * Replace tilde and path-specific values with its equivalents

--- a/test/data/test-ini
+++ b/test/data/test-ini
@@ -27,6 +27,16 @@
 	unquoted_comment = String with a # comment
 	color_comment = "#ffffff" # comment
 
+[list]
+	simple = A,simple,list
+	spaces = A, list, with, spaces
+	multiword = A list, with, multiword entries
+	quoted = "A, quoted, list"
+	quoted_with_quotes = "A, list, "with quotes""
+	unquoted_with_quotes = A, list, "with quotes"
+	quoted_comment = "List, with, a" # comment
+	unquoted_comment = List, with, a # comment
+
 [path]
 	expand_tilde    = ~/.path/to/tilde
 


### PR DESCRIPTION
This PR introduces functions for parsing configuration options provided in `dunstrc` or on the command line as comma-separated lists of one or more values. Elements are separated by single commas, and trailing whitespace around commas is trimmed, although whitespace in the middle of elements is preserved. Additionally, it makes use of this new parsing by changing the `mouse_left_click`, `mouse_middle_click`, and `mouse_right_click` options to be lists instead of just strings. Current config files are not broken by this. Some tests are provided, though any suggestions or improvements to better the style and code coverage of said tests is appreciated.

Implements #690.