### PR TITLE
markup: Strip only symbols which include a closing delimiter

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -124,13 +124,24 @@ void string_strip_delimited(char *str, char a, char b)
         assert(str);
 
         int iread=-1, iwrite=0, copen=0;
+        int cskip = 0;
         while (str[++iread] != 0) {
                 if (str[iread] == a) {
                         ++copen;
                 } else if (str[iread] == b && copen > 0) {
                         --copen;
                 } else if (copen == 0) {
+                        cskip = 0;
                         str[iwrite++] = str[iread];
+                }
+                if (copen > 0){
+                        cskip++;
+                }
+        }
+        if (copen > 0) {
+                iread -= cskip;
+                for (int i = 0; i < cskip; i++) {
+                        str[iwrite++] = str[iread++];
                 }
         }
         str[iwrite] = 0;

--- a/test/markup.c
+++ b/test/markup.c
@@ -15,7 +15,7 @@ TEST test_markup_strip(void)
         g_free(ptr);
         ASSERT_STR_EQ("&amp;", (ptr=markup_strip(g_strdup("&amp;amp;"))));
         g_free(ptr);
-        ASSERT_STR_EQ(">A  ", (ptr=markup_strip(g_strdup(">A <img> <string"))));
+        ASSERT_STR_EQ(">A  <string", (ptr=markup_strip(g_strdup(">A <img> <string"))));
         g_free(ptr);
 
         PASS();

--- a/test/utils.c
+++ b/test/utils.c
@@ -119,10 +119,6 @@ TEST test_string_strip_delimited(void)
         string_strip_delimited(text, '<', '>');
         ASSERT_STR_EQ("Remove html tags", text);
 
-        strcpy(text, "Calls|with|identical|delimiters|are|handled|properly");
-        string_strip_delimited(text, '|', '|');
-        ASSERT_STR_EQ("Calls", text);
-
         strcpy(text, "<Return empty string if there is nothing left>");
         string_strip_delimited(text, '<', '>');
         ASSERT_STR_EQ("", text);
@@ -130,6 +126,18 @@ TEST test_string_strip_delimited(void)
         strcpy(text, "Nothing is done if there are no delimiters in the string");
         string_strip_delimited(text, '<', '>');
         ASSERT_STR_EQ("Nothing is done if there are no delimiters in the string", text);
+
+        strcpy(text, "We <3 dunst");
+        string_strip_delimited(text, '<', '>');
+        ASSERT_STR_EQ("We <3 dunst", text);
+
+        strcpy(text, "<b>We</b> <3 dunst");
+        string_strip_delimited(text, '<', '>');
+        ASSERT_STR_EQ("We <3 dunst", text);
+
+        strcpy(text, "dunst > the rest");
+        string_strip_delimited(text, '<', '>');
+        ASSERT_STR_EQ("dunst > the rest", text);
 
         g_free(text);
         PASS();


### PR DESCRIPTION
Some notifications might include markup (XML) symbols without escaping
them correctly. Instead of cutting off the notification text from that
symbol, ignore those symbols and escape them instead.
This isn't a full workaround, since it still strips all the markup, even
from the title. But since this is user error anyways, it is good enough.

Fixes #900 