### PR TITLE
Add filetype to vim modeline

### DIFF
--- a/config.h
+++ b/config.h
@@ -141,4 +141,4 @@ struct rule default_rules[] = {
         }
 };
 
-/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */
+/* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/dunstify.c
+++ b/dunstify.c
@@ -364,4 +364,4 @@ int main(int argc, char *argv[])
     die(0);
 }
 
-/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */
+/* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/main.c
+++ b/main.c
@@ -4,4 +4,4 @@ int main(int argc, char *argv[])
 {
         return dunst_main(argc, argv);
 }
-/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */
+/* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -847,4 +847,4 @@ void dbus_teardown(int owner_id)
         g_bus_unown_name(owner_id);
 }
 
-/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */
+/* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/dbus.h
+++ b/src/dbus.h
@@ -22,4 +22,4 @@ void signal_notification_closed(struct notification *n, enum reason reason);
 void signal_action_invoked(const struct notification *n, const char *identifier);
 
 #endif
-/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */
+/* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/draw.c
+++ b/src/draw.c
@@ -716,4 +716,4 @@ void draw_deinit(void)
         x_win_destroy(win);
         x_free();
 }
-/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */
+/* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/draw.h
+++ b/src/draw.h
@@ -13,4 +13,4 @@ void draw_rounded_rect(cairo_t *c, int x, int y, int width, int height, int corn
 void draw_deinit(void);
 
 #endif
-/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */
+/* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/dunst.c
+++ b/src/dunst.c
@@ -229,4 +229,4 @@ void print_version(void)
         exit(EXIT_SUCCESS);
 }
 
-/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */
+/* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/dunst.h
+++ b/src/dunst.h
@@ -41,4 +41,4 @@ void usage(int exit_status);
 void print_version(void);
 
 #endif
-/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */
+/* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/icon.c
+++ b/src/icon.c
@@ -367,4 +367,4 @@ GdkPixbuf *icon_get_for_data(GVariant *data, char **id)
         return pixbuf;
 }
 
-/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */
+/* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/icon.h
+++ b/src/icon.h
@@ -58,4 +58,4 @@ GdkPixbuf *icon_get_for_name(const char *name, char **id);
 GdkPixbuf *icon_get_for_data(GVariant *data, char **id);
 
 #endif
-/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */
+/* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/log.c
+++ b/src/log.c
@@ -98,4 +98,4 @@ void dunst_log_init(bool testing)
         g_log_set_default_handler(dunst_log_handler, (void*)testing);
 }
 
-/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */
+/* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/log.h
+++ b/src/log.h
@@ -45,4 +45,4 @@ void log_set_level_from_string(const char* level);
 void dunst_log_init(bool testing);
 
 #endif
-/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */
+/* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/markup.c
+++ b/src/markup.c
@@ -338,4 +338,4 @@ char *markup_transform(char *str, enum markup_mode markup_mode)
         return str;
 }
 
-/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */
+/* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/markup.h
+++ b/src/markup.h
@@ -48,4 +48,4 @@ void markup_strip_img(char **str, char **urls);
 char *markup_transform(char *str, enum markup_mode markup_mode);
 
 #endif
-/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */
+/* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/menu.c
+++ b/src/menu.c
@@ -362,4 +362,4 @@ static gpointer context_menu_thread(gpointer data)
 
         return NULL;
 }
-/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */
+/* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/menu.h
+++ b/src/menu.h
@@ -21,4 +21,4 @@ void regex_teardown(void);
 void context_menu(void);
 
 #endif
-/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */
+/* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/notification.c
+++ b/src/notification.c
@@ -619,4 +619,4 @@ void notification_invalidate_actions(struct notification *n) {
         g_hash_table_remove_all(n->actions);
 }
 
-/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */
+/* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/notification.h
+++ b/src/notification.h
@@ -212,4 +212,4 @@ const char *notification_urgency_to_string(const enum urgency urgency);
 const char *enum_to_string_fullscreen(enum behavior_fullscreen in);
 
 #endif
-/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */
+/* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/option_parser.c
+++ b/src/option_parser.c
@@ -716,4 +716,4 @@ const char *cmdline_create_usage(void)
         return usage_str;
 }
 
-/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */
+/* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/option_parser.h
+++ b/src/option_parser.h
@@ -86,4 +86,4 @@ int option_get_bool(const char *ini_section,
 const char *next_section(const char *section);
 
 #endif
-/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */
+/* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/queues.c
+++ b/src/queues.c
@@ -550,4 +550,4 @@ void queues_teardown(void)
 }
 
 
-/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */
+/* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/queues.h
+++ b/src/queues.h
@@ -164,4 +164,4 @@ struct notification* queues_get_by_id(int id);
 void queues_teardown(void);
 
 #endif
-/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */
+/* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/rules.c
+++ b/src/rules.c
@@ -106,4 +106,4 @@ bool rule_matches_notification(struct rule *r, struct notification *n)
                 && rule_field_matches_string(n->category,       r->category)
                 && rule_field_matches_string(n->stack_tag,      r->stack_tag);
 }
-/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */
+/* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/rules.h
+++ b/src/rules.h
@@ -52,4 +52,4 @@ void rule_apply_all(struct notification *n);
 bool rule_matches_notification(struct rule *r, struct notification *n);
 
 #endif
-/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */
+/* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/settings.c
+++ b/src/settings.c
@@ -787,4 +787,4 @@ void load_settings(char *cmdline_config_path)
         }
 #endif
 }
-/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */
+/* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/settings.h
+++ b/src/settings.h
@@ -99,4 +99,4 @@ extern struct settings settings;
 void load_settings(char *cmdline_config_path);
 
 #endif
-/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */
+/* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/utils.c
+++ b/src/utils.c
@@ -247,4 +247,4 @@ const char *user_get_home(void)
         return home_directory;
 }
 
-/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */
+/* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/utils.h
+++ b/src/utils.h
@@ -138,4 +138,4 @@ gint64 time_monotonic_now(void);
 const char *user_get_home(void);
 
 #endif
-/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */
+/* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/x11/screen.c
+++ b/src/x11/screen.c
@@ -439,4 +439,4 @@ static int FollowXErrorHandler(Display *display, XErrorEvent *e)
 
         return 0;
 }
-/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */
+/* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/x11/screen.h
+++ b/src/x11/screen.h
@@ -45,4 +45,4 @@ bool have_fullscreen_window(void);
 bool window_is_fullscreen(Window window);
 
 #endif
-/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */
+/* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -940,4 +940,4 @@ static void x_shortcut_init(struct keyboard_shortcut *ks)
         g_free(str_begin);
 }
 
-/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */
+/* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/x11/x.h
+++ b/src/x11/x.h
@@ -69,4 +69,4 @@ void x_free(void);
 struct geometry x_parse_geometry(const char *geom_str);
 
 #endif
-/* vim: set tabstop=8 shiftwidth=8 expandtab textwidth=0: */
+/* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */


### PR DESCRIPTION
This PR adds the filetype to the vim modeline, because vim recognizes .h files as cpp.