### PR TITLE
Add icon-static server capability

### DIFF
--- a/src/dbus.c
+++ b/src/dbus.c
@@ -307,6 +307,7 @@ static void dbus_cb_GetCapabilities(
         g_variant_builder_add(builder, "s", "actions");
         g_variant_builder_add(builder, "s", "body");
         g_variant_builder_add(builder, "s", "body-hyperlinks");
+        g_variant_builder_add(builder, "s", "icon-static");
 
         for (int i = 0; i < sizeof(stack_tag_hints)/sizeof(*stack_tag_hints); ++i)
                 g_variant_builder_add(builder, "s", stack_tag_hints[i]);

--- a/test/dbus.c
+++ b/test/dbus.c
@@ -686,6 +686,7 @@ TEST test_server_caps(enum markup_mode markup)
         ASSERT(g_strv_contains(capsarray, "actions"));
         ASSERT(g_strv_contains(capsarray, "body"));
         ASSERT(g_strv_contains(capsarray, "body-hyperlinks"));
+        ASSERT(g_strv_contains(capsarray, "icon-static"));
         ASSERT(g_strv_contains(capsarray, "x-dunst-stack-tag"));
 
         if (settings.markup != MARKUP_NO)


### PR DESCRIPTION
Dunst supports displaying the first frame of an icon, thus it seems reasonable that it should announce that capability with `icon-static`.

`"icon-static" | Supports display of exactly 1 frame of any given image array. This value is mutually exclusive with "icon-multi", it is a protocol error for the server to specify both.` 
from https://developer.gnome.org/notification-spec/#hints

I check for this capability in another project. notify-osd is the only other I know that supports/announces it, however dunst doesn't when it could since it has this already. I've been relying upon the `image-path` hint as an alternative which is more or less a fire and forget approach but it'd be nice to know if the capability exists

