### PR TITLE
 Add history_pop_id feature

### DIFF
--- a/dunstctl
+++ b/dunstctl
@@ -21,7 +21,8 @@ show_help() {
 	  close-all                         Close the all notifications
 	  context                           Open context menu
 	  count [displayed|history|waiting] Show the number of notifications
-	  history-pop                       Pop one notification from history
+	  history-pop [ID]                  Pop latest notification from history. If ID is
+	                                    provided, pop the notification with that ID instead.
 	  is-paused                         Check if dunst is running or paused
 	  set-paused [true|false|toggle]    Set the pause status
 	  debug                             Print debugging information
@@ -74,7 +75,13 @@ case "${1:-}" in
 		fi
 		;;
 	"history-pop")
-		method_call "${DBUS_IFAC_DUNST}.NotificationShow" >/dev/null
+		[ $# -le 2 ] || die "Too many arguments. Expected 0 or 1."
+
+		if [ $# -eq 1 ]; then
+			method_call "${DBUS_IFAC_DUNST}.NotificationShow" >/dev/null
+		else
+			method_call "${DBUS_IFAC_DUNST}.NotificationShowID" "int32:${2}" >/dev/null
+		fi
 		;;
 	"is-paused")
 		property_get paused | ( read -r _ _ paused; printf "%s\n" "${paused}"; )

--- a/src/queues.c
+++ b/src/queues.c
@@ -351,6 +351,25 @@ void queues_history_pop(void)
 }
 
 /* see queues.h */
+bool queues_history_pop_id(int id)
+{
+        if (g_queue_is_empty(history))
+                return false;
+
+        struct notification *n = queues_get_by_id(id);
+        if (!n)
+                return false;
+
+        if (!g_queue_remove(history, n))
+                return false;
+
+        n->redisplayed = true;
+        n->timeout = settings.sticky_history ? 0 : n->timeout;
+        g_queue_insert_sorted(waiting, n, notification_cmp_data, NULL);
+        return true;
+}
+
+/* see queues.h */
 void queues_history_push(struct notification *n)
 {
         if (!n->history_ignore) {

--- a/src/queues.c
+++ b/src/queues.c
@@ -190,7 +190,7 @@ int queues_notification_insert(struct notification *n)
                 }
                 inserted = true;
         } else {
-                n->id = ++next_notification_id;
+                n->id = next_notification_id++;
         }
 
         if (!inserted && STR_FULL(n->stack_tag) && queues_stack_by_tag(n))

--- a/src/queues.h
+++ b/src/queues.h
@@ -101,10 +101,19 @@ void queues_notification_close_id(int id, enum reason reason);
 void queues_notification_close(struct notification *n, enum reason reason);
 
 /**
- * Pushes the latest notification of history to the displayed queue
+ * Pushes the latest notification from history to the displayed queue
  * and removes it from history
  */
 void queues_history_pop(void);
+
+/**
+ * Pushes selected notification from history to the displayed queue
+ * and removes it from history.
+ *
+ * @param id id of the notification to pop
+ * @returns false if the notifiction doesn't exist. True otherwise.
+ */
+bool queues_history_pop_id(int id);
 
 /**
  * Push a single notification to history
@@ -146,8 +155,8 @@ void queues_update(struct dunst_status status);
 gint64 queues_get_next_datachange(gint64 time);
 
 /**
- * Get the notification which has the given id in the displayed and waiting queue or
- * NULL if not found
+ * Get the notification which has the given id in the displayed, waiting and
+ * history queue or NULL if not found
  *
  * @param the id searched for.
  *


### PR DESCRIPTION
This allows users to bring back a specific notification back from
history, instead of only the last one.

Fixes #806