### PR TITLE
Horizontal and vertical centering of notifications

### DIFF
--- a/config.h
+++ b/config.h
@@ -26,7 +26,9 @@ struct settings defaults = {
               .negative_x = 0,
               .negative_y = 0,
               .negative_width = 0,
-              .width_set = 0
+              .width_set = 0,
+              .h_center = 0,
+              .v_center = 0
             },
 .title = "Dunst",            /* the title of dunst notification windows */
 .class = "Dunst",            /* the class of dunst notification windows */

--- a/docs/dunst.5.pod
+++ b/docs/dunst.5.pod
@@ -100,6 +100,16 @@ the notification on the left border of the screen while a horizontal offset of
 
 =back
 
+=item B<h_center> (values: [true/false], default: false)
+
+Causes the notification window to be centered horizontally within the screen.
+Geometry B<x/y> offsets will still apply.
+
+=item B<v_center> (values: [true/false], default: false)
+
+Causes the notification window to be centered vertically within the screen.
+Geometry B<x/y> offsets will still apply.
+
 =item B<progress_bar> (values: [true/false], default: true)
 
 When an integer value is passed to dunst as a hint (see B<NOTIFY-SEND>), a

--- a/dunstrc
+++ b/dunstrc
@@ -31,6 +31,12 @@
     # screen width minus the width defined in within the geometry option.
     geometry = "300x5-30+20"
 
+    # Center window horizontally, geometry offsets apply
+    h_center = true
+
+    # Center window vertically, geometry offsets apply
+    v_center = true
+
     # Turn on the progess bar
     progress_bar = true
 

--- a/src/draw.c
+++ b/src/draw.c
@@ -780,7 +780,9 @@ static void calc_window_pos(int width, int height, int *ret_x, int *ret_y)
         const struct screen_info *scr = output->get_active_screen();
 
         if (ret_x) {
-                if (settings.geometry.negative_x) {
+                if (settings.geometry.h_center) {
+                        *ret_x = ((scr->x + scr->w - width) / 2) + settings.geometry.x;
+                } else if (settings.geometry.negative_x) {
                         *ret_x = (scr->x + (scr->w - width)) + settings.geometry.x;
                 } else {
                         *ret_x = scr->x + settings.geometry.x;
@@ -788,7 +790,9 @@ static void calc_window_pos(int width, int height, int *ret_x, int *ret_y)
         }
 
         if (ret_y) {
-                if (settings.geometry.negative_y) {
+                if (settings.geometry.v_center) {
+                        *ret_y = ((scr->y + scr->h - height) / 2) + settings.geometry.y;
+                } else if (settings.geometry.negative_y) {
                         *ret_y = scr->y + (scr->h + settings.geometry.y) - height;
                 } else {
                         *ret_y = scr->y + settings.geometry.y;

--- a/src/settings.c
+++ b/src/settings.c
@@ -288,6 +288,18 @@ void load_settings(char *cmdline_config_path)
 
         }
 
+        settings.geometry.h_center = option_get_bool(
+                "global",
+                "h_center", "-h_center", defaults.geometry.h_center,
+                "Horizontally center notification window"
+        );
+
+        settings.geometry.v_center = option_get_bool(
+                "global",
+                "v_center", "-v_center", defaults.geometry.v_center,
+                "Vertically center notification window"
+        );
+
         settings.shrink = option_get_bool(
                 "global",
                 "shrink", "-shrink", defaults.shrink,

--- a/src/settings.h
+++ b/src/settings.h
@@ -44,6 +44,8 @@ struct geometry {
         bool negative_y;
         bool negative_width;
         bool width_set;
+        bool h_center;
+        bool v_center;
 };
 
 struct settings {


### PR DESCRIPTION
New config parameters:
  h_center: Boolean, horizontally center
  v_center: Boolean, vertically center

Geometry config can adjust positioning of centered
window.

----

I did this for a personal fork, it solved my need as I couldn't figure out a way to center my notifications.
I also don't know C so this was just me monkeying around.