### PR TITLE
fixed doxygen generation

### DIFF
--- a/src/icon.h
+++ b/src/icon.h
@@ -65,7 +65,7 @@ GdkPixbuf *get_pixbuf_from_icon(const char *iconname, int scale);
  *             get searched in the folders of the icon_path setting.
  * @param id   (necessary) A unique identifier of the returned pixbuf. Only filled,
  *             if the return value is non-NULL.
- * @param scale An integer representing the output dpi scaling.
+ * @param dpi_scale An integer representing the output dpi scaling.
  * @return an instance of `GdkPixbuf`, representing the name's image
  * @retval NULL: Invalid path given
  */

--- a/src/queues.h
+++ b/src/queues.h
@@ -149,7 +149,7 @@ gint64 queues_get_next_datachange(gint64 time);
  * Get the notification which has the given id in the displayed and waiting queue or
  * NULL if not found
  *
- * @param the id searched for.
+ * @param id the id searched for.
  *
  * @return the `id` notification  or NULL
  */


### PR DESCRIPTION
`make doc-doxygen` did not run, because some parameters were not named correctly