### PR TITLE
Change default for icon_position in dunstrc

### DIFF
--- a/dunstrc
+++ b/dunstrc
@@ -164,7 +164,7 @@
     ### Icons ###
 
     # Align icons left/right/off
-    icon_position = off
+    icon_position = left
 
     # Scale small icons up to this size, set to 0 to disable. Helpful
     # for e.g. small files or high-dpi screens. In case of conflict,


### PR DESCRIPTION
Current PR enables by default the notification icons.

On a default installation of dunst these icons are disabled until the user explicitly overrides this setting in their corresponding `dunstrc`.