### PR TITLE
Dunstrc: Actually use it and be less disruptive on (un)install

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -1,7 +1,8 @@
 # paths
 PREFIX ?= /usr/local
 BINDIR ?= ${PREFIX}/bin
-SYSCONFDIR ?= /etc
+SYSCONFDIR ?= ${PREFIX}/etc/xdg
+SYSCONFFILE ?= ${SYSCONFDIR}/dunst/dunstrc
 DATADIR ?= ${PREFIX}/share
 # around for backwards compatibility
 MANPREFIX ?= ${DATADIR}/man
@@ -33,9 +34,11 @@ ifneq (0, ${WAYLAND})
 ENABLE_WAYLAND= -DENABLE_WAYLAND
 endif
 
+DEF_SYSCONFFILE=-DSYSCONFFILE=\"${SYSCONFFILE}\"
+
 # flags
 DEFAULT_CPPFLAGS = -D_DEFAULT_SOURCE -DVERSION=\"${VERSION}\"
-DEFAULT_CFLAGS   = -g --std=gnu99 -pedantic -Wall -Wno-overlength-strings -Os ${ENABLE_WAYLAND} ${EXTRA_CFLAGS}
+DEFAULT_CFLAGS   = -g --std=gnu99 -pedantic -Wall -Wno-overlength-strings -Os ${DEF_SYSCONFFILE} ${ENABLE_WAYLAND} ${EXTRA_CFLAGS}
 DEFAULT_LDFLAGS  = -lm -lrt
 
 CPPFLAGS_DEBUG := -DDEBUG_BUILD

--- a/src/settings.c
+++ b/src/settings.c
@@ -19,7 +19,6 @@ struct settings settings;
 
 static FILE *xdg_config(const char *filename)
 {
-        const gchar * const * systemdirs = g_get_system_config_dirs();
         const gchar * userdir = g_get_user_config_dir();
 
         FILE *f;
@@ -29,16 +28,8 @@ static FILE *xdg_config(const char *filename)
         f = fopen(path, "r");
         g_free(path);
 
-        for (const gchar * const *d = systemdirs;
-             !f && *d;
-             d++) {
-                path = g_strconcat(*d, filename, NULL);
-                f = fopen(path, "r");
-                g_free(path);
-        }
-
         if (!f) {
-                f = fopen("/etc/dunst/dunstrc", "r");
+                f = fopen(SYSCONFFILE, "r");
         }
 
         return f;


### PR DESCRIPTION
This PR proposes a fix for several issues with dunstrc. For starters, it was installing to the wrong location ('/etc/dunst/dunstrc') instead of at least ('/etc/xdg/dunst/dunstrc'), which would be the right place, were it not a distro managed confdir. On top of that 'make install' would happily overwrite whatever file is there already, violating at least the Debian Policy of never silently overwriting user/admin configs. Locally installed software is expected to put its system-wide conffiles in '/usr/local/etc'. In this case the XDG_CONF_DIRS spec (XDG base directory spec) comes into play, so the right location is '/usr/local/etc/xdg/dunst/dunstrc'. With theses changes, installation of 'dunstrc' is made to that path.
Plus, now install won't overwrite an already existing dunstrc, i.e. on upgrade. And it will also not remove it on uninstall. I introduce a new make target called "purge", blatantly borrowing the name from Debian, think: 'apt-get purge' as opposed to 'apt-get remove'. Also the current behavior (before this PR) is to just 'rm -rf /etc/dunst', which does not account for files the admin might have in there besides dunstrc, i.e. backups of said file or maybe even a git repo for versioning. The latter seems to be all the rage today for tinkering with configs. *Edit: But then again, judging by the Makefile, dunstrc was considered to be documentation and the current documentation, which I intend to update as well (see below), seems to do the same: "Copy it and make it work", in short.*

But there is a catch: XDG_CONF_DIRS might not be set (i.e. on Ubuntu), so it defaults to '/etc/xdg', which in turn would lead dunstrc being picked up from there and not the local etc. To account for that the systemd user service and the dbus service set XDG_CONF_DIRS appropriately in their respective environments. Which only leaves the case of running /usr/local/bin/dunst directly. I have not yet found a way to deal with that. So the user has a choice: run it and use a possibly outdated conffile provided by the distro, which might contain obsolete settings. Or make sure that they set XDG_CONF_DIRS, ie: 'env XDG_CONF_DIRS=/usr/local/etc/xdg:$XDG_CONF_DIRS /usr/local/dunst'.

Now, this PR is not *quite* finished, but I figured I might as well get some feedback before I update the README and also on the TODO list: remove non-existent settings from dunstrc which dunst keeps complaining about, now that it actually reads it.