### PR TITLE
Add ignore_dbusclose settings

### DIFF
--- a/config.h
+++ b/config.h
@@ -38,6 +38,7 @@ struct settings defaults = {
 .history_length = 20,        /* max amount of notifications kept in history */
 .show_indicators = true,
 .word_wrap = false,
+.ignore_dbusclose = false,
 .ellipsize = ELLIPSE_MIDDLE,
 .ignore_newline = false,
 .line_height = 0,            /* if line height < font height, it will be raised to font height */

--- a/docs/dunst.pod
+++ b/docs/dunst.pod
@@ -515,6 +515,13 @@ Close all notifications.
 
 =back
 
+
+=item B<ignore_dbusclose> (default: false)
+
+Ignore the dbus closeNotification message. This is useful to enforce the timeout
+set by dunst configuration. Without this parameter, an application may close
+the notification sent before the user defined timeout.
+
 =back
 
 =head2 Shortcut section B<DEPRECATED SEE DUNSTCTL>

--- a/dunstrc
+++ b/dunstrc
@@ -224,6 +224,12 @@
     # notification height to avoid clipping text and/or icons.
     corner_radius = 0
 
+    # Ignore the dbus closeNotification message.
+    # Useful to enforce the timeout set by dunst configuration. Without this
+    # parameter, an application may close the notification sent before the 
+    # user defined timeout.
+    ignore_dbusclose = false
+
     ### Legacy
 
     # Use the Xinerama extension instead of RandR for multi-monitor support.

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -494,8 +494,16 @@ static void dbus_cb_CloseNotification(
 {
         guint32 id;
         g_variant_get(parameters, "(u)", &id);
-        if (!settings.ignore_dbusclose) 
+        if (settings.ignore_dbusclose) {
+                // Stay commpliant by lying to the sender,  telling him we closed the notification 
+                if (id > 0) {
+                        struct notification *n = queues_get_by_id(id);
+                        if (n) 
+                                signal_notification_closed(n, REASON_SIG);
+                }
+        } else {
                 queues_notification_close_id(id, REASON_SIG);
+        }
         wake_up();
         g_dbus_method_invocation_return_value(invocation, NULL);
         g_dbus_connection_flush(connection, NULL, NULL, NULL);

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -525,8 +525,6 @@ static void dbus_cb_GetServerInformation(
 void signal_notification_closed(struct notification *n, enum reason reason)
 {
         if (!n->dbus_valid) {
-                LOG_W("Closing notification '%s' not supported. "
-                      "Notification already closed.", n->summary);
                 return;
         }
 

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -494,7 +494,8 @@ static void dbus_cb_CloseNotification(
 {
         guint32 id;
         g_variant_get(parameters, "(u)", &id);
-        queues_notification_close_id(id, REASON_SIG);
+        if (!settings.ignore_dbusclose) 
+                queues_notification_close_id(id, REASON_SIG);
         wake_up();
         g_dbus_method_invocation_return_value(invocation, NULL);
         g_dbus_connection_flush(connection, NULL, NULL, NULL);

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -495,6 +495,7 @@ static void dbus_cb_CloseNotification(
         guint32 id;
         g_variant_get(parameters, "(u)", &id);
         if (settings.ignore_dbusclose) {
+                LOG_D("Ignoring CloseNotification message");
                 // Stay commpliant by lying to the sender,  telling him we closed the notification 
                 if (id > 0) {
                         struct notification *n = queues_get_by_id(id);

--- a/src/queues.c
+++ b/src/queues.c
@@ -506,6 +506,27 @@ gint64 queues_get_next_datachange(gint64 time)
         return sleep != G_MAXINT64 ? sleep : -1;
 }
 
+
+
+
+/* see queues.h */
+struct notification* queues_get_by_id(int id)
+{
+        assert(id > 0);
+
+        GQueue *recqueues[] = { displayed, waiting, history };
+        for (int i = 0; i < sizeof(recqueues)/sizeof(GQueue*); i++) {
+                for (GList *iter = g_queue_peek_head_link(recqueues[i]); iter;
+                     iter = iter->next) {
+                        struct notification *cur = iter->data;
+                        if (cur->id == id)
+                                return cur;
+                }
+        }
+
+        return NULL;
+}
+
 /**
  * Helper function for queues_teardown() to free a single notification
  *
@@ -527,4 +548,6 @@ void queues_teardown(void)
         g_queue_free_full(waiting, teardown_notification);
         waiting = NULL;
 }
+
+
 /* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/queues.h
+++ b/src/queues.h
@@ -146,6 +146,17 @@ void queues_update(struct dunst_status status);
 gint64 queues_get_next_datachange(gint64 time);
 
 /**
+ * Get the notification which has the given id in the displayed and waiting queue or
+ * NULL if not found
+ *
+ * @param the id searched for.
+ *
+ * @return the `id` notification  or NULL
+ */
+struct notification* queues_get_by_id(int id);
+
+
+/**
  * Remove all notifications from all list and free the notifications
  *
  * @pre At least one time queues_init() called

--- a/src/settings.c
+++ b/src/settings.c
@@ -176,6 +176,11 @@ void load_settings(char *cmdline_config_path)
                 "word_wrap", "-word_wrap", defaults.word_wrap,
                 "Truncating long lines or do word wrap"
         );
+        settings.ignore_dbusclose = option_get_bool(
+                "global",
+                "ignore_dbusclose", "-ignore_dbusclose", defaults.ignore_dbusclose,
+                "Ignore dbus CloseNotification events"
+        );
 
         {
                 char *c = option_get_string(

--- a/src/settings.h
+++ b/src/settings.h
@@ -59,6 +59,7 @@ struct settings {
         int history_length;
         int show_indicators;
         int word_wrap;
+        int ignore_dbusclose;
         enum ellipsize ellipsize;
         int ignore_newline;
         int line_height;

--- a/test/queues.c
+++ b/test/queues.c
@@ -740,6 +740,29 @@ TEST test_queues_timeout_before_paused(void)
         PASS();
 }
 
+TEST test_queue_find_by_id(void)
+{
+        struct notification *n;
+        int id;
+        queues_init();
+
+        n = test_notification("n", 0);
+        queues_notification_insert(n);
+        n = test_notification("n1", 0);
+        queues_notification_insert(n);
+        id = n->id;
+        n = test_notification("n2", 0);
+        queues_notification_insert(n);
+
+        n = queues_get_by_id(id);
+
+        ASSERT(n->id == id);
+        ASSERT(!strncmp(n->summary, "n1", 2));
+
+        queues_teardown();
+        PASS();
+}
+
 SUITE(suite_queues)
 {
         settings.icon_path = "";
@@ -770,6 +793,7 @@ SUITE(suite_queues)
         RUN_TEST(test_queues_update_seeping);
         RUN_TEST(test_queues_update_xmore);
         RUN_TEST(test_queues_timeout_before_paused);
+        RUN_TEST(test_queue_find_by_id);
 
         settings.icon_path = NULL;
 }


### PR DESCRIPTION
closes #731

However I was not able to test it because of X BadAtom error:
```
./dunst -print -verbosity debug
{
	appname: 'dunst'
	summary: 'startup'
	body: 'dunst is up and running'
	icon: 'dialog-information'
	raw_icon set: false
	icon_id: 'dialog-information'
	desktop_entry: ''
	category: 
	timeout: 10000
	urgency: LOW
	transient: 0
	formatted: '<b>startup</b>
dunst is up and running'
	fg: #888888
	bg: #222222
	frame: #aaaaaa
	fullscreen: pushback
	progress: -1
	stack_tag: 
	id: 2
	actions: {}
	script: (null)
}
DEBUG: RUN
DEBUG: XEvent: Ignoring '65'
DEBUG: XEvent: processing 'CreateNotify'
DEBUG: XEvent: Checking for active screen changes
DEBUG: XEvent: Checking for active screen changes
DEBUG: XEvent: Checking for active screen changes
DEBUG: XEvent: Checking for active screen changes
DEBUG: XEvent: Ignoring '65'
DEBUG: XEvent: Checking for active screen changes
DEBUG: XEvent: Checking for active screen changes
DEBUG: XEvent: Ignoring '19'
DEBUG: XEvent: Ignoring '19'
DEBUG: XEvent: Ignoring '15'
DEBUG: XEvent: processing 'Expose'
X Error of failed request:  BadAtom (invalid Atom parameter)
  Major opcode of failed request:  23 (X_GetSelectionOwner)
  Atom id in failed request:  0x0
  Serial number of failed request:  218
  Current serial number in output stream:  218
```