### PR TITLE
Wayland: fallback to X11 output when initialization fails

### DIFF
--- a/src/draw.c
+++ b/src/draw.c
@@ -51,7 +51,6 @@ void draw_setup(void)
         const struct output *out = output_create(settings.force_xwayland);
         output = out;
 
-        out->init();
         win = out->win_create();
 
         pango_fdesc = pango_font_description_from_string(settings.font);

--- a/src/output.c
+++ b/src/output.c
@@ -24,7 +24,6 @@ const struct output output_x11 = {
         x_win_hide,
 
         x_display_surface,
-        x_win_visible,
         x_win_get_context,
 
         get_active_screen,
@@ -45,7 +44,6 @@ const struct output output_wl = {
         wl_win_hide,
 
         wl_display_surface,
-        wl_win_visible,
         wl_win_get_context,
 
         wl_get_active_screen,

--- a/src/output.h
+++ b/src/output.h
@@ -27,7 +27,7 @@ struct screen_info {
 };
 
 struct output {
-        void (*init)(void);
+        bool (*init)(void);
         void (*deinit)(void);
 
         window (*win_create)(void);
@@ -47,9 +47,14 @@ struct output {
         bool (*have_fullscreen_window)(void);
 };
 
+/**
+ * return an initialized output, selecting the correct output type from either
+ * wayland or X11 according to the settings and environment.
+ * When the wayland output fails to initilize, it falls back to X11 output.
+ */
 const struct output* output_create(bool force_xwayland);
 
-const bool is_running_wayland(void);
+bool is_running_wayland(void);
 
 #endif
 /* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/output.h
+++ b/src/output.h
@@ -38,7 +38,6 @@ struct output {
 
         void (*display_surface)(cairo_surface_t *srf, window win, const struct dimensions*);
 
-        bool (*win_visible)(window);
         cairo_t* (*win_get_context)(window);
 
         const struct screen_info* (*get_active_screen)(void);

--- a/src/wayland/wl.c
+++ b/src/wayland/wl.c
@@ -616,6 +616,8 @@ void wl_win_destroy(window winptr) {
 }
 
 void wl_win_show(window win) {
+        // This is here for compatibilty with the X11 output. The window is
+        // already shown in wl_display_surface.
 }
 
 void wl_win_hide(window win) {
@@ -640,10 +642,6 @@ void wl_display_surface(cairo_surface_t *srf, window winptr, const struct dimens
 
         set_dirty();
         wl_display_roundtrip(ctx.display);
-}
-
-bool wl_win_visible(window win) {
-        return true;
 }
 
 cairo_t* wl_win_get_context(window winptr) {

--- a/src/wayland/wl.h
+++ b/src/wayland/wl.h
@@ -7,7 +7,7 @@
 
 #include "../output.h"
 
-void wl_init(void);
+bool wl_init(void);
 void wl_deinit(void);
 
 window wl_win_create(void);

--- a/src/wayland/wl.h
+++ b/src/wayland/wl.h
@@ -17,7 +17,6 @@ void wl_win_show(window);
 void wl_win_hide(window);
 
 void wl_display_surface(cairo_surface_t *srf, window win, const struct dimensions*);
-bool wl_win_visible(window);
 cairo_t* wl_win_get_context(window);
 
 const struct screen_info* wl_get_active_screen(void);

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -501,14 +501,16 @@ static void XRM_update_db(void)
 /*
  * Setup X11 stuff
  */
-void x_setup(void)
+bool x_setup(void)
 {
 
         /* initialize xctx.dc, font, keyboard, colors */
         if (!setlocale(LC_CTYPE, "") || !XSupportsLocale())
                 LOG_W("No locale support");
+
         if (!(xctx.dpy = XOpenDisplay(NULL))) {
-                DIE("Cannot open X11 display.");
+                LOG_W("Cannot open X11 display.");
+                return false;
         }
 
         x_shortcut_init(&settings.close_ks);
@@ -532,6 +534,7 @@ void x_setup(void)
 
         init_screens();
         x_shortcut_grab(&settings.history_ks);
+        return true;
 }
 
 struct geometry x_parse_geometry(const char *geom_str)

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -179,11 +179,6 @@ void x_display_surface(cairo_surface_t *srf, window winptr, const struct dimensi
 
 }
 
-bool x_win_visible(window winptr)
-{
-        return ((struct window_x11*)winptr)->visible;
-}
-
 cairo_t* x_win_get_context(window winptr)
 {
         return ((struct window_x11*)win)->c_ctx;

--- a/src/x11/x.h
+++ b/src/x11/x.h
@@ -47,7 +47,7 @@ cairo_t* x_win_get_context(window);
 
 /* X misc */
 bool x_is_idle(void);
-void x_setup(void);
+bool x_setup(void);
 void x_free(void);
 
 struct geometry x_parse_geometry(const char *geom_str);

--- a/src/x11/x.h
+++ b/src/x11/x.h
@@ -42,7 +42,6 @@ void x_win_hide(window);
 
 void x_display_surface(cairo_surface_t *srf, window, const struct dimensions *dim);
 
-bool x_win_visible(window);
 cairo_t* x_win_get_context(window);
 
 /* X misc */


### PR DESCRIPTION
Fixes #833 