### PR TITLE
Better default installation locations for systemd and dbus units

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,30 +8,7 @@ ifneq ($(wildcard ./.git/),)
 VERSION := $(shell ${GIT} describe --tags)
 endif
 
-ifeq (,${SYSTEMD})
-# Check for systemctl to avoid discrepancies on systems, where
-# systemd is installed, but systemd.pc is in another package
-systemctl := $(shell command -v ${SYSTEMCTL} >/dev/null && echo systemctl)
-ifeq (systemctl,${systemctl})
-SYSTEMD := 1
-else
-SYSTEMD := 0
-endif
-endif
-
-SERVICEDIR_DBUS ?= $(shell $(PKG_CONFIG) dbus-1 --variable=session_bus_services_dir)
-SERVICEDIR_DBUS := ${SERVICEDIR_DBUS}
-ifeq (,${SERVICEDIR_DBUS})
-$(error "Failed to query $(PKG_CONFIG) for package 'dbus-1'!")
-endif
-
-ifneq (0,${SYSTEMD})
-SERVICEDIR_SYSTEMD ?= $(shell $(PKG_CONFIG) systemd --variable=systemduserunitdir)
-SERVICEDIR_SYSTEMD := ${SERVICEDIR_SYSTEMD}
-ifeq (,${SERVICEDIR_SYSTEMD})
-$(error "Failed to query $(PKG_CONFIG) for package 'systemd'!")
-endif
-endif
+SYSTEMD ?= $(shell $(PKG_CONFIG) --silence-errors ${SYSTEMDAEMON} || echo 0)
 
 ifneq (0,${WAYLAND})
 DATA_DIR_WAYLAND_PROTOCOLS ?= $(shell $(PKG_CONFIG) wayland-protocols --variable=pkgdatadir)

--- a/README.md
+++ b/README.md
@@ -107,10 +107,10 @@ sudo make install
 - `BINDIR=<PATH>`: Set the `dunst` executable's path (Default: `${PREFIX}/bin`)
 - `DATADIR=<PATH>`: Set the path for shared files. (Default: `${PREFIX}/share`)
 - `MANDIR=<PATH>`: Set the prefix of the manpage. (Default: `${DATADIR}/man`)
-- `SYSTEMD=(0|1)`: Disable/Enable the systemd unit. (Default: detected via `pkg-config`)
+- `SYSTEMD=(0|1)`: Disable/Enable the systemd unit. (Default: autodetect systemd)
 - `WAYLAND=(0|1)`: Disable/Enable wayland support. (Default: 1 (enabled))
-- `SERVICEDIR_SYSTEMD=<PATH>`: The path to put the systemd user service file. Unused, if `SYSTEMD=0`. (Default: detected via `pkg-config`)
-- `SERVICEDIR_DBUS=<PATH>`: The path to put the dbus service file. (Default: detected via `pkg-config`)
+- `SERVICEDIR_SYSTEMD=<PATH>`: The path to put the systemd user service file. Unused, if `SYSTEMD=0`. (Default: `${PREFIX}/lib/systemd/user`)
+- `SERVICEDIR_DBUS=<PATH>`: The path to put the dbus service file. (Default: `${DATADIR}/dbus-1/services`)
 - `EXTRA_CFLAGS=<FLAGS>`: Additional flags for the compiler.
 
 **Make sure to run all make calls with the same parameter set. So when building with `make PREFIX=/usr`, you have to install it with `make PREFIX=/usr install`, too.**

--- a/config.mk
+++ b/config.mk
@@ -6,6 +6,8 @@ DATADIR ?= ${PREFIX}/share
 # around for backwards compatibility
 MANPREFIX ?= ${DATADIR}/man
 MANDIR ?= ${MANPREFIX}
+SERVICEDIR_DBUS ?= ${DATADIR}/dbus-1/services
+SERVICEDIR_SYSTEMD ?= ${PREFIX}/lib/systemd/user
 EXTRA_CFLAGS ?=
 
 DOXYGEN ?= doxygen
@@ -15,7 +17,7 @@ GIT ?= git
 PKG_CONFIG ?= pkg-config
 POD2MAN ?= pod2man
 SED ?= sed
-SYSTEMCTL ?= systemctl
+SYSTEMDAEMON ?= systemd
 VALGRIND ?= valgrind
 
 # Disable systemd service file installation,


### PR DESCRIPTION
This PR proposes better default locations, so locally installed dunst versions can coexist with distro version, as it should be. This fixes #907.