### PR TITLE
Add new CI images

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,9 +19,11 @@ jobs:
           - alpine
           - archlinux
           - debian-stretch
+          - debian-buster
           - fedora
           - ubuntu-xenial
           - ubuntu-bionic
+          - ubuntu-focal
 
     env:
       CC: ${{ matrix.CC }}

--- a/.valgrind.suppressions
+++ b/.valgrind.suppressions
@@ -48,6 +48,20 @@
    ...
 }
 
+# Some new in ArchLinux
+{
+   rsvg_rust_handle_close
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   ...
+   fun:rsvg_rust_handle_close
+   obj:*/loaders/libpixbufloader-svg.so
+   ...
+   fun:gdk_pixbuf_new_from_file
+   ...
+}
+
 # rsvg_error_writehandler got fixed in
 # - GNOME/librsvg@7b4cc9b
 # (2018-11-12, first tags: v2.45.0, v2.44.9)


### PR DESCRIPTION
This PR adds new CI images, which had been introduced in dunst-project/docker-images@5bee3b519552d73a925406c47438726def345092