### PR TITLE
Set cursor to left_ptr when mouse is over a notification on wayland

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -56,4 +56,5 @@ pkg_config_packs += libnotify
 
 ifneq (0,${WAYLAND})
 pkg_config_packs += wayland-client
+pkg_config_packs += wayland-cursor
 endif


### PR DESCRIPTION
As in mako here: https://github.com/emersion/mako/commit/85a3e38e9334cdd31dd43802b6850255986a72f2

Currently (on wayland) the cursor remains what it was when the mouse enters the notification window (i.e. from a terminal or a text entry box it'll be a vertical bar), this fixes that.

Code is taken from [mako](https://github.com/emersion/mako) (which used to have the same issue) and adapted a little to fit dunst.