### PR TITLE
Update Pango Markup reference link

### DIFF
--- a/docs/dunst.5.pod
+++ b/docs/dunst.5.pod
@@ -292,7 +292,7 @@ Allow a small subset of html markup in notifications
     <u>underline</u>
 
 For a complete reference see
-<https://developer.gnome.org/pango/stable/pango-Markup.html>
+<https://developer.gnome.org/pygtk/stable/pango-markup-language.html>
 
 =item B<strip>
 

--- a/dunstrc
+++ b/dunstrc
@@ -120,7 +120,7 @@
     #        <u>underline</u>
     #
     #        For a complete reference see
-    #        <https://developer.gnome.org/pango/stable/pango-Markup.html>.
+    #        <https://developer.gnome.org/pygtk/stable/pango-markup-language.html>.
     #
     # strip: This setting is provided for compatibility with some broken
     #        clients that send markup even though it's not enabled on the


### PR DESCRIPTION
It seems the old [link](https://developer.gnome.org/pango/stable/pango-Markup.html) is unreachable.