### PR TITLE
Drop support for DUNST_COMMAND_*

### DIFF
--- a/src/notification.c
+++ b/src/notification.c
@@ -452,6 +452,12 @@ void notification_init(struct notification *n)
         /* Process rules */
         rule_apply_all(n);
 
+        if (g_str_has_prefix(n->summary, "DUNST_COMMAND_")) {
+                char *msg = "DUNST_COMMAND_* has been removed, please switch to dunstctl. See #830 for more details. https://github.com/dunst-project/dunst/pull/830";
+                LOG_W(msg);
+                n->body = string_append(n->body, msg, "\n");
+        }
+
         /* UPDATE derived fields */
         notification_extract_urls(n);
         notification_format_message(n);

--- a/src/queues.c
+++ b/src/queues.c
@@ -168,19 +168,6 @@ int queues_notification_insert(struct notification *n)
                 LOG_M("Skipping notification: '%s' '%s'", n->body, n->summary);
                 return 0;
         }
-        /* Do not insert the message if it's a command */
-        if (STR_EQ("DUNST_COMMAND_PAUSE", n->summary)) {
-                dunst_status(S_RUNNING, false);
-                return 0;
-        }
-        if (STR_EQ("DUNST_COMMAND_RESUME", n->summary)) {
-                dunst_status(S_RUNNING, true);
-                return 0;
-        }
-        if (STR_EQ("DUNST_COMMAND_TOGGLE", n->summary)) {
-                dunst_status(S_RUNNING, !dunst_status_get().running);
-                return 0;
-        }
 
         bool inserted = false;
         if (n->id != 0) {


### PR DESCRIPTION
These commands may be used for a DoS attack. Specifically, an
application that's running from a sandbox (e.g.  websites with
notification permission) can toggle the permissions.

This is a low severity issue but since dunstctl is available which
performs the exact same task there is no reason to leave this in.

Credit to Vít Šesták for reporting this.