### PR TITLE
Add support for keeping notification history in a file (#307)

### DIFF
--- a/config.h
+++ b/config.h
@@ -110,6 +110,8 @@ struct settings defaults = {
 
 .mouse_right_click = (enum mouse_action []){MOUSE_CLOSE_ALL, -1},
 
+.history_file = NULL,
+
 };
 
 struct rule default_rules[] = {

--- a/src/notification.h
+++ b/src/notification.h
@@ -165,8 +165,18 @@ void notification_icon_replace_data(struct notification *n, GVariant *new_icon);
  * settings.always_run_script is not set, do nothing.
  */
 void notification_run_script(struct notification *n);
+
 /**
- * print a human readable representation
+ * Write (in append mode) the json representation
+ * of the given notification to the history file.
+ *
+ * The json file will consist of an array of notification objects,
+ * i.e., the top-level object of the json file is an array.
+ */
+void notification_print_to_history_file(const struct notification *n);
+
+/**
+ * Print a single json object representation
  * of the given notification to stdout.
  */
 void notification_print(const struct notification *n);

--- a/src/queues.c
+++ b/src/queues.c
@@ -16,7 +16,6 @@
 #include "queues.h"
 
 #include <assert.h>
-#include <fcntl.h>
 #include <glib.h>
 #include <stdio.h>
 #include <string.h>

--- a/src/queues.c
+++ b/src/queues.c
@@ -16,6 +16,7 @@
 #include "queues.h"
 
 #include <assert.h>
+#include <fcntl.h>
 #include <glib.h>
 #include <stdio.h>
 #include <string.h>
@@ -203,6 +204,9 @@ int queues_notification_insert(struct notification *n)
 
         if (settings.print_notifications)
                 notification_print(n);
+
+        if (settings.history_file)
+                notification_print_to_history_file(n);
 
         return n->id;
 }

--- a/src/settings.c
+++ b/src/settings.c
@@ -686,6 +686,12 @@ void load_settings(char *cmdline_config_path)
                 "Shortcut for context menu"
         );
 
+        settings.history_file = option_get_path(
+                "global",
+                "history_file", "-hist/-history_file", defaults.history_file,
+                "Path to the notification history file"
+        );
+
         settings.print_notifications = cmdline_get_bool(
                 "-print", false,
                 "Print notifications to cmdline (DEBUG)"

--- a/src/settings.h
+++ b/src/settings.h
@@ -92,6 +92,7 @@ struct settings {
         enum mouse_action *mouse_left_click;
         enum mouse_action *mouse_middle_click;
         enum mouse_action *mouse_right_click;
+        char *history_file;
 };
 
 extern struct settings settings;


### PR DESCRIPTION
## Motivation
In #307, @ohque stated that:
> Let the users get notification history, ..., and then leave it to them to do with the data whatever they want.
>
> One use case that I have in mind specifically is displaying notification count in the panel, as well as some other info based on what kind of notifications are in the history stack at the moment.

## Overview
This PR adds support for keeping the notifications in a "history" file, which keeps the notification history even if dunst has been restarted. This file can be deleted at anytime, and when the next notification is received the file will start repopulating again.

The entire history will be stored as a json array which can be easily loaded via Python's json module (or any other language's json parsing library), leaving these history data to the users to do whatever they want. An example with Python3:
```
>>> import json
>>> with open('/home/aesophor/.cache/dunst/history', 'r') as f:
...     j = json.loads(f.read())
...
>>> len(j)
2
>>> j[1]
{'appname': 'dunstify', 'summary': 'Call waiting', 'body': '', 'icon': 'dialog-information', 'raw_icon set': False, 'icon_id': 'dialog-information', 'desktop_entry': '', 'category': '', 'timeout': 10000, 'urgency': 'NORMAL', 'transient': 0, 'formatted': '<b>Call waiting </b>', 'fg': '#F5F5F5', 'bg': '#292d3f', 'frame': '#41485f', 'fullscreen': 'show', 'progress': -1, 'stack_tag': '', 'id': 2, 'actions': {'yes': 'ACCEPT', 'no': 'DECLINE'}, 'script_count': 1, 'scripts': ['/home/aesophor/.local/bin/_play_notification_sound.sh']}
>>>
```

## New Cmdline Option
`-hist/-history_file`: Path to the notification history file
```
$ mkdir -p ~/.cache/dunst
$ dunst -hist ~/.cache/dunst/history
```

## New Config Option
Users may also set this option in the config's `[global]` section,
just make sure the target directory exists and it must be writable. For example,
```
[global]
    ...
    history_file = ~/.cache/dunst/history
```