### PR TITLE
Rgba support

### DIFF
--- a/src/draw.c
+++ b/src/draw.c
@@ -59,61 +59,37 @@ static struct color hex_to_color(uintmax_t hexValue, int dpc)
         return ret;
 }
 
-static inline void color_clip(struct color * c)
-{
-        if (c->r > 1.0) c->r = 1.0;
-        if (c->g > 1.0) c->g = 1.0;
-        if (c->b > 1.0) c->b = 1.0;
-        if (c->a > 1.0) c->a = 1.0;
-}
-
 static struct color string_to_color(const char *str)
 {
-        if (str[0] == '#') {
-                uintmax_t val;
-                unsigned clen;
-                {
-                        int cn;
-
-                        /* accept 3 or 4 equal components */ {
-                                char *end;
-                                val = strtoumax(str+1, &end, 16);
-                                if (errno == ERANGE || (end[0] != '\0' && end[1] != '\0'))
-                                        goto err;
-
-                                const int len = (end - (str+1));
-                                if      (len % 3 == 0) cn = 3;
-                                else if (len % 4 == 0) cn = 4;
-                                else    goto err;
-                                clen = len / cn;
-                        }
-                        /* component length must be 2^n */ {
-                                unsigned mask = 1;
-                                while(mask < clen) mask <<= 1;
-                                if  (mask != clen) goto err;
-                        }
-                        /* turn 3-component to opaque 4-components */ {
-                                const unsigned csize = clen * 4;
-                                if (cn == 3)
-                                        val = (val << csize) | UINT_MAX_N(csize);
-                        }
-                }
-                return hex_to_color(val, clen);
-        }
-
-        /* rgba(fp, fp, fp, fp) */
+        uintmax_t val;
+        unsigned clen;
         {
-                struct color col;
-                if (sscanf(str, "rgba ( %lf , %lf , %lf , %lf )", &col.r, &col.g, &col.b, &col.a) == 4) {
-                        color_clip(&col);
-                        return col;
+                int cn;
+
+                /* accept 3 or 4 equal components */ {
+                        char *end;
+                        val = strtoumax(str+1, &end, 16);
+                        if (errno == ERANGE || (end[0] != '\0' && end[1] != '\0'))
+                                goto err;
+
+                        const int len = (end - (str+1));
+                        if      (len % 3 == 0) cn = 3;
+                        else if (len % 4 == 0) cn = 4;
+                        else    goto err;
+                        clen = len / cn;
                 }
-                if (sscanf(str, "rgb ( %lf , %lf , %lf )", &col.r, &col.g, &col.b) == 3) {
-                        color_clip(&col);
-                        col.a = 1.0;
-                        return col;
+                /* component length must be 2^n */ {
+                        unsigned mask = 1;
+                        while(mask < clen) mask <<= 1;
+                        if  (mask != clen) goto err;
+                }
+                /* turn 3-component to opaque 4-components */ {
+                        const unsigned csize = clen * 4;
+                        if (cn == 3)
+                                val = (val << csize) | UINT_MAX_N(csize);
                 }
         }
+        return hex_to_color(val, clen);
 
         /* return black on error */
         err:

--- a/src/draw.c
+++ b/src/draw.c
@@ -35,7 +35,7 @@ struct window_x11 *win;
 
 PangoFontDescription *pango_fdesc;
 
-#define UINT_MAX_N(bits) (1 << (bits-1) | (( 1 << (bits-1) ) - 1))
+#define UINT_MAX_N(bits) ((1 << bits) - 1)
 
 void draw_setup(void)
 {

--- a/src/draw.c
+++ b/src/draw.c
@@ -61,12 +61,12 @@ static struct color hex_to_color(uint32_t hexValue, int dpc)
 static struct color string_to_color(const char *str)
 {
         char *end;
-        uint32_t val = strtoul(str+1, &end, 16);
-        if (*end != '\0' && *(end+1) != '\0') {
+        uint_fast32_t val = strtoul(str+1, &end, 16);
+        if (end[0] != '\0' && end[1] != '\0') {
                 LOG_W("Invalid color string: '%s'", str);
         }
 
-        switch (strlen(str+1)) {
+        switch (end - (str+1)) {
                 case 3:  return hex_to_color((val << 4) | 0xF, 1);
                 case 6:  return hex_to_color((val << 8) | 0xFF, 2);
                 case 4:  return hex_to_color(val, 1);

--- a/src/draw.c
+++ b/src/draw.c
@@ -581,7 +581,7 @@ static cairo_surface_t *render_background(cairo_surface_t *srf,
         cairo_set_source_rgba(c, cl->bg.r, cl->bg.g, cl->bg.b, cl->bg.a);
         cairo_fill(c);
 
-        cairo_set_operator(c, CAIRO_OPERATOR_OVER);
+        cairo_set_operator(c, CAIRO_OPERATOR_SOURCE);
 
         if (   settings.sep_color.type != SEP_FRAME
             && settings.separator_height > 0

--- a/src/draw.c
+++ b/src/draw.c
@@ -488,8 +488,7 @@ static cairo_surface_t *render_background(cairo_surface_t *srf,
         else
                 height += settings.separator_height;
 
-        if (settings.frame_width > 0)
-        {
+        if (settings.frame_width > 0) {
                 cairo_set_source_rgb(c, cl->frame.r, cl->frame.g, cl->frame.b);
                 draw_rounded_rect(c, x, y, width, height, corner_radius, first, last);
                 cairo_fill(c);

--- a/src/draw.c
+++ b/src/draw.c
@@ -481,6 +481,12 @@ static cairo_surface_t *render_background(cairo_surface_t *srf,
 
         cairo_t *c = cairo_create(srf);
 
+        /* stroke area doesn't intersect with main area */
+        cairo_set_fill_rule(c, CAIRO_FILL_RULE_EVEN_ODD);
+
+        /* for correct combination of adjacent areas */
+        cairo_set_operator(c, CAIRO_OPERATOR_ADD);
+
         if (first)
                 height += settings.frame_width;
         if (last)
@@ -489,9 +495,7 @@ static cairo_surface_t *render_background(cairo_surface_t *srf,
                 height += settings.separator_height;
 
         if (settings.frame_width > 0) {
-                cairo_set_source_rgb(c, cl->frame.r, cl->frame.g, cl->frame.b);
                 draw_rounded_rect(c, x, y, width, height, corner_radius, first, last);
-                cairo_fill(c);
 
                 /* adding frame */
                 x += settings.frame_width;
@@ -508,11 +512,17 @@ static cairo_surface_t *render_background(cairo_surface_t *srf,
                         height -= settings.separator_height;
 
                 radius_int = frame_internal_radius (corner_radius, settings.frame_width, height);
+
+                draw_rounded_rect(c, x, y, width, height, radius_int, first, last);
+                cairo_set_source_rgb(c, cl->frame.r, cl->frame.g, cl->frame.b);
+                cairo_fill(c);
         }
 
-        cairo_set_source_rgb(c, cl->bg.r, cl->bg.g, cl->bg.b);
         draw_rounded_rect(c, x, y, width, height, radius_int, first, last);
+        cairo_set_source_rgb(c, cl->bg.r, cl->bg.g, cl->bg.b);
         cairo_fill(c);
+
+        cairo_set_operator(c, CAIRO_OPERATOR_OVER);
 
         if (   settings.sep_color.type != SEP_FRAME
             && settings.separator_height > 0

--- a/src/draw.c
+++ b/src/draw.c
@@ -10,6 +10,7 @@
 #include <pango/pango-types.h>
 #include <stdlib.h>
 #include <inttypes.h>
+#include <errno.h>
 
 #include "dunst.h"
 #include "icon.h"
@@ -44,7 +45,7 @@ void draw_setup(void)
         pango_fdesc = pango_font_description_from_string(settings.font);
 }
 
-static struct color hex_to_color(uint32_t hexValue, int dpc)
+static struct color hex_to_color(uintmax_t hexValue, int dpc)
 {
         const int bpc = 4 * dpc;
         const unsigned single_max = UINT_MAX_N(bpc);
@@ -60,20 +61,38 @@ static struct color hex_to_color(uint32_t hexValue, int dpc)
 
 static struct color string_to_color(const char *str)
 {
-        char *end;
-        uint32_t val = strtoul(str+1, &end, 16);
-        if (*end != '\0' && *(end+1) != '\0') {
-                LOG_W("Invalid color string: '%s'", str);
-        }
+        uintmax_t val;
+        unsigned clen;
+        {
+                int cn;
 
-        switch (strlen(str+1)) {
-                case 3:  return hex_to_color((val << 4) | 0xF, 1);
-                case 6:  return hex_to_color((val << 8) | 0xFF, 2);
-                case 4:  return hex_to_color(val, 1);
-                case 8:  return hex_to_color(val, 2);
+                /* accept 3 or 4 equal components */ {
+                        char *end;
+                        val = strtoumax(str+1, &end, 16);
+                        if (errno == ERANGE || (end[0] != '\0' && end[1] != '\0'))
+                                goto err;
+
+                        const int len = (end - (str+1));
+                        if      (len % 3 == 0) cn = 3;
+                        else if (len % 4 == 0) cn = 4;
+                        else    goto err;
+                        clen = len / cn;
+                }
+                /* component length must be 2^n */ {
+                        unsigned mask = 1;
+                        while(mask < clen) mask <<= 1;
+                        if  (mask != clen) goto err;
+                }
+                /* turn 3-component to opaque 4-components */ {
+                        const unsigned csize = clen * 4;
+                        if (cn == 3)
+                                val = (val << csize) | UINT_MAX_N(csize);
+                }
         }
+        return hex_to_color(val, clen);
 
         /* return black on error */
+        err:
         LOG_W("Invalid color string: '%s'", str);
         return hex_to_color(0xF, 1);
 }

--- a/src/x11/x.h
+++ b/src/x11/x.h
@@ -44,6 +44,7 @@ struct color {
         double r;
         double g;
         double b;
+        double a;
 };
 
 extern struct x_context xctx;


### PR DESCRIPTION
Besides core rgba support I tried to implement support for arbitrary hex color string length (though limited by maximum unsigned length for given machine), as well as rgba() and rgb() formats, using scanf.

What's also interesting, adjacent non-overlaping areas are better to be combined in additive mode, so that fading out pixels at bounds mix correctly. I'm not sure though, if cairo uses alpha channel correctly (must be summed too, not like how it does with multiply op), but at least it removes artifacts between frame and background, visible when both are equally contrast with background.

Btw, imho colors are better to be parsed once on theme loading instead of on each draw().