### PR TITLE
queues: require the same appid for stacking a notification

### DIFF
--- a/docs/dunst.5.pod
+++ b/docs/dunst.5.pod
@@ -841,9 +841,9 @@ Updates the icon of the notification, it should be a path to a valid image.
 =item C<set_stack_tag>
 
 Sets the stack tag for the notification, notifications with the same (non-empty)
-stack tag will replace each-other so only the newest one is visible. This can be
-useful for example in volume or brightness notifications where you only want one of
-the same type visible.
+stack tag and the same appid will replace each-other so only the newest one is
+visible. This can be useful for example in volume or brightness notifications
+where you only want one of the same type visible.
 
 The stack tag can be set by the client with the 'synchronous',
 'private-synchronous' 'x-canonical-private-synchronous' or the

--- a/src/queues.c
+++ b/src/queues.c
@@ -247,7 +247,8 @@ static bool queues_stack_by_tag(struct notification *new)
                 for (GList *iter = g_queue_peek_head_link(allqueues[i]); iter;
                             iter = iter->next) {
                         struct notification *old = iter->data;
-                        if (STR_FULL(old->stack_tag) && STR_EQ(old->stack_tag, new->stack_tag)) {
+                        if (STR_FULL(old->stack_tag) && STR_EQ(old->stack_tag, new->stack_tag)
+                                        && STR_EQ(old->appname, new->appname)) {
                                 iter->data = new;
                                 new->dup_count = old->dup_count;
 


### PR DESCRIPTION
This has been suggested in https://gitlab.freedesktop.org/xdg/xdg-specs/-/issues/77 to prevent name collisions.