### PR TITLE
X11: enable dpi scaling

### DIFF
--- a/docs/dunst.5.pod
+++ b/docs/dunst.5.pod
@@ -106,6 +106,15 @@ the notification on the left border of the screen while a horizontal offset of
 
 =back
 
+=item B<scale> (default: 0, X11 only)
+
+Specifies a scale factor for dimensions to adapt notifications to
+HiDPI screens. This scales the notification geometry and it's
+contents. It is not recommended to use a fractional scaling factor, as
+this may result in things being one pixel off. Try to use a whole
+number scaling factor and adjust the font size and other sizes as
+needed. If 0 is specified, the scale factor is auto-detected.
+
 =item B<progress_bar> (values: [true/false], default: true)
 
 When an integer value is passed to dunst as a hint (see B<NOTIFY-SEND>), a

--- a/dunstrc
+++ b/dunstrc
@@ -33,6 +33,9 @@
     # screen width minus the width defined in within the geometry option.
     geometry = "300x5-30+20"
 
+    # Scale factor. It is auto-detected if value is 0.
+    scale = 0
+
     # Turn on the progess bar. It appears when a progress hint is passed with
     # for example dunstify -h int:value:12
     progress_bar = true

--- a/src/draw.c
+++ b/src/draw.c
@@ -774,31 +774,6 @@ static struct dimensions layout_render(cairo_surface_t *srf,
         return dim;
 }
 
-/**
- * Calculates the position the window should be placed at given its width and
- * height and stores them in \p ret_x and \p ret_y.
- */
-static void calc_window_pos(int width, int height, int *ret_x, int *ret_y)
-{
-        const struct screen_info *scr = output->get_active_screen();
-
-        if (ret_x) {
-                if (settings.geometry.negative_x) {
-                        *ret_x = (scr->x + (scr->w - width)) + settings.geometry.x;
-                } else {
-                        *ret_x = scr->x + settings.geometry.x;
-                }
-        }
-
-        if (ret_y) {
-                if (settings.geometry.negative_y) {
-                        *ret_y = scr->y + (scr->h + settings.geometry.y) - height;
-                } else {
-                        *ret_y = scr->y + settings.geometry.y;
-                }
-        }
-}
-
 void draw(void)
 {
         assert(queues_length_displayed() > 0);
@@ -821,7 +796,6 @@ void draw(void)
                 first = false;
         }
 
-        calc_window_pos(dim.w, dim.h, &dim.x, &dim.y);
         output->display_surface(image_surface, win, &dim);
 
         cairo_surface_destroy(image_surface);

--- a/src/draw.c
+++ b/src/draw.c
@@ -144,11 +144,11 @@ static struct color layout_get_sepcolor(struct colored_layout *cl,
 
 static void layout_setup_pango(PangoLayout *layout, int width)
 {
-        int scale = output->get_scale();
+        double scale = output->get_scale();
         pango_layout_set_wrap(layout, PANGO_WRAP_WORD_CHAR);
-        pango_layout_set_width(layout, width * scale * PANGO_SCALE);
+        pango_layout_set_width(layout, round(width * scale * PANGO_SCALE));
         pango_layout_set_font_description(layout, pango_fdesc);
-        pango_layout_set_spacing(layout, settings.line_height * scale * PANGO_SCALE);
+        pango_layout_set_spacing(layout, round(settings.line_height * scale * PANGO_SCALE));
 
         PangoAlignment align;
         switch (settings.align) {
@@ -196,20 +196,20 @@ static bool have_progress_bar(const struct notification *n)
         return (n->progress >= 0 && settings.progress_bar == true);
 }
 
-static void get_text_size(PangoLayout *l, int *w, int *h, int scale) {
+static void get_text_size(PangoLayout *l, int *w, int *h, double scale) {
         pango_layout_get_pixel_size(l, w, h);
         // scale the size down, because it may be rendered at higher DPI
 
         if (w)
-                *w /= scale;
+                *w = round(*w / scale);
         if (h)
-                *h /= scale;
+                *h = round(*h / scale);
 }
 
 static struct dimensions calculate_dimensions(GSList *layouts)
 {
         struct dimensions dim = { 0 };
-        int scale = output->get_scale();
+        double scale = output->get_scale();
 
         const struct screen_info *scr = output->get_active_screen();
         if (have_dynamic_width()) {
@@ -235,7 +235,7 @@ static struct dimensions calculate_dimensions(GSList *layouts)
         int text_width = 0, total_width = 0;
         for (GSList *iter = layouts; iter; iter = iter->next) {
                 struct colored_layout *cl = iter->data;
-                int w=0,h=0;
+                int w=0, h=0;
                 get_text_size(cl->l, &w, &h, scale);
                 if (cl->icon) {
                         h = MAX(get_icon_height(cl->icon, scale), h);
@@ -314,7 +314,7 @@ static struct colored_layout *layout_init_shared(cairo_t *c, const struct notifi
 {
         struct colored_layout *cl = g_malloc(sizeof(struct colored_layout));
         cl->l = layout_create(c);
-        int scale = output->get_scale();
+        double scale = output->get_scale();
 
         if (!settings.word_wrap) {
                 PangoEllipsizeMode ellipsize;
@@ -383,7 +383,7 @@ static struct colored_layout *layout_from_notification(cairo_t *c, struct notifi
 {
 
         struct colored_layout *cl = layout_init_shared(c, n);
-        int scale = output->get_scale();
+        double scale = output->get_scale();
 
         /* markup */
         GError *err = NULL;
@@ -452,7 +452,7 @@ static GSList *create_layouts(cairo_t *c)
 }
 
 
-static int layout_get_height(struct colored_layout *cl, int scale)
+static int layout_get_height(struct colored_layout *cl, double scale)
 {
         int h;
         int h_icon = 0;
@@ -499,15 +499,15 @@ static int frame_internal_radius (int r, int w, int h)
  * The top corners will get rounded by `corner_radius`, if `first` is set.
  * Respectably the same for `last` with the bottom corners.
  */
-void draw_rounded_rect(cairo_t *c, int x, int y, int width, int height, int corner_radius, int scale, bool first, bool last)
+void draw_rounded_rect(cairo_t *c, int x, int y, int width, int height, int corner_radius, double scale, bool first, bool last)
 {
-        width *= scale;
-        height *= scale;
-        x *= scale;
-        y *= scale;
-        corner_radius *= scale;
+        width = round(width * scale);
+        height = round(height * scale);
+        x = round(x * scale);
+        y = round(y * scale);
+        corner_radius = round(corner_radius * scale);
 
-        const float degrees = M_PI / 180.0;
+        const double degrees = M_PI / 180.0;
 
         cairo_new_sub_path(c);
 
@@ -557,8 +557,8 @@ void draw_rounded_rect(cairo_t *c, int x, int y, int width, int height, int corn
 /**
  * A small wrapper around cairo_rectange for drawing a scaled rectangle.
  */
-void draw_rect(cairo_t *c, int x, int y, int width, int height, int scale) {
-        cairo_rectangle(c, x * scale, y * scale, width * scale, height * scale);
+static void draw_rect(cairo_t *c, double x, double y, double width, double height, double scale) {
+        cairo_rectangle(c, round(x * scale), round(y * scale), round(width * scale), round(height * scale));
 }
 
 static cairo_surface_t *render_background(cairo_surface_t *srf,
@@ -571,7 +571,7 @@ static cairo_surface_t *render_background(cairo_surface_t *srf,
                                           bool first,
                                           bool last,
                                           int *ret_width,
-                                          int scale)
+                                          double scale)
 {
         int x = 0;
         int radius_int = corner_radius;
@@ -635,10 +635,12 @@ static cairo_surface_t *render_background(cairo_surface_t *srf,
         if (ret_width)
                 *ret_width = width;
 
-        return cairo_surface_create_for_rectangle(srf, x * scale, y * scale, width * scale, height * scale);
+        return cairo_surface_create_for_rectangle(srf,
+                                                  round(x * scale), round(y * scale),
+                                                  round(width * scale), round(height * scale));
 }
 
-static void render_content(cairo_t *c, struct colored_layout *cl, int width, int scale)
+static void render_content(cairo_t *c, struct colored_layout *cl, int width, double scale)
 {
         const int h = layout_get_height(cl, scale);
         int h_without_progress_bar = h;
@@ -667,7 +669,7 @@ static void render_content(cairo_t *c, struct colored_layout *cl, int width, int
                         text_x = get_icon_width(cl->icon, scale) + settings.h_padding + get_text_icon_padding();
                 } // else ICON_RIGHT
         }
-        cairo_move_to(c, text_x * scale, text_y * scale);
+        cairo_move_to(c, round(text_x * scale), round(text_y * scale));
 
         cairo_set_source_rgba(c, cl->fg.r, cl->fg.g, cl->fg.b, cl->fg.a);
         pango_cairo_update_layout(c, cl->l);
@@ -695,7 +697,7 @@ static void render_content(cairo_t *c, struct colored_layout *cl, int width, int
                         image_x = settings.h_padding;
                 } // else ICON_RIGHT
 
-                cairo_set_source_surface(c, cl->icon, image_x * scale, image_y * scale);
+                cairo_set_source_surface(c, cl->icon, round(image_x * scale), round(image_y * scale));
                 draw_rect(c, image_x, image_y, image_width, image_height, scale);
                 cairo_fill(c);
         }
@@ -728,8 +730,14 @@ static void render_content(cairo_t *c, struct colored_layout *cl, int width, int
                 cairo_fill(c);
                 // border
                 cairo_set_source_rgba(c, cl->frame.r, cl->frame.g, cl->frame.b, cl->frame.a);
-                // TODO draw_rect instead of cairo_rectangle resulted in blurry lines. Why?
-                cairo_rectangle(c, (frame_x + half_frame_width) * scale, (frame_y + half_frame_width) * scale, (progress_width - frame_width) * scale, progress_height * scale);
+                // TODO draw_rect instead of cairo_rectangle resulted
+                // in blurry lines due to rounding (half_frame_width
+                // can be non-integer)
+                cairo_rectangle(c,
+                                (frame_x + half_frame_width) * scale,
+                                (frame_y + half_frame_width) * scale,
+                                (progress_width - frame_width) * scale,
+                                progress_height * scale);
                 cairo_set_line_width(c, frame_width * scale);
                 cairo_stroke(c);
         }
@@ -742,7 +750,7 @@ static struct dimensions layout_render(cairo_surface_t *srf,
                                        bool first,
                                        bool last)
 {
-        int scale = output->get_scale();
+        double scale = output->get_scale();
         const int cl_h = layout_get_height(cl, scale);
 
         int h_text = 0;
@@ -781,9 +789,11 @@ void draw(void)
         GSList *layouts = create_layouts(output->win_get_context(win));
 
         struct dimensions dim = calculate_dimensions(layouts);
-        int scale = output->get_scale();
+        double scale = output->get_scale();
 
-        cairo_surface_t *image_surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, dim.w * scale, dim.h * scale);
+        cairo_surface_t *image_surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32,
+                                                                    round(dim.w * scale),
+                                                                    round(dim.h * scale));
 
         bool first = true;
         for (GSList *iter = layouts; iter; iter = iter->next) {
@@ -808,7 +818,7 @@ void draw_deinit(void)
         output->deinit();
 }
 
-int draw_get_scale(void)
+double draw_get_scale(void)
 {
         if (output) {
                 return output->get_scale();

--- a/src/draw.h
+++ b/src/draw.h
@@ -12,10 +12,10 @@ void draw_setup(void);
 
 void draw(void);
 
-void draw_rounded_rect(cairo_t *c, int x, int y, int width, int height, int corner_radius, int scale, bool first, bool last);
+void draw_rounded_rect(cairo_t *c, int x, int y, int width, int height, int corner_radius, double scale, bool first, bool last);
 
 // TODO get rid of this function by passing scale to everything that needs it.
-int draw_get_scale(void);
+double draw_get_scale(void);
 
 void draw_deinit(void);
 

--- a/src/icon.c
+++ b/src/icon.c
@@ -86,12 +86,12 @@ static void pixbuf_data_to_cairo_data(
         }
 }
 
-int get_icon_width(cairo_surface_t *icon, int scale) {
-        return cairo_image_surface_get_width(icon) / scale;
+int get_icon_width(cairo_surface_t *icon, double scale) {
+        return round(cairo_image_surface_get_width(icon) / scale);
 }
 
-int get_icon_height(cairo_surface_t *icon, int scale) {
-        return cairo_image_surface_get_height(icon) / scale;
+int get_icon_height(cairo_surface_t *icon, double scale) {
+        return round(cairo_image_surface_get_height(icon) / scale);
 }
 
 cairo_surface_t *gdk_pixbuf_to_cairo_surface(GdkPixbuf *pixbuf)
@@ -158,7 +158,7 @@ static bool icon_size_clamp(int *w, int *h) {
  *         necessary, it returns the same pixbuf. Transfers full
  *         ownership of the reference.
  */
-static GdkPixbuf *icon_pixbuf_scale(GdkPixbuf *pixbuf, int dpi_scale)
+static GdkPixbuf *icon_pixbuf_scale(GdkPixbuf *pixbuf, double dpi_scale)
 {
         ASSERT_OR_RET(pixbuf, NULL);
 
@@ -170,8 +170,8 @@ static GdkPixbuf *icon_pixbuf_scale(GdkPixbuf *pixbuf, int dpi_scale)
         if (icon_size_clamp(&w, &h)) {
                 GdkPixbuf *scaled = gdk_pixbuf_scale_simple(
                                 pixbuf,
-                                w * dpi_scale,
-                                h * dpi_scale,
+                                round(w * dpi_scale),
+                                round(h * dpi_scale),
                                 GDK_INTERP_BILINEAR);
                 g_object_unref(pixbuf);
                 pixbuf = scaled;
@@ -180,7 +180,7 @@ static GdkPixbuf *icon_pixbuf_scale(GdkPixbuf *pixbuf, int dpi_scale)
         return pixbuf;
 }
 
-GdkPixbuf *get_pixbuf_from_file(const char *filename, int scale)
+GdkPixbuf *get_pixbuf_from_file(const char *filename, double scale)
 {
         char *path = string_to_path(g_strdup(filename));
         GError *error = NULL;
@@ -194,8 +194,8 @@ GdkPixbuf *get_pixbuf_from_file(const char *filename, int scale)
         // TODO immediately rescale icon upon scale changes
         icon_size_clamp(&w, &h);
         GdkPixbuf *pixbuf = gdk_pixbuf_new_from_file_at_scale(path,
-                                                              w * scale,
-                                                              h * scale,
+                                                              round(w * scale),
+                                                              round(h * scale),
                                                               TRUE,
                                                               &error);
 
@@ -263,7 +263,7 @@ char *get_path_from_icon_name(const char *iconname)
         return new_name;
 }
 
-GdkPixbuf *get_pixbuf_from_icon(const char *iconname, int scale)
+GdkPixbuf *get_pixbuf_from_icon(const char *iconname, double scale)
 {
         char *path = get_path_from_icon_name(iconname);
         if (!path) {
@@ -281,7 +281,7 @@ GdkPixbuf *get_pixbuf_from_icon(const char *iconname, int scale)
         return pixbuf;
 }
 
-GdkPixbuf *icon_get_for_name(const char *name, char **id, int scale)
+GdkPixbuf *icon_get_for_name(const char *name, char **id, double scale)
 {
         ASSERT_OR_RET(name, NULL);
         ASSERT_OR_RET(id, NULL);
@@ -292,7 +292,7 @@ GdkPixbuf *icon_get_for_name(const char *name, char **id, int scale)
         return pb;
 }
 
-GdkPixbuf *icon_get_for_data(GVariant *data, char **id, int dpi_scale)
+GdkPixbuf *icon_get_for_data(GVariant *data, char **id, double dpi_scale)
 {
         ASSERT_OR_RET(data, NULL);
         ASSERT_OR_RET(id, NULL);

--- a/src/icon.h
+++ b/src/icon.h
@@ -16,7 +16,7 @@ cairo_surface_t *gdk_pixbuf_to_cairo_surface(GdkPixbuf *pixbuf);
  * @return an instance of `GdkPixbuf`
  * @retval NULL: file does not exist, not readable, etc..
  */
-GdkPixbuf *get_pixbuf_from_file(const char *filename, int scale);
+GdkPixbuf *get_pixbuf_from_file(const char *filename, double scale);
 
 
 /**
@@ -25,12 +25,12 @@ GdkPixbuf *get_pixbuf_from_file(const char *filename, int scale);
  * If scale is 2 for example, the icon will render in twice the size, but
  * get_icon_width still returns the same size as when scale is 1.
  */
-int get_icon_width(cairo_surface_t *icon, int scale);
+int get_icon_width(cairo_surface_t *icon, double scale);
 
 /**
  * Get the unscaled icon height, see get_icon_width.
  */
-int get_icon_height(cairo_surface_t *icon, int scale);
+int get_icon_height(cairo_surface_t *icon, double scale);
 
 /** Retrieve a path from an icon name.
  *
@@ -53,7 +53,7 @@ char *get_path_from_icon_name(const char *iconname);
  * @return an instance of `GdkPixbuf`
  * @retval NULL: file does not exist, not readable, etc..
  */
-GdkPixbuf *get_pixbuf_from_icon(const char *iconname, int scale);
+GdkPixbuf *get_pixbuf_from_icon(const char *iconname, double scale);
 
 /** Read an icon from disk and convert it to a GdkPixbuf, scaled according to settings
  *
@@ -69,7 +69,7 @@ GdkPixbuf *get_pixbuf_from_icon(const char *iconname, int scale);
  * @return an instance of `GdkPixbuf`, representing the name's image
  * @retval NULL: Invalid path given
  */
-GdkPixbuf *icon_get_for_name(const char *name, char **id, int dpi_scale);
+GdkPixbuf *icon_get_for_name(const char *name, char **id, double dpi_scale);
 
 /** Convert a GVariant like described in GdkPixbuf, scaled according to settings
  *
@@ -84,7 +84,7 @@ GdkPixbuf *icon_get_for_name(const char *name, char **id, int dpi_scale);
  * @return an instance of `GdkPixbuf` derived from the GVariant
  * @retval NULL: GVariant parameter nulled, invalid or in wrong format
  */
-GdkPixbuf *icon_get_for_data(GVariant *data, char **id, int scale);
+GdkPixbuf *icon_get_for_data(GVariant *data, char **id, double scale);
 
 #endif
 /* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/option_parser.c
+++ b/src/option_parser.c
@@ -284,6 +284,8 @@ bool set_from_string(void *target, struct setting setting, const char *value) {
         switch (setting.type) {
                 case TYPE_INT:
                         return safe_string_to_int(target, value);
+                case TYPE_DOUBLE:
+                        return safe_string_to_double(target, value);
                 case TYPE_STRING:
                         g_free(*(char**) target);
                         *(char**) target = g_strdup(value);

--- a/src/output.h
+++ b/src/output.h
@@ -45,7 +45,7 @@ struct output {
         bool (*is_idle)(void);
         bool (*have_fullscreen_window)(void);
 
-        int (*get_scale)(void);
+        double (*get_scale)(void);
 };
 
 /**

--- a/src/settings.h
+++ b/src/settings.h
@@ -35,7 +35,7 @@ enum zwlr_layer_shell_v1_layer {
 #endif /* ZWLR_LAYER_SHELL_V1_LAYER_ENUM */
 
 // TODO make a TYPE_CMD, instead of using TYPE_PATH for settings like dmenu and browser
-enum setting_type { TYPE_MIN = 0, TYPE_INT, TYPE_STRING, TYPE_PATH, TYPE_TIME,
+enum setting_type { TYPE_MIN = 0, TYPE_INT, TYPE_DOUBLE, TYPE_STRING, TYPE_PATH, TYPE_TIME,
         TYPE_GEOMETRY, TYPE_LIST, TYPE_CUSTOM,
         TYPE_DEPRECATED, TYPE_MAX = TYPE_DEPRECATED + 1 }; // to be implemented
 
@@ -96,6 +96,7 @@ struct settings {
         char *frame_color;
         int startup_notification;
         int monitor;
+        double scale;
         char *dmenu;
         char **dmenu_cmd;
         char *browser;

--- a/src/settings_data.h
+++ b/src/settings_data.h
@@ -932,6 +932,16 @@ static const struct setting allowed_settings[] = {
                 .parser_data = NULL,
         },
         {
+                .name = "scale",
+                .section = "global",
+                .description = "Scale factor, set to 0 to auto-detect, X11 only",
+                .type = TYPE_DOUBLE,
+                .default_value = "0",
+                .value = &settings.scale,
+                .parser = NULL,
+                .parser_data = NULL,
+        },
+        {
                 .name = "alignment",
                 .section = "global",
                 .description = "Text alignment left/center/right",

--- a/src/utils.c
+++ b/src/utils.c
@@ -202,6 +202,25 @@ bool safe_string_to_int(int *in, const char *str) {
 }
 
 /* see utils.h */
+bool safe_string_to_double(double *in, const char *str) {
+        errno = 0;
+        char *endptr;
+        double val = g_ascii_strtod(str, &endptr);
+        if (errno != 0) {
+                LOG_W("'%s': %s.", str, strerror(errno));
+                return false;
+        } else if (str == endptr) {
+                LOG_W("'%s': No digits found.", str);
+                return false;
+        } else if (*endptr != '\0') {
+                LOG_W("'%s': String contains non-digits.", str);
+                return false;
+        }
+        *in = val;
+        return true;
+}
+
+/* see utils.h */
 gint64 string_to_time(const char *string)
 {
         assert(string);

--- a/src/utils.h
+++ b/src/utils.h
@@ -116,13 +116,17 @@ char *string_to_path(char *string);
  * @param[in] str The string to parse
  * @return a bool if the conversion succeeded
  */
-
 bool safe_string_to_int(int *in, const char *str);
 
 /**
  * Same as safe_string_to_int, but then for a long
  */
 bool safe_string_to_long_long(long long *in, const char *str);
+
+/**
+ * Same as safe_string_to_int, but then for a double
+ */
+bool safe_string_to_double(double *in, const char *str);
 
 /**
  * Convert time units (ms, s, m) to the internal `gint64` microseconds format

--- a/src/wayland/wl.c
+++ b/src/wayland/wl.c
@@ -898,7 +898,7 @@ bool wl_have_fullscreen_window(void) {
         return have_fullscreen;
 }
 
-int wl_get_scale(void) {
+double wl_get_scale(void) {
         int scale = 0;
         struct dunst_output *output = get_configured_output();
         if (output) {

--- a/src/wayland/wl.h
+++ b/src/wayland/wl.h
@@ -27,6 +27,6 @@ bool wl_have_fullscreen_window(void);
 // Return the dpi scaling of the current output. Everything that's rendered
 // should be multiplied by this value, but don't use it to multiply other
 // values. All sizes should be in unscaled units.
-int wl_get_scale(void);
+double wl_get_scale(void);
 #endif
 /* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -161,8 +161,24 @@ static bool x_win_composited(struct window_x11 *win)
 void x_display_surface(cairo_surface_t *srf, window winptr, const struct dimensions *dim)
 {
         struct window_x11 *win = (struct window_x11*)winptr;
-        x_win_move(win, dim->x, dim->y, dim->w, dim->h);
-        cairo_xlib_surface_set_size(win->root_surface, dim->w, dim->h);
+        const struct screen_info *scr = get_active_screen();
+        int scale = x_get_scale();
+        int x, y;
+
+        if (settings.geometry.negative_x) {
+                x = (scr->x + (scr->w - dim->w * scale)) + settings.geometry.x * scale;
+        } else {
+                x = scr->x + settings.geometry.x * scale;
+        }
+
+        if (settings.geometry.negative_y) {
+                y = scr->y + (scr->h + settings.geometry.y * scale) - dim->h * scale;
+        } else {
+                y = scr->y + settings.geometry.y * scale;
+        }
+
+        x_win_move(win, x, y, dim->w * scale, dim->h * scale);
+        cairo_xlib_surface_set_size(win->root_surface, dim->w * scale, dim->h * scale);
 
         XClearWindow(xctx.dpy, win->xwin);
 
@@ -171,7 +187,7 @@ void x_display_surface(cairo_surface_t *srf, window winptr, const struct dimensi
         cairo_show_page(win->c_ctx);
 
         if (settings.corner_radius != 0 && ! x_win_composited(win))
-                x_win_corners_shape(win, dim->corner_radius);
+                x_win_corners_shape(win, dim->corner_radius * scale);
         else
                 x_win_corners_unshape(win);
 
@@ -943,7 +959,11 @@ static void x_shortcut_init(struct keyboard_shortcut *ks)
 }
 
 int x_get_scale(void) {
-        return 1;
+        const struct screen_info *scr_info = get_active_screen();
+        int scale = MAX(1, round(scr_info->dpi/96.));
+        LOG_D("X11 dpi: %i", scr_info->dpi);
+        LOG_D("X11 scale: %i", scale);
+        return scale;
 }
 
 /* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -959,6 +959,9 @@ static void x_shortcut_init(struct keyboard_shortcut *ks)
 }
 
 double x_get_scale(void) {
+        if (settings.scale > 0)
+                return settings.scale;
+
         const struct screen_info *scr_info = get_active_screen();
         double scale = MAX(1, scr_info->dpi/96.);
         LOG_D("X11 dpi: %i", scr_info->dpi);

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -162,23 +162,23 @@ void x_display_surface(cairo_surface_t *srf, window winptr, const struct dimensi
 {
         struct window_x11 *win = (struct window_x11*)winptr;
         const struct screen_info *scr = get_active_screen();
-        int scale = x_get_scale();
+        double scale = x_get_scale();
         int x, y;
 
         if (settings.geometry.negative_x) {
-                x = (scr->x + (scr->w - dim->w * scale)) + settings.geometry.x * scale;
+                x = (scr->x + (scr->w - round(dim->w * scale))) + round(settings.geometry.x * scale);
         } else {
-                x = scr->x + settings.geometry.x * scale;
+                x = scr->x + round(settings.geometry.x * scale);
         }
 
         if (settings.geometry.negative_y) {
-                y = scr->y + (scr->h + settings.geometry.y * scale) - dim->h * scale;
+                y = scr->y + (scr->h + round(settings.geometry.y * scale)) - round(dim->h * scale);
         } else {
-                y = scr->y + settings.geometry.y * scale;
+                y = scr->y + round(settings.geometry.y * scale);
         }
 
-        x_win_move(win, x, y, dim->w * scale, dim->h * scale);
-        cairo_xlib_surface_set_size(win->root_surface, dim->w * scale, dim->h * scale);
+        x_win_move(win, x, y, round(dim->w * scale), round(dim->h * scale));
+        cairo_xlib_surface_set_size(win->root_surface, round(dim->w * scale), round(dim->h * scale));
 
         XClearWindow(xctx.dpy, win->xwin);
 
@@ -187,7 +187,7 @@ void x_display_surface(cairo_surface_t *srf, window winptr, const struct dimensi
         cairo_show_page(win->c_ctx);
 
         if (settings.corner_radius != 0 && ! x_win_composited(win))
-                x_win_corners_shape(win, dim->corner_radius * scale);
+                x_win_corners_shape(win, round(dim->corner_radius * scale));
         else
                 x_win_corners_unshape(win);
 
@@ -958,11 +958,11 @@ static void x_shortcut_init(struct keyboard_shortcut *ks)
         g_free(str_begin);
 }
 
-int x_get_scale(void) {
+double x_get_scale(void) {
         const struct screen_info *scr_info = get_active_screen();
-        int scale = MAX(1, round(scr_info->dpi/96.));
+        double scale = MAX(1, scr_info->dpi/96.);
         LOG_D("X11 dpi: %i", scr_info->dpi);
-        LOG_D("X11 scale: %i", scale);
+        LOG_D("X11 scale: %f", scale);
         return scale;
 }
 

--- a/src/x11/x.h
+++ b/src/x11/x.h
@@ -51,6 +51,6 @@ void x_free(void);
 
 struct geometry x_parse_geometry(const char *geom_str);
 
-int x_get_scale(void);
+double x_get_scale(void);
 #endif
 /* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/test/option_parser.c
+++ b/test/option_parser.c
@@ -179,6 +179,65 @@ TEST test_string_to_int_invalid(void)
         PASS();
 }
 
+TEST test_string_to_double(void)
+{
+        if (2.3 != atof("2.3")) {
+                SKIPm("Skipping test_string_to_double, as it seems we're running under musl+valgrind!");
+        }
+
+        double val = -100.0;
+        const char* inputs[] = {
+                "0",
+                "1",
+                "-1",
+                "45.8",
+                "-45.8"
+        };
+        const double results[] = {
+                0,
+                1,
+                -1,
+                45.8,
+                -45.8
+        };
+        struct setting s;
+        s.type = TYPE_DOUBLE;
+
+        char buf[50];
+        for (int i = 0; i < G_N_ELEMENTS(inputs); i++) {
+                sprintf(buf, "Failed in round %i", i);
+                ASSERTm(buf, set_from_string(&val, s, inputs[i]));
+                ASSERT_EQm(buf, val, results[i]);
+        }
+        PASS();
+}
+
+TEST test_string_to_double_invalid(void)
+{
+        double val = -100.0;
+        const char* inputs[] = {
+                "a0",
+                "something",
+                "x1234asdf",
+                "-dsf1234asdf",
+                "1234a567",
+                "12.34a567",
+                "56.7.1",
+        };
+
+        struct setting s;
+        s.type = TYPE_DOUBLE;
+        s.name = "test_double";
+
+        char buf[50];
+        for (int i = 0; i < G_N_ELEMENTS(inputs); i++) {
+                sprintf(buf, "Failed in round %i", i);
+                ASSERT_FALSEm(buf, set_from_string(&val, s, inputs[i]));
+        }
+        ASSERT_EQm("Value should not be changed for invalid doubles", val, -100.0);
+        PASS();
+}
+
 TEST test_string_to_boolean(void)
 {
         bool val;
@@ -631,6 +690,8 @@ SUITE(suite_option_parser)
         // are normally stripped out by the ini parser.
         RUN_TEST(test_string_to_int);
         RUN_TEST(test_string_to_int_invalid);
+        RUN_TEST(test_string_to_double);
+        RUN_TEST(test_string_to_double_invalid);
         RUN_TEST(test_string_to_enum);
         RUN_TEST(test_string_to_enum_invalid);
         RUN_TEST(test_string_to_boolean);

--- a/test/setting.c
+++ b/test/setting.c
@@ -102,7 +102,8 @@ TEST test_dunstrc_defaults(void) {
                                                 ASSERT_EQm(message, a, b);
                                         }
                                       break;
-                        case TYPE_STRING: ;
+                        case TYPE_DOUBLE:
+                        case TYPE_STRING:
                         case TYPE_PATH:
                         case TYPE_GEOMETRY:
                         case TYPE_LIST:

--- a/test/settings_data.c
+++ b/test/settings_data.c
@@ -89,6 +89,7 @@ TEST test_valid_parser_and_data_per_type(void)
                         case TYPE_STRING:
                         case TYPE_TIME:
                         case TYPE_GEOMETRY:
+                        case TYPE_DOUBLE:
                         case TYPE_INT: ; // no parser and no parser data needed
                                 gchar *error1 = g_strdup_printf("Parser of setting %s should be NULL. It's not needed for this type", curr.name);
                                 gchar *error2 = g_strdup_printf("Parser data of setting %s should be NULL. It's not needed for this type", curr.name);


### PR DESCRIPTION
The scaling factor is derived from the active screen's dpi. This may
or may not match what is expected. Other sources could be font DPI or
Gdk/WindowScalingFactor.

Currently, only integer scaling is supported.

This reuses most of the code that was present for Wayland and the
change is limited to compute a scaling factor and putting the window
at the right position and at the right size. The code to compute the
window position in `draw.c` was only used for X11, so it was moved
directly in `x.c`.

See #884 for the discussion.

I would also be interested to support fractional scaling. From my understanding, this is not possible with Wayland, right? For X11, we can and the change would mostly be replacing `scale` by `scale*10` and divide it again by 10 everywhere.