### PR TITLE
Get the number of notifications

### DIFF
--- a/docs/dunstctl.pod
+++ b/docs/dunstctl.pod
@@ -46,6 +46,11 @@ Set the paused status of dunst. If false, dunst is running normally, if true,
 dunst is paused. See the is-paused command and the dunst man page for more
 information.
 
+=item B<status> [displayed/history/waiting]
+
+Returns the number of displayed, shown and waiting notifications. If no argument
+is provided, everything will be printed.
+
 =item B<debug>
 
 Tries to contact dunst and checks for common faults between dunstctl and dunst.

--- a/docs/dunstctl.pod
+++ b/docs/dunstctl.pod
@@ -29,6 +29,11 @@ Close all notifications currently being displayed
 Open the context menu, presenting all available actions and urls for the
 currently open notifications.
 
+=item B<count> [displayed/history/waiting]
+
+Returns the number of displayed, shown and waiting notifications. If no argument
+is provided, everything will be printed.
+
 =item B<history-pop>
 
 Redisplay the notification that was most recently closed. This can be called
@@ -45,11 +50,6 @@ will be kept but not shown until it is unpaused.
 Set the paused status of dunst. If false, dunst is running normally, if true,
 dunst is paused. See the is-paused command and the dunst man page for more
 information.
-
-=item B<status> [displayed/history/waiting]
-
-Returns the number of displayed, shown and waiting notifications. If no argument
-is provided, everything will be printed.
 
 =item B<debug>
 

--- a/dunstctl
+++ b/dunstctl
@@ -14,17 +14,18 @@ show_help() {
 	cat <<-EOH
 	Usage: dunstctl <command> [parameters]"
 	Commands:
-	  action                         Perform the default action, or open the
-	                                 context menu of the notification at the
-	                                 given position
-	  close                          Close the last notification
-	  close-all                      Close the all notifications
-	  context                        Open context menu
-	  history-pop                    Pop one notification from history
-	  is-paused                      Check if dunst is running or paused
-	  set-paused [true|false|toggle] Set the pause status
-	  debug                          Print debugging information
-	  help                           Show this help
+	  action                             Perform the default action, or open the
+	                                     context menu of the notification at the
+	                                     given position
+	  close                              Close the last notification
+	  close-all                          Close the all notifications
+	  context                            Open context menu
+	  history-pop                        Pop one notification from history
+	  is-paused                          Check if dunst is running or paused
+	  set-paused [true|false|toggle]     Set the pause status
+	  status [displayed|history|waiting] Show the number of notifications
+	  debug                              Print debugging information
+	  help                               Show this help
 	EOH
 }
 dbus_send_checked() {
@@ -81,6 +82,17 @@ case "${1:-}" in
 			fi
 		else
 			property_set paused variant:boolean:"$2"
+		fi
+		;;
+	"status")
+		[ $# -eq 1 ] || [ "${2}" = "displayed" ] || [ "${2}" = "history" ] || [ "${2}" = "waiting" ] \
+			|| die "Please give either 'displayed', 'history', 'waiting' or none as status parameter."
+		if [ $# -eq 1 ]; then
+			property_get waiting   | ( read -r _ _ waiting;   printf "              Waiting: %s\n" "${waiting}" )
+			property_get displayed | ( read -r _ _ displayed; printf "  Currently displayed: %s\n" "${displayed}" )
+			property_get history   | ( read -r _ _ history;   printf "              History: %s\n" "${history}")
+		else
+			property_get ${2} | ( read -r _ _ notifications; printf "%s\n" "${notifications}"; )
 		fi
 		;;
 	"help"|"--help"|"-h")

--- a/dunstctl
+++ b/dunstctl
@@ -14,18 +14,18 @@ show_help() {
 	cat <<-EOH
 	Usage: dunstctl <command> [parameters]"
 	Commands:
-	  action                             Perform the default action, or open the
-	                                     context menu of the notification at the
-	                                     given position
-	  close                              Close the last notification
-	  close-all                          Close the all notifications
-	  context                            Open context menu
-	  history-pop                        Pop one notification from history
-	  is-paused                          Check if dunst is running or paused
-	  set-paused [true|false|toggle]     Set the pause status
-	  status [displayed|history|waiting] Show the number of notifications
-	  debug                              Print debugging information
-	  help                               Show this help
+	  action                            Perform the default action, or open the
+	                                    context menu of the notification at the
+	                                    given position
+	  close                             Close the last notification
+	  close-all                         Close the all notifications
+	  context                           Open context menu
+	  count [displayed|history|waiting] Show the number of notifications
+	  history-pop                       Pop one notification from history
+	  is-paused                         Check if dunst is running or paused
+	  set-paused [true|false|toggle]    Set the pause status
+	  debug                             Print debugging information
+	  help                              Show this help
 	EOH
 }
 dbus_send_checked() {
@@ -62,6 +62,17 @@ case "${1:-}" in
 	"context")
 		method_call "${DBUS_IFAC_DUNST}.ContextMenuCall" >/dev/null
 		;;
+	"count")
+		[ $# -eq 1 ] || [ "${2}" = "displayed" ] || [ "${2}" = "history" ] || [ "${2}" = "waiting" ] \
+			|| die "Please give either 'displayed', 'history', 'waiting' or none as count parameter."
+		if [ $# -eq 1 ]; then
+			property_get waiting   | ( read -r _ _ waiting;   printf "              Waiting: %s\n" "${waiting}" )
+			property_get displayed | ( read -r _ _ displayed; printf "  Currently displayed: %s\n" "${displayed}" )
+			property_get history   | ( read -r _ _ history;   printf "              History: %s\n" "${history}")
+		else
+			property_get ${2} | ( read -r _ _ notifications; printf "%s\n" "${notifications}"; )
+		fi
+		;;
 	"history-pop")
 		method_call "${DBUS_IFAC_DUNST}.NotificationShow" >/dev/null
 		;;
@@ -82,17 +93,6 @@ case "${1:-}" in
 			fi
 		else
 			property_set paused variant:boolean:"$2"
-		fi
-		;;
-	"status")
-		[ $# -eq 1 ] || [ "${2}" = "displayed" ] || [ "${2}" = "history" ] || [ "${2}" = "waiting" ] \
-			|| die "Please give either 'displayed', 'history', 'waiting' or none as status parameter."
-		if [ $# -eq 1 ]; then
-			property_get waiting   | ( read -r _ _ waiting;   printf "              Waiting: %s\n" "${waiting}" )
-			property_get displayed | ( read -r _ _ displayed; printf "  Currently displayed: %s\n" "${displayed}" )
-			property_get history   | ( read -r _ _ history;   printf "              History: %s\n" "${history}")
-		else
-			property_get ${2} | ( read -r _ _ notifications; printf "%s\n" "${notifications}"; )
 		fi
 		;;
 	"help"|"--help"|"-h")

--- a/dunstctl
+++ b/dunstctl
@@ -66,11 +66,11 @@ case "${1:-}" in
 		[ $# -eq 1 ] || [ "${2}" = "displayed" ] || [ "${2}" = "history" ] || [ "${2}" = "waiting" ] \
 			|| die "Please give either 'displayed', 'history', 'waiting' or none as count parameter."
 		if [ $# -eq 1 ]; then
-			property_get waiting   | ( read -r _ _ waiting;   printf "              Waiting: %s\n" "${waiting}" )
-			property_get displayed | ( read -r _ _ displayed; printf "  Currently displayed: %s\n" "${displayed}" )
-			property_get history   | ( read -r _ _ history;   printf "              History: %s\n" "${history}")
+			property_get waitingLength   | ( read -r _ _ waiting;   printf "              Waiting: %s\n" "${waiting}" )
+			property_get displayedLength | ( read -r _ _ displayed; printf "  Currently displayed: %s\n" "${displayed}" )
+			property_get historyLength   | ( read -r _ _ history;   printf "              History: %s\n" "${history}")
 		else
-			property_get ${2} | ( read -r _ _ notifications; printf "%s\n" "${notifications}"; )
+			property_get ${2}Length | ( read -r _ _ notifications; printf "%s\n" "${notifications}"; )
 		fi
 		;;
 	"history-pop")

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -85,6 +85,10 @@ static const char *introspection_xml =
     "            <annotation name=\"org.freedesktop.DBus.Property.EmitsChangedSignal\" value=\"true\"/>"
     "        </property>"
 
+    "        <property name=\"displayed\" type=\"u\" access=\"read\" />"
+    "        <property name=\"history\" type=\"u\" access=\"read\" />"
+    "        <property name=\"waiting\" type=\"u\" access=\"read\" />"
+
     "    </interface>"
     "</node>";
 
@@ -597,6 +601,15 @@ GVariant *dbus_cb_dunst_Properties_Get(GDBusConnection *connection,
 
         if (STR_EQ(property_name, "paused")) {
                 return g_variant_new_boolean(!status.running);
+        } else if (STR_EQ(property_name, "displayed")) {
+                unsigned int displayed = queues_length_displayed();
+                return g_variant_new_uint32(displayed);
+        } else if (STR_EQ(property_name, "history")) {
+                unsigned int history =  queues_length_history();
+                return g_variant_new_uint32(history);
+        } else if (STR_EQ(property_name, "waiting")) {
+                unsigned int waiting =  queues_length_waiting();
+                return g_variant_new_uint32(waiting);
         } else {
                 LOG_W("Unknown property!\n");
                 *error = g_error_new(G_DBUS_ERROR, G_DBUS_ERROR_UNKNOWN_PROPERTY, "Unknown property");

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -85,9 +85,9 @@ static const char *introspection_xml =
     "            <annotation name=\"org.freedesktop.DBus.Property.EmitsChangedSignal\" value=\"true\"/>"
     "        </property>"
 
-    "        <property name=\"displayed\" type=\"u\" access=\"read\" />"
-    "        <property name=\"history\" type=\"u\" access=\"read\" />"
-    "        <property name=\"waiting\" type=\"u\" access=\"read\" />"
+    "        <property name=\"displayedLength\" type=\"u\" access=\"read\" />"
+    "        <property name=\"historyLength\" type=\"u\" access=\"read\" />"
+    "        <property name=\"waitingLength\" type=\"u\" access=\"read\" />"
 
     "    </interface>"
     "</node>";
@@ -601,13 +601,13 @@ GVariant *dbus_cb_dunst_Properties_Get(GDBusConnection *connection,
 
         if (STR_EQ(property_name, "paused")) {
                 return g_variant_new_boolean(!status.running);
-        } else if (STR_EQ(property_name, "displayed")) {
+        } else if (STR_EQ(property_name, "displayedLength")) {
                 unsigned int displayed = queues_length_displayed();
                 return g_variant_new_uint32(displayed);
-        } else if (STR_EQ(property_name, "history")) {
+        } else if (STR_EQ(property_name, "historyLength")) {
                 unsigned int history =  queues_length_history();
                 return g_variant_new_uint32(history);
-        } else if (STR_EQ(property_name, "waiting")) {
+        } else if (STR_EQ(property_name, "waitingLength")) {
                 unsigned int waiting =  queues_length_waiting();
                 return g_variant_new_uint32(waiting);
         } else {


### PR DESCRIPTION
This will add the dbus properties
* `displayed`
* `waiting`
* `history`

and extends `dunstctl` with the sub-command `status`, which provides this information.

Currently I'm not sure, if `history` is the right term. Maybe `shown` fits here better.

See also the feature request #792.