### PR TITLE
Fix ugly frame

### DIFF
--- a/src/draw.c
+++ b/src/draw.c
@@ -464,25 +464,25 @@ static cairo_surface_t *render_background(cairo_surface_t *srf,
         else
                 height += settings.separator_height;
 
-	if (settings.frame_width > 0)
+        if (settings.frame_width > 0)
         {
-            cairo_set_source_rgb(c, cl->frame.r, cl->frame.g, cl->frame.b);
-            draw_rounded_rect(c, x, y, width, height, corner_radius, first, last);
-            cairo_fill(c);
+                cairo_set_source_rgb(c, cl->frame.r, cl->frame.g, cl->frame.b);
+                draw_rounded_rect(c, x, y, width, height, corner_radius, first, last);
+                cairo_fill(c);
 
-            /* adding frame */
-            x += settings.frame_width;
-            if (first) {
-                    y += settings.frame_width;
-                    height -= settings.frame_width;
-            }
+                /* adding frame */
+                x += settings.frame_width;
+                if (first) {
+                        y += settings.frame_width;
+                        height -= settings.frame_width;
+                }
 
-            width -= 2 * settings.frame_width;
+                width -= 2 * settings.frame_width;
 
-            if (last)
-                    height -= settings.frame_width;
-            else
-                    height -= settings.separator_height;
+                if (last)
+                        height -= settings.frame_width;
+                else
+                        height -= settings.separator_height;
         }
 
         cairo_set_source_rgb(c, cl->bg.r, cl->bg.g, cl->bg.b);

--- a/src/draw.c
+++ b/src/draw.c
@@ -416,7 +416,7 @@ static int frame_internal_radius (int r, int w, int h)
  * The top corners will get rounded by `corner_radius`, if `first` is set.
  * Respectably the same for `last` with the bottom corners.
  */
-static void draw_rounded_rect(cairo_t *c, int x, int y, int width, int height, int corner_radius, bool first, bool last)
+void draw_rounded_rect(cairo_t *c, int x, int y, int width, int height, int corner_radius, bool first, bool last)
 {
         const float degrees = M_PI / 180.0;
 

--- a/src/draw.c
+++ b/src/draw.c
@@ -464,23 +464,26 @@ static cairo_surface_t *render_background(cairo_surface_t *srf,
         else
                 height += settings.separator_height;
 
-        cairo_set_source_rgb(c, cl->frame.r, cl->frame.g, cl->frame.b);
-        draw_rounded_rect(c, x, y, width, height, corner_radius, first, last);
-        cairo_fill(c);
+	if (settings.frame_width > 0)
+        {
+            cairo_set_source_rgb(c, cl->frame.r, cl->frame.g, cl->frame.b);
+            draw_rounded_rect(c, x, y, width, height, corner_radius, first, last);
+            cairo_fill(c);
 
-        /* adding frame */
-        x += settings.frame_width;
-        if (first) {
-                y += settings.frame_width;
-                height -= settings.frame_width;
+            /* adding frame */
+            x += settings.frame_width;
+            if (first) {
+                    y += settings.frame_width;
+                    height -= settings.frame_width;
+            }
+
+            width -= 2 * settings.frame_width;
+
+            if (last)
+                    height -= settings.frame_width;
+            else
+                    height -= settings.separator_height;
         }
-
-        width -= 2 * settings.frame_width;
-
-        if (last)
-                height -= settings.frame_width;
-        else
-                height -= settings.separator_height;
 
         cairo_set_source_rgb(c, cl->bg.r, cl->bg.g, cl->bg.b);
         draw_rounded_rect(c, x, y, width, height, corner_radius, first, last);

--- a/src/draw.h
+++ b/src/draw.h
@@ -8,6 +8,8 @@ void draw_setup(void);
 
 void draw(void);
 
+void draw_rounded_rect(cairo_t *c, int x, int y, int width, int height, int corner_radius, bool first, bool last);
+
 void draw_deinit(void);
 
 #endif

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -89,11 +89,6 @@ static void x_win_round_corners(struct window_x11 *win, const int rad)
 {
         const int width = win->dim.w;
         const int height = win->dim.h;
-        unsigned const int coords[] = {
-	        0 + rad,
-                width - rad,
-                height - rad,
-        };
 
         Pixmap mask;
         cairo_surface_t * cxbm;
@@ -112,12 +107,10 @@ static void x_win_round_corners(struct window_x11 *win, const int rad)
         cairo_paint(cr);
         cairo_set_source_rgba(cr, 1, 1, 1, 1);
 
-        cairo_new_path(cr);
-        cairo_arc(cr, coords[0], coords[0], rad,  M_PI,   -M_PI_2);
-        cairo_arc(cr, coords[1], coords[0], rad, -M_PI_2,  0);
-        cairo_arc(cr, coords[1], coords[2], rad,  0,       M_PI_2);
-        cairo_arc(cr, coords[0], coords[2], rad,  M_PI_2,  M_PI);
-        cairo_close_path(cr);
+        draw_rounded_rect(cr, 0, 0,
+                          width, height,
+                          rad,
+                          true, true);
         cairo_fill(cr);
 
         cairo_show_page(cr);

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -110,9 +110,9 @@ static void x_win_round_corners(struct window_x11 *win, const int rad)
 
         /* To mark all pixels, which should get exposed, we
          * use a circle for every corner and two overlapping rectangles */
-	int fw = settings.frame_width / 2 + settings.frame_width % 2;
-	if (fw < 1)
-		fw=1;
+        int fw = settings.frame_width / 2 + settings.frame_width % 2;
+        if (fw < 1)
+                fw=1;
         unsigned const int centercoords[] = {
                 -fw,             -fw,
                 width - dia - 1, -fw,

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -110,13 +110,10 @@ static void x_win_round_corners(struct window_x11 *win, const int rad)
 
         /* To mark all pixels, which should get exposed, we
          * use a circle for every corner and two overlapping rectangles */
-        int fw = settings.frame_width / 2 + settings.frame_width % 2;
-        if (fw < 1)
-                fw = 1;
         unsigned const int centercoords[] = {
-                -fw,             -fw,
-                width - dia - 1, -fw,
-                -fw,             height - dia - 1,
+                0,            0,
+                width - dia - 1, 0,
+                0,               height - dia - 1,
                 width - dia - 1, height - dia - 1,
         };
 
@@ -124,10 +121,10 @@ static void x_win_round_corners(struct window_x11 *win, const int rad)
                 XFillArc(xctx.dpy,
                          mask,
                          shape_gc,
-                         centercoords[i],
-                         centercoords[i+1],
-                         dia+fw,
-                         dia+fw,
+                         centercoords[i]-1,
+                         centercoords[i+1]-1,
+                         dia+2,
+                         dia+2,
                          degrees * 0,
                          degrees * 360);
         }

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -160,6 +160,9 @@ void x_display_surface(cairo_surface_t *srf, struct window_x11 *win, const struc
         x_win_move(win, dim->x, dim->y, dim->w, dim->h);
         cairo_xlib_surface_set_size(win->root_surface, dim->w, dim->h);
 
+        XClearWindow(xctx.dpy, win->xwin);
+        XFlush(xctx.dpy);
+
         cairo_set_source_surface(win->c_ctx, srf, 0, 0);
         cairo_paint(win->c_ctx);
         cairo_show_page(win->c_ctx);
@@ -650,6 +653,7 @@ struct window_x11 *x_win_create(void)
 
         wa.override_redirect = true;
         wa.background_pixmap = ParentRelative;
+        wa.background_pixel = 0;
         wa.event_mask =
             ExposureMask | KeyPressMask | VisibilityChangeMask |
             ButtonReleaseMask | FocusChangeMask| StructureNotifyMask;
@@ -665,7 +669,7 @@ struct window_x11 *x_win_create(void)
                                  DefaultDepth(xctx.dpy, DefaultScreen(xctx.dpy)),
                                  CopyFromParent,
                                  DefaultVisual(xctx.dpy, DefaultScreen(xctx.dpy)),
-                                 CWOverrideRedirect | CWBackPixmap | CWEventMask,
+                                 CWOverrideRedirect | CWBackPixmap | CWBackPixel | CWEventMask,
                                  &wa);
 
         x_set_wm(win->xwin);

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -136,6 +136,7 @@ static void x_win_round_corners(struct window_x11 *win, const int rad)
 void x_display_surface(cairo_surface_t *srf, struct window_x11 *win, const struct dimensions *dim)
 {
         char astr[sizeof("_NET_WM_CM_S") / sizeof(char) + 8];
+        Atom cm_sel;
 
         x_win_move(win, dim->x, dim->y, dim->w, dim->h);
         cairo_xlib_surface_set_size(win->root_surface, dim->w, dim->h);
@@ -147,8 +148,8 @@ void x_display_surface(cairo_surface_t *srf, struct window_x11 *win, const struc
         cairo_paint(win->c_ctx);
         cairo_show_page(win->c_ctx);
 
-        sprintf (astr, "_NET_WM_CM_S%i", win->cur_screen);
-        Atom cm_sel = XInternAtom (xctx.dpy, astr, true);
+        sprintf(astr, "_NET_WM_CM_S%i", win->cur_screen);
+        cm_sel = XInternAtom(xctx.dpy, astr, true);
         if (settings.corner_radius != 0 && XGetSelectionOwner(xctx.dpy, cm_sel) == None)
                 x_win_round_corners(win, dim->corner_radius);
         else

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -110,10 +110,13 @@ static void x_win_round_corners(struct window_x11 *win, const int rad)
 
         /* To mark all pixels, which should get exposed, we
          * use a circle for every corner and two overlapping rectangles */
+	int fw = settings.frame_width / 2 + settings.frame_width % 2;
+	if (fw < 1)
+		fw=1;
         unsigned const int centercoords[] = {
-                0,               0,
-                width - dia - 1, 0,
-                0,               height - dia - 1,
+                -fw,             -fw,
+                width - dia - 1, -fw,
+                -fw,             height - dia - 1,
                 width - dia - 1, height - dia - 1,
         };
 
@@ -123,8 +126,8 @@ static void x_win_round_corners(struct window_x11 *win, const int rad)
                          shape_gc,
                          centercoords[i],
                          centercoords[i+1],
-                         dia,
-                         dia,
+                         dia+fw,
+                         dia+fw,
                          degrees * 0,
                          degrees * 360);
         }

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -651,13 +651,10 @@ struct window_x11 *x_win_create(void)
 
         scr_n = DefaultScreen(xctx.dpy);
         root = RootWindow(xctx.dpy, scr_n);
-        if (XMatchVisualInfo(xctx.dpy, scr_n, 32, TrueColor, &vi))
-        {
+        if (XMatchVisualInfo(xctx.dpy, scr_n, 32, TrueColor, &vi)) {
                 vis  = vi.visual;
                 depth = vi.depth;
-        }
-        else
-        {
+        } else {
                 vis = DefaultVisual(xctx.dpy, scr_n);
                 depth = DefaultDepth(xctx.dpy, scr_n);
         }

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -85,7 +85,7 @@ static void x_win_move(struct window_x11 *win, int x, int y, int width, int heig
         }
 }
 
-static void x_win_round_corners(struct window_x11 *win, const int rad)
+static void x_win_corners_shape(struct window_x11 *win, const int rad)
 {
         const int width = win->dim.w;
         const int height = win->dim.h;
@@ -161,8 +161,8 @@ void x_display_surface(cairo_surface_t *srf, struct window_x11 *win, const struc
         cairo_paint(win->c_ctx);
         cairo_show_page(win->c_ctx);
 
-                x_win_round_corners(win, dim->corner_radius);
         if (settings.corner_radius != 0 && ! x_win_composited(win))
+                x_win_corners_shape(win, dim->corner_radius);
         else
                 x_win_corners_unshape(win);
 

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -112,7 +112,7 @@ static void x_win_round_corners(struct window_x11 *win, const int rad)
          * use a circle for every corner and two overlapping rectangles */
         int fw = settings.frame_width / 2 + settings.frame_width % 2;
         if (fw < 1)
-                fw=1;
+                fw = 1;
         unsigned const int centercoords[] = {
                 -fw,             -fw,
                 width - dia - 1, -fw,

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -648,18 +648,29 @@ struct window_x11 *x_win_create(void)
 
         Window root;
         int scr_n;
+        int depth;
+        Visual * vis;
         XVisualInfo vi;
         XSetWindowAttributes wa;
 
         scr_n = DefaultScreen(xctx.dpy);
         root = RootWindow(xctx.dpy, scr_n);
-        XMatchVisualInfo(xctx.dpy, scr_n, 32, TrueColor, &vi);
+        if (XMatchVisualInfo(xctx.dpy, scr_n, 32, TrueColor, &vi))
+        {
+                vis  = vi.visual;
+                depth = vi.depth;
+        }
+        else
+        {
+                vis = DefaultVisual(xctx.dpy, scr_n);
+                depth = DefaultDepth(xctx.dpy, scr_n);
+        }
 
         wa.override_redirect = true;
         wa.background_pixmap = None;
         wa.background_pixel = 0;
         wa.border_pixel = 0;
-        wa.colormap = XCreateColormap(xctx.dpy, root, vi.visual, AllocNone);
+        wa.colormap = XCreateColormap(xctx.dpy, root, vis, AllocNone);
         wa.event_mask =
             ExposureMask | KeyPressMask | VisibilityChangeMask |
             ButtonReleaseMask | FocusChangeMask| StructureNotifyMask;
@@ -672,9 +683,9 @@ struct window_x11 *x_win_create(void)
                                  scr->w,
                                  1,
                                  0,
-                                 vi.depth,
+                                 depth,
                                  CopyFromParent,
-                                 vi.visual,
+                                 vis,
                                  CWOverrideRedirect | CWBackPixmap | CWBackPixel | CWBorderPixel | CWColormap | CWEventMask,
                                  &wa);
 
@@ -686,7 +697,7 @@ struct window_x11 *x_win_create(void)
                                    (0xffffffff / 100)));
 
         win->root_surface = cairo_xlib_surface_create(xctx.dpy, win->xwin,
-                                                      vi.visual,
+                                                      vis,
                                                       WIDTH, HEIGHT);
         win->c_ctx = cairo_create(win->root_surface);
 


### PR DESCRIPTION
1. Original shaping mask caused antialiasing pixels to be cut, leading to ugly look. Solved by increasing mask corder radus by half-borderwidth, but not less than 1pix (for zero-width border).
2. And when border width is set to zero, it should not be painted. Current approach caused transparent pixels from AA to sum, producing subtle edge-like artifact at corners.