### PR TITLE
Allow toggling pause state via dunstctl

### DIFF
--- a/docs/dunst.pod
+++ b/docs/dunst.pod
@@ -872,8 +872,8 @@ Example time: "1000ms" "10m"
 
 =head1 MISCELLANEOUS
 
-Dunst can be paused via the `dunstctl set-running false` command. To unpause dunst use
-`dunstctl set-status true` and to unpause `dunstctl set-status false`.
+Dunst can be paused via the `dunstctl set-paused true` command. To unpause dunst use
+`dunstctl set-paused false`.
 Alternatively you can send SIGUSR1 and SIGUSR2 to pause and unpause
 respectively. For Example:
 

--- a/docs/dunstctl.pod
+++ b/docs/dunstctl.pod
@@ -35,15 +35,15 @@ Redisplay the notification that was most recently closed. This can be called
 multiple times to show older notifications, up to the history limit configured
 in dunst.
 
-=item B<running>
+=item B<is-paused>
 
 Check if dunst is currently running or paused. If dunst is paused notifications
 will be kept but not shown until it is unpaused.
 
-=item B<set-running> true/false/toggle
+=item B<set-paused> true/false/toggle
 
-Set the paused status of dunst. If true, dunst is running normally, if false,
-dunst is paused. See the running command and the dunst man page for more
+Set the paused status of dunst. If false, dunst is running normally, if true,
+dunst is paused. See the is-paused command and the dunst man page for more
 information.
 
 =item B<debug>

--- a/docs/dunstctl.pod
+++ b/docs/dunstctl.pod
@@ -40,7 +40,7 @@ in dunst.
 Check if dunst is currently running or paused. If dunst is paused notifications
 will be kept but not shown until it is unpaused.
 
-=item B<set-running> true/false
+=item B<set-running> true/false/toggle
 
 Set the paused status of dunst. If true, dunst is running normally, if false,
 dunst is paused. See the running command and the dunst man page for more

--- a/dunstctl
+++ b/dunstctl
@@ -45,11 +45,11 @@ property_set() {
 }
 
 invert_boolean() {
-        if [ "${1}" = "true" ]; then
-            printf "%s\n" "false"
-        elif [ "${1}" = "false" ]; then
-            printf "%s\n" "true"
-        fi
+	if [ "${1}" = "true" ]; then
+		printf "%s\n" "false"
+	elif [ "${1}" = "false" ]; then
+		printf "%s\n" "true"
+	fi
 }
 
 command -v dbus-send >/dev/null 2>/dev/null || \
@@ -73,28 +73,28 @@ case "${1:-}" in
 		method_call "${DBUS_IFAC_DUNST}.NotificationShow" >/dev/null
 		;;
 	"is-paused")
-                running=$(property_get running | ( read -r _ _ running; printf "%s\n" "${running}"; ))
-                # invert boolean to indiciate pause status rather than running one
-                paused=$(invert_boolean "${running}")
-                printf "%s\n" "${paused}"
+		running=$(property_get running | ( read -r _ _ running; printf "%s\n" "${running}"; ))
+		# invert boolean to indiciate pause status rather than running one
+		paused=$(invert_boolean "${running}")
+		printf "%s\n" "${paused}"
 		;;
 	"set-paused")
 		[ "${2:-}" ] \
 			|| die "No status parameter specified. Please give either 'true', 'false' or 'toggle' as paused parameter."
 		[ "${2}" = "true" ] || [ "${2}" = "false" ] || [ "${2}" = "toggle" ] \
 			|| die "Please give either 'true', 'false' or 'toggle' as paused parameter."
-                if [ "${2}" = "toggle" ]; then
-                    running=$(property_get running | ( read -r _ _ running; printf "%s\n" "${running}"; ))
-                    if [ "${running}" = "true" ]; then
-                        property_set running variant:boolean:false
-                    else
-                        property_set running variant:boolean:true
-                    fi
-                else
-                    # invert boolean to indiciate running status rather than pause one
-                    running=$(invert_boolean "${2}")
-		    property_set running variant:boolean:"${running}"
-                fi
+		if [ "${2}" = "toggle" ]; then
+			running=$(property_get running | ( read -r _ _ running; printf "%s\n" "${running}"; ))
+			if [ "${running}" = "true" ]; then
+				property_set running variant:boolean:false
+			else
+				property_set running variant:boolean:true
+			fi
+		else
+			# invert boolean to indiciate running status rather than pause one
+			running=$(invert_boolean "${2}")
+			property_set running variant:boolean:"${running}"
+		fi
 		;;
 	"help"|"--help"|"-h")
 		show_help

--- a/dunstctl
+++ b/dunstctl
@@ -14,17 +14,17 @@ show_help() {
 	cat <<-EOH
 	Usage: dunstctl <command> [parameters]"
 	Commands:
-	  action                          Perform the default action, or open the
-	                                  context menu of the notification at the
-	                                  given position
-	  close                           Close the last notification
-	  close-all                       Close the all notifications
-	  context                         Open context menu
-	  history-pop                     Pop one notification from history
-	  running                         Check if dunst is running or paused
-	  set-running [true|false|toggle] Set the pause status
-	  debug                           Print debugging information
-	  help                            Show this help
+	  action                         Perform the default action, or open the
+	                                 context menu of the notification at the
+	                                 given position
+	  close                          Close the last notification
+	  close-all                      Close the all notifications
+	  context                        Open context menu
+	  history-pop                    Pop one notification from history
+	  is-paused                      Check if dunst is running or paused
+	  set-paused [true|false|toggle] Set the pause status
+	  debug                          Print debugging information
+	  help                           Show this help
 	EOH
 }
 dbus_send_checked() {
@@ -42,6 +42,14 @@ property_get() {
 
 property_set() {
 	dbus_send_checked --print-reply=literal --dest="${DBUS_NAME}" "${DBUS_PATH}" "${DBUS_IFAC_PROP}.Set" "string:${DBUS_IFAC_DUNST}" "string:${1}" "${2}"
+}
+
+invert_boolean() {
+        if [ "${1}" = "true" ]; then
+            printf "%s\n" "false"
+        elif [ "${1}" = "false" ]; then
+            printf "%s\n" "true"
+        fi
 }
 
 command -v dbus-send >/dev/null 2>/dev/null || \
@@ -64,23 +72,28 @@ case "${1:-}" in
 	"history-pop")
 		method_call "${DBUS_IFAC_DUNST}.NotificationShow" >/dev/null
 		;;
-	"running")
-		property_get running | ( read -r _ _ paused; printf "%s\n" "${paused}"; )
+	"is-paused")
+                running=$(property_get running | ( read -r _ _ running; printf "%s\n" "${running}"; ))
+                # invert boolean to indiciate pause status rather than running one
+                paused=$(invert_boolean "${running}")
+                printf "%s\n" "${paused}"
 		;;
-	"set-running")
+	"set-paused")
 		[ "${2:-}" ] \
-			|| die "No status parameter specified. Please give either 'true', 'false' or 'toggle' as running parameter."
+			|| die "No status parameter specified. Please give either 'true', 'false' or 'toggle' as paused parameter."
 		[ "${2}" = "true" ] || [ "${2}" = "false" ] || [ "${2}" = "toggle" ] \
-			|| die "Please give either 'true', 'false' or 'toggle' as running parameter."
+			|| die "Please give either 'true', 'false' or 'toggle' as paused parameter."
                 if [ "${2}" = "toggle" ]; then
-                    paused=$(property_get running | ( read -r _ _ paused; printf "%s\n" "${paused}"; ))
-                    if [ "${paused}" = "true" ]; then
+                    running=$(property_get running | ( read -r _ _ running; printf "%s\n" "${running}"; ))
+                    if [ "${running}" = "true" ]; then
                         property_set running variant:boolean:false
                     else
                         property_set running variant:boolean:true
                     fi
                 else
-		    property_set running variant:boolean:"${2}"
+                    # invert boolean to indiciate running status rather than pause one
+                    running=$(invert_boolean "${2}")
+		    property_set running variant:boolean:"${running}"
                 fi
 		;;
 	"help"|"--help"|"-h")

--- a/dunstctl
+++ b/dunstctl
@@ -14,17 +14,17 @@ show_help() {
 	cat <<-EOH
 	Usage: dunstctl <command> [parameters]"
 	Commands:
-	  action                   Perform the default action, or open the
-	                           context menu of the notification at the
-	                           given position
-	  close                    Close the last notification
-	  close-all                Close the all notifications
-	  context                  Open context menu
-	  history-pop              Pop one notification from history
-	  running                  Check if dunst is running or paused
-	  set-running [true|false] Set the pause status
-	  debug                    Print debugging information
-	  help                     Show this help
+	  action                          Perform the default action, or open the
+	                                  context menu of the notification at the
+	                                  given position
+	  close                           Close the last notification
+	  close-all                       Close the all notifications
+	  context                         Open context menu
+	  history-pop                     Pop one notification from history
+	  running                         Check if dunst is running or paused
+	  set-running [true|false|toggle] Set the pause status
+	  debug                           Print debugging information
+	  help                            Show this help
 	EOH
 }
 dbus_send_checked() {
@@ -69,10 +69,19 @@ case "${1:-}" in
 		;;
 	"set-running")
 		[ "${2:-}" ] \
-			|| die "No status parameter specified. Please give either 'true' or 'false' as running parameter."
-		[ "${2}" = "true" ] || [ "${2}" = "false" ] \
-			|| die "Please give either 'true' or 'false' as running parameter."
-		property_set running variant:boolean:"${2}"
+			|| die "No status parameter specified. Please give either 'true', 'false' or 'toggle' as running parameter."
+		[ "${2}" = "true" ] || [ "${2}" = "false" ] || [ "${2}" = "toggle" ] \
+			|| die "Please give either 'true', 'false' or 'toggle' as running parameter."
+                if [ "${2}" = "toggle" ]; then
+                    paused=$(property_get running | ( read -r _ _ paused; printf "%s\n" "${paused}"; ))
+                    if [ "${paused}" = "true" ]; then
+                        property_set running variant:boolean:false
+                    else
+                        property_set running variant:boolean:true
+                    fi
+                else
+		    property_set running variant:boolean:"${2}"
+                fi
 		;;
 	"help"|"--help"|"-h")
 		show_help

--- a/dunstctl
+++ b/dunstctl
@@ -44,14 +44,6 @@ property_set() {
 	dbus_send_checked --print-reply=literal --dest="${DBUS_NAME}" "${DBUS_PATH}" "${DBUS_IFAC_PROP}.Set" "string:${DBUS_IFAC_DUNST}" "string:${1}" "${2}"
 }
 
-invert_boolean() {
-	if [ "${1}" = "true" ]; then
-		printf "%s\n" "false"
-	elif [ "${1}" = "false" ]; then
-		printf "%s\n" "true"
-	fi
-}
-
 command -v dbus-send >/dev/null 2>/dev/null || \
 	die "Command dbus-send not found"
 
@@ -73,10 +65,7 @@ case "${1:-}" in
 		method_call "${DBUS_IFAC_DUNST}.NotificationShow" >/dev/null
 		;;
 	"is-paused")
-		running=$(property_get running | ( read -r _ _ running; printf "%s\n" "${running}"; ))
-		# invert boolean to indiciate pause status rather than running one
-		paused=$(invert_boolean "${running}")
-		printf "%s\n" "${paused}"
+		property_get paused | ( read -r _ _ paused; printf "%s\n" "${paused}"; )
 		;;
 	"set-paused")
 		[ "${2:-}" ] \
@@ -84,16 +73,14 @@ case "${1:-}" in
 		[ "${2}" = "true" ] || [ "${2}" = "false" ] || [ "${2}" = "toggle" ] \
 			|| die "Please give either 'true', 'false' or 'toggle' as paused parameter."
 		if [ "${2}" = "toggle" ]; then
-			running=$(property_get running | ( read -r _ _ running; printf "%s\n" "${running}"; ))
-			if [ "${running}" = "true" ]; then
-				property_set running variant:boolean:false
+			paused=$(property_get paused | ( read -r _ _ paused; printf "%s\n" "${paused}"; ))
+			if [ "${paused}" = "true" ]; then
+				property_set paused variant:boolean:false
 			else
-				property_set running variant:boolean:true
+				property_set paused variant:boolean:true
 			fi
 		else
-			# invert boolean to indiciate running status rather than pause one
-			running=$(invert_boolean "${2}")
-			property_set running variant:boolean:"${running}"
+			property_set paused variant:boolean:"$2"
 		fi
 		;;
 	"help"|"--help"|"-h")

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -81,7 +81,7 @@ static const char *introspection_xml =
     "        <method name=\"NotificationShow\"      />"
     "        <method name=\"Ping\"                  />"
 
-    "        <property name=\"running\" type=\"b\" access=\"readwrite\">"
+    "        <property name=\"paused\" type=\"b\" access=\"readwrite\">"
     "            <annotation name=\"org.freedesktop.DBus.Property.EmitsChangedSignal\" value=\"true\"/>"
     "        </property>"
 

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -589,7 +589,7 @@ GVariant *dbus_cb_dunst_Properties_Get(GDBusConnection *connection,
         struct dunst_status status = dunst_status_get();
 
         if (STR_EQ(property_name, "paused")) {
-                return !g_variant_new_boolean(status.running);
+                return g_variant_new_boolean(!status.running);
         } else {
                 LOG_W("Unknown property!\n");
                 *error = g_error_new(G_DBUS_ERROR, G_DBUS_ERROR_UNKNOWN_PROPERTY, "Unknown property");

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -588,8 +588,8 @@ GVariant *dbus_cb_dunst_Properties_Get(GDBusConnection *connection,
 {
         struct dunst_status status = dunst_status_get();
 
-        if (STR_EQ(property_name, "running")) {
-                return g_variant_new_boolean(status.running);
+        if (STR_EQ(property_name, "paused")) {
+                return !g_variant_new_boolean(status.running);
         } else {
                 LOG_W("Unknown property!\n");
                 *error = g_error_new(G_DBUS_ERROR, G_DBUS_ERROR_UNKNOWN_PROPERTY, "Unknown property");
@@ -606,8 +606,8 @@ gboolean dbus_cb_dunst_Properties_Set(GDBusConnection *connection,
                                       GError **error,
                                       gpointer user_data)
 {
-        if (STR_EQ(property_name, "running")) {
-                dunst_status(S_RUNNING, g_variant_get_boolean(value));
+        if (STR_EQ(property_name, "paused")) {
+                dunst_status(S_RUNNING, !g_variant_get_boolean(value));
                 wake_up();
                 return true;
         }


### PR DESCRIPTION
Implements the feature proposed in #709 to allow toggling the pause state via `dunstctl`.
This also fixes #710 to improve user intuition.