### PR TITLE
Create abstract output and fix wayland bug

### DIFF
--- a/docs/dunst.pod
+++ b/docs/dunst.pod
@@ -238,6 +238,8 @@ Set to 0 to disable.
 A client can mark a notification as transient to bypass this setting and timeout
 anyway. Use a rule with 'set_transient = no' to disable this behavior.
 
+Note: this doesn't work on wayland yet.
+
 =item B<font> (default: "Monospace 8")
 
 Defines the font or font set used. Optionally set the size as a decimal number

--- a/src/draw.h
+++ b/src/draw.h
@@ -1,8 +1,12 @@
 #ifndef DUNST_DRAW_H
 #define DUNST_DRAW_H
 
-#include "x11/x.h"
-extern struct window_x11 *win; // Temporary
+#include <stdbool.h>
+#include <cairo.h>
+#include "output.h"
+
+extern window win; // Temporary
+extern const struct output *output;
 
 void draw_setup(void);
 

--- a/src/dunst.c
+++ b/src/dunst.c
@@ -20,8 +20,7 @@
 #include "queues.h"
 #include "settings.h"
 #include "utils.h"
-#include "x11/screen.h"
-#include "x11/x.h"
+#include "output.h"
 
 GMainLoop *mainloop = NULL;
 
@@ -67,8 +66,8 @@ static gboolean run(void *data)
 
         LOG_D("RUN");
 
-        dunst_status(S_FULLSCREEN, have_fullscreen_window());
-        dunst_status(S_IDLE, x_is_idle());
+        dunst_status(S_FULLSCREEN, output->have_fullscreen_window());
+        dunst_status(S_IDLE, output->is_idle());
 
         queues_update(status);
 
@@ -77,9 +76,9 @@ static gboolean run(void *data)
         if (active) {
                 // Call draw before showing the window to avoid flickering
                 draw();
-                x_win_show(win);
+                output->win_show(win);
         } else {
-                x_win_hide(win);
+                output->win_hide(win);
         }
 
         if (active) {

--- a/src/output.c
+++ b/src/output.c
@@ -1,0 +1,62 @@
+#include "output.h"
+
+#include "log.h"
+#include "x11/x.h"
+#include "x11/screen.h"
+/* #include "wayland/wl.h" */ // Not yet
+
+const bool is_running_wayland(void){
+        char* wayland_display = getenv("WAYLAND_DISPLAY");
+        return !(wayland_display == NULL);
+}
+
+const struct output output_x11 = {
+        x_setup,
+        x_free,
+
+        x_win_create,
+        x_win_destroy,
+
+        x_win_show,
+        x_win_hide,
+
+        x_display_surface,
+        x_win_visible,
+        x_win_get_context,
+
+        get_active_screen,
+
+        x_is_idle,
+        have_fullscreen_window
+};
+
+/* const struct output output_wl = { */
+        /* wl_init, */
+        /* wl_deinit, */
+
+        /* wl_win_create, */
+        /* wl_win_destroy, */
+
+        /* wl_win_show, */
+        /* wl_win_hide, */
+
+        /* wl_display_surface, */
+        /* wl_win_visible, */
+        /* wl_win_get_context, */
+
+        /* wl_get_active_screen, */
+
+        /* wl_is_idle, */
+        /* wl_have_fullscreen_window */
+/* }; */
+
+const struct output* output_create(void)
+{
+        if (is_running_wayland()) {
+                LOG_I("System is running wayland");
+        } else{
+                LOG_I("System is running X11");
+        }
+        return &output_x11;
+}
+/* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/output.h
+++ b/src/output.h
@@ -1,0 +1,55 @@
+#ifndef DUNST_OUTPUT_H
+#define DUNST_OUTPUT_H
+
+#include <stdbool.h>
+#include <glib.h>
+#include <cairo.h>
+
+typedef gpointer window;
+
+struct dimensions {
+        int x;
+        int y;
+        int w;
+        int h;
+
+        int corner_radius;
+};
+
+struct screen_info {
+        int id;
+        int x;
+        int y;
+        unsigned int h;
+        unsigned int mmh;
+        unsigned int w;
+        int dpi;
+};
+
+struct output {
+        void (*init)(void);
+        void (*deinit)(void);
+
+        window (*win_create)(void);
+        void (*win_destroy)(window);
+
+        void (*win_show)(window);
+        void (*win_hide)(window);
+
+        void (*display_surface)(cairo_surface_t *srf, window win, const struct dimensions*);
+
+        bool (*win_visible)(window);
+        cairo_t* (*win_get_context)(window);
+
+        const struct screen_info* (*get_active_screen)(void);
+
+        bool (*is_idle)(void);
+        bool (*have_fullscreen_window)(void);
+};
+
+const struct output* output_create(void);
+
+const bool is_running_wayland(void);
+
+#endif
+/* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/queues.c
+++ b/src/queues.c
@@ -25,6 +25,7 @@
 #include "notification.h"
 #include "settings.h"
 #include "utils.h"
+#include "output.h" // For checking if wayland is active.
 
 /* notification lists */
 static GQueue *waiting   = NULL; /**< all new notifications get into here */
@@ -143,7 +144,8 @@ static bool queues_notification_is_finished(struct notification *n, struct dunst
         bool is_idle = status.fullscreen ? false : status.idle;
 
         /* don't timeout when user is idle */
-        if (is_idle && !n->transient) {
+        /* NOTE: Idle is not working on wayland */
+        if (is_idle && !n->transient && !is_running_wayland()) {
                 n->start = time_monotonic_now();
                 return false;
         }

--- a/src/x11/screen.c
+++ b/src/x11/screen.c
@@ -69,12 +69,12 @@ static double screen_dpi_get_from_xft(void)
         return screen_dpi_xft_cache;
 }
 
-static double screen_dpi_get_from_monitor(struct screen_info *scr)
+static double screen_dpi_get_from_monitor(const struct screen_info *scr)
 {
         return (double)scr->h * 25.4 / (double)scr->mmh;
 }
 
-double screen_dpi_get(struct screen_info *scr)
+double screen_dpi_get(const struct screen_info *scr)
 {
         if (  ! settings.force_xinerama
              && settings.per_monitor_dpi)
@@ -156,6 +156,7 @@ void randr_update(void)
                 screens[i].w = m[i].width;
                 screens[i].h = m[i].height;
                 screens[i].mmh = m[i].mheight;
+                screens[i].dpi = screen_dpi_get(&screens[i]);
         }
 
         XRRFreeMonitors(m);
@@ -300,7 +301,7 @@ bool window_is_fullscreen(Window window)
  * Select the screen on which the Window
  * should be displayed.
  */
-struct screen_info *get_active_screen(void)
+const struct screen_info *get_active_screen(void)
 {
         int ret = 0;
         bool force_follow_mouse = false;

--- a/src/x11/screen.h
+++ b/src/x11/screen.h
@@ -7,21 +7,12 @@
 
 #define INRECT(x,y,rx,ry,rw,rh) ((x) >= (rx) && (x) < (rx)+(rw) && (y) >= (ry) && (y) < (ry)+(rh))
 
-struct screen_info {
-        int id;
-        int x;
-        int y;
-        unsigned int h;
-        unsigned int mmh;
-        unsigned int w;
-};
-
 void init_screens(void);
 void screen_dpi_xft_cache_purge(void);
 bool screen_check_event(XEvent *ev);
 
-struct screen_info *get_active_screen(void);
-double screen_dpi_get(struct screen_info *scr);
+const struct screen_info *get_active_screen(void);
+double screen_dpi_get(const struct screen_info *scr);
 
 /**
  * Find the currently focused window and check if it's in

--- a/src/x11/x.h
+++ b/src/x11/x.h
@@ -11,6 +11,8 @@
 #include <X11/X.h>
 #include <X11/Xlib.h>
 
+#include "../output.h"
+
 #include "screen.h"
 
 struct keyboard_shortcut {
@@ -24,42 +26,24 @@ struct keyboard_shortcut {
 // Cyclical dependency
 #include "../settings.h"
 
-struct window_x11;
-
-struct dimensions {
-        int x;
-        int y;
-        int w;
-        int h;
-
-        int corner_radius;
-};
-
 struct x_context {
         Display *dpy;
         XScreenSaverInfo *screensaver_info;
 };
 
-struct color {
-        double r;
-        double g;
-        double b;
-        double a;
-};
-
 extern struct x_context xctx;
 
 /* window */
-struct window_x11 *x_win_create(void);
-void x_win_destroy(struct window_x11 *win);
+window x_win_create(void);
+void x_win_destroy(window);
 
-void x_win_show(struct window_x11 *win);
-void x_win_hide(struct window_x11 *win);
+void x_win_show(window);
+void x_win_hide(window);
 
-void x_display_surface(cairo_surface_t *srf, struct window_x11 *win, const struct dimensions *dim);
+void x_display_surface(cairo_surface_t *srf, window, const struct dimensions *dim);
 
-bool x_win_visible(struct window_x11 *win);
-cairo_t* x_win_get_context(struct window_x11 *win);
+bool x_win_visible(window);
+cairo_t* x_win_get_context(window);
 
 /* X misc */
 bool x_is_idle(void);


### PR DESCRIPTION
This commit adds an output struct which abstracts the X11 specific
functions and makes it possible to easily create a drop-in wayland
output.

It also fixes a bug in wayland where notifications won't disappear.
This is because wayland doesn't give access to user input when a
client is not in focus. This way it seems like the user is always
idle. The idle functionality is now disabled in Wayland until proper
support is added.

Dunst should now work fine on wayland using X11 compatibility.
Only the idle functionality won't work, obviously.