### PR TITLE
Change config location to /etc/dunst/dunstrc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ install-dunstctl: dunstctl
 	install -Dm755 dunstctl ${DESTDIR}${BINDIR}/dunstctl
 
 install-doc:
-	install -Dm644 dunstrc ${DESTDIR}${DATADIR}/dunst/dunstrc
+	install -Dm644 dunstrc ${DESTDIR}${SYSCONFDIR}/dunst/dunstrc
 
 install-service: install-service-dbus
 install-service-dbus: service-dbus
@@ -223,7 +223,7 @@ uninstall: uninstall-service uninstall-dunstctl
 	rm -f ${DESTDIR}${BINDIR}/dunstify
 	rm -f ${DESTDIR}${MANPREFIX}/man1/dunst.1
 	rm -f ${DESTDIR}${MANPREFIX}/man1/dunstctl.1
-	rm -rf ${DESTDIR}${DATADIR}/dunst
+	rm -rf ${DESTDIR}${SYSCONFDIR}/dunst
 
 uninstall-dunstctl:
 	rm -f ${DESTDIR}${BINDIR}/dunstctl

--- a/config.mk
+++ b/config.mk
@@ -1,6 +1,7 @@
 # paths
 PREFIX ?= /usr/local
 BINDIR ?= ${PREFIX}/bin
+SYSCONFDIR ?= /etc
 DATADIR ?= ${PREFIX}/share
 # around for backwards compatibility
 MANPREFIX ?= ${DATADIR}/man

--- a/docs/dunst.pod
+++ b/docs/dunst.pod
@@ -35,7 +35,8 @@ rules or using the output in other scripts.
 
 =head1 CONFIGURATION
 
-An example configuration file is included (usually /usr/share/dunst/dunstrc).
+An example configuration file is included (usually /etc/dunst/dunstrc). Note:
+this was previously /usr/share/dunst/dunstrc.
 To change the configuration, copy this file to ~/.config/dunst/dunstrc and edit
 it accordingly.
 

--- a/src/settings.c
+++ b/src/settings.c
@@ -54,6 +54,10 @@ static FILE *xdg_config(const char *filename)
                 g_free(path);
         }
 
+        if (!f) {
+                f = fopen("/etc/dunst/dunstrc", "r");
+        }
+
         return f;
 }
 

--- a/test/test-install.sh
+++ b/test/test-install.sh
@@ -1,27 +1,31 @@
 #!/usr/bin/env bash
 
+# Throw error any time a command fails
 set -euo pipefail
 
 BASE="$(dirname "$(dirname "$(readlink -f "$0")")")"
-PREFIX="${BASE}/install"
+DESTDIR="${BASE}/install"
+PREFIX="/testprefix"
+SYSCONFDIR="/sysconfdir"
 
-make -C "${BASE}" SYSTEMD=1 SERVICEDIR_SYSTEMD="${PREFIX}/systemd" SERVICEDIR_DBUS="${PREFIX}/dbus" PREFIX="${PREFIX}" install
+make -C "${BASE}" SYSTEMD=1 DESTDIR="${DESTDIR}" PREFIX="${PREFIX}" SYSCONFDIR="${SYSCONFDIR}" SERVICEDIR_SYSTEMD="/systemd" SERVICEDIR_DBUS="/dbus" install
 
-diff -u <(find "${PREFIX}" -type f -printf "%P\n" | sort) - <<EOF
-bin/dunst
-bin/dunstctl
-bin/dunstify
+diff -u <(find "${DESTDIR}" -type f -printf "%P\n" | sort) - <<EOF
 dbus/org.knopwob.dunst.service
-share/dunst/dunstrc
-share/man/man1/dunst.1
-share/man/man1/dunstctl.1
+sysconfdir/dunst/dunstrc
 systemd/dunst.service
+testprefix/bin/dunst
+testprefix/bin/dunstctl
+testprefix/bin/dunstify
+testprefix/share/man/man1/dunst.1
+testprefix/share/man/man1/dunstctl.1
 EOF
+# make sure to manually sort the above values
 
-make -C "${BASE}" SYSTEMD=1 SERVICEDIR_SYSTEMD="${PREFIX}/systemd" SERVICEDIR_DBUS="${PREFIX}/dbus" PREFIX="${PREFIX}" uninstall
+make -C "${BASE}" SYSTEMD=1 DESTDIR="${DESTDIR}" PREFIX="${PREFIX}" SYSCONFDIR="${SYSCONFDIR}" SERVICEDIR_SYSTEMD="/systemd" SERVICEDIR_DBUS="/dbus" uninstall
 
-if ! [ -z "$(find "${PREFIX}" -type f)" ]; then
+if ! [ -z "$(find "${DESTDIR}" -type f)" ]; then
         echo "Uninstall failed, following files weren't removed"
-        find "${PREFIX}" -type f
+        find "${DESTDIR}" -type f
         exit 1
 fi


### PR DESCRIPTION
Fixes #795 
The makefile still isn't fully xdg compliant. If the user has set `$XDG_CONFIG_DIRS` it should be reflected our install, I believe.
I didn't know the best way to implement that, but [this](https://www.gnu.org/software/make/manual/make.html#Directory-Variables) is some make documentation about all the standard directories, and [this](https://specifications.freedesktop.org/basedir-spec/latest/ar01s03.html) is the spec.