### PR TITLE
Fix possible division by zero in radius calculation.

### DIFF
--- a/src/draw.c
+++ b/src/draw.c
@@ -412,7 +412,7 @@ static int layout_get_height(struct colored_layout *cl)
  */
 static int frame_internal_radius (int r, int w, int h)
 {
-        if (r == 0 || w == 0 || h == 0)
+        if (r == 0 || h + (w - r) * 2 == 0)
                 return 0;
 
         // Integer precision scaler, using 1/4 of int size


### PR DESCRIPTION
Check all possible causes of division by zero in the calculation of the radius.

This fixes #746, and correctly checks for division by zero.

Checking `s == 0` too might be a bit overkill though.