### PR TITLE
Adding a config variable that adds extra space between the notification icon and text

### DIFF
--- a/config.h
+++ b/config.h
@@ -54,6 +54,7 @@ struct settings defaults = {
 .separator_height = 2,       /* height of the separator line between two notifications */
 .padding = 0,
 .h_padding = 0,              /* horizontal padding */
+.text_icon_padding = 0,     /* padding between icon and text*/
 .sep_color = {SEP_AUTO},     /* SEP_AUTO, SEP_FOREGROUND, SEP_FRAME, SEP_CUSTOM */
 
 .frame_width = 0,

--- a/docs/dunst.pod
+++ b/docs/dunst.pod
@@ -218,6 +218,23 @@ in the vertical axis
 The distance in pixels from the content to the border of the window
 in the horizontal axis
 
+=item B<text_icon_padding> (default: 0)
+
+The distance in pixels from the text to the icon (or vice versa)
+in the horizontal axis.
+
+Setting this to a non-zero value overwrites any padding that horizontal_padding was adding between the notification text and icon.
+
+So for example setting
+
+    text_icon_padding=10
+    horizontal_padding=10
+
+is equivalent to
+
+    text_icon_padding=0
+    horizontal_padding=10
+
 =item B<frame_width> (default: 0)
 
 Defines width in pixels of frame around the notification window. Set to 0 to

--- a/dunstrc
+++ b/dunstrc
@@ -30,7 +30,7 @@
     # The width can be negative.  In this case the actual width is the
     # screen width minus the width defined in within the geometry option.
     geometry = "300x5-30+20"
-	
+
     # Turn on the progess bar
     progress_bar = true
 
@@ -40,14 +40,14 @@
 
     # Set the frame width of the progress bar
     progress_bar_frame_width = 1
-    
+
     # Set the minimum width for the progress bar
     progress_bar_min_width = 150
 
     # Set the maximum width for the progress bar
     progress_bar_max_width = 300
-    
-    
+
+
     # Show how many messages are currently hidden (because of geometry).
     indicate_hidden = yes
 
@@ -75,6 +75,9 @@
 
     # Horizontal padding.
     horizontal_padding = 8
+
+    # Padding between text and icon.
+    text_icon_padding = 0
 
     # Defines width in pixels of frame around the notification window.
     # Set to 0 to disable.
@@ -243,7 +246,7 @@
 
     # Ignore the dbus closeNotification message.
     # Useful to enforce the timeout set by dunst configuration. Without this
-    # parameter, an application may close the notification sent before the 
+    # parameter, an application may close the notification sent before the
     # user defined timeout.
     ignore_dbusclose = false
 

--- a/src/draw.c
+++ b/src/draw.c
@@ -179,6 +179,15 @@ static bool have_dynamic_width(void)
         return (settings.geometry.width_set && settings.geometry.w == 0);
 }
 
+static int get_text_icon_padding()
+{
+        if (settings.text_icon_padding) {
+                return settings.text_icon_padding;
+        } else {
+                return settings.h_padding;
+        }
+}
+
 static bool have_progress_bar(const struct notification *n)
 {
         return (n->progress >= 0 && settings.progress_bar == true);
@@ -241,7 +250,9 @@ static struct dimensions calculate_dimensions(GSList *layouts)
                         w = dim.w;
                         w -= 2 * settings.h_padding;
                         w -= 2 * settings.frame_width;
-                        if (cl->icon) w -= cairo_image_surface_get_width(cl->icon) + settings.h_padding;
+                        if (cl->icon) {
+                                w -= cairo_image_surface_get_width(cl->icon) + get_text_icon_padding();
+                        }
                         layout_setup_pango(cl->l, w);
 
                         /* re-read information */
@@ -335,7 +346,9 @@ static struct colored_layout *layout_init_shared(cairo_t *c, const struct notifi
         } else {
                 width -= 2 * settings.h_padding;
                 width -= 2 * settings.frame_width;
-                if (cl->icon) width -= cairo_image_surface_get_width(cl->icon) + settings.h_padding;
+                if (cl->icon) {
+                        width -= cairo_image_surface_get_width(cl->icon) + get_text_icon_padding();
+                }
                 layout_setup_pango(cl->l, width);
         }
 
@@ -621,7 +634,7 @@ static void render_content(cairo_t *c, struct colored_layout *cl, int width)
 
                 // icon position
                 if (settings.icon_position == ICON_LEFT) {
-                        text_x = cairo_image_surface_get_width(cl->icon) + 2 * settings.h_padding;
+                        text_x = cairo_image_surface_get_width(cl->icon) + settings.h_padding + get_text_icon_padding();
                 } // else ICON_RIGHT
         }
         cairo_move_to(c, text_x, text_y);

--- a/src/settings.c
+++ b/src/settings.c
@@ -366,6 +366,12 @@ void load_settings(char *cmdline_config_path)
                 "horizontal padding"
         );
 
+        settings.text_icon_padding = option_get_int(
+                "global",
+                "text_icon_padding", "-text_icon_padding", defaults.text_icon_padding,
+                "Padding between text and icon"
+        );
+
         settings.transparency = option_get_int(
                 "global",
                 "transparency", "-transparency", defaults.transparency,

--- a/src/settings.h
+++ b/src/settings.h
@@ -81,6 +81,7 @@ struct settings {
         int separator_height;
         int padding;
         int h_padding;
+        int text_icon_padding;
         struct separator_color_data sep_color;
         int frame_width;
         char *frame_color;


### PR DESCRIPTION
This solves/satisfies the feature request in #543 by creating another config variable called ```text_icon_padding``` which defaults to 0, but when set with a pixel value adds that to the regular h_padding to create the desired effect.

Testing is required to see if it breaks any of the regular padding behavior.