### PR TITLE
Add word wrap in again

### DIFF
--- a/docs/dunst.5.pod
+++ b/docs/dunst.5.pod
@@ -370,10 +370,6 @@ If any of these exists in the format but hasn't been specified in the
 notification (e.g. no icon has been set), the placeholders will simply be
 removed from the format.
 
-=item B<alignment> (values: [left/center/right], default: left)
-
-Defines how the text should be aligned within the notification.
-
 =item B<vertical_alignment> (values: [top/center/bottom], default: center)
 
 Defines how the text and icon should be aligned vertically within the
@@ -870,6 +866,10 @@ the text doesn't fit in the window, it will be ellipsize according to ellipsize.
 =item B<ellipsize> (values: [start/middle/end], default: middle)
 
 Specifies where truncated lines should be ellipsized.
+
+=item B<alignment> (values: [left/center/right], default: left)
+
+Defines how the text should be aligned within the notification.
 
 =back
 

--- a/docs/dunst.5.pod
+++ b/docs/dunst.5.pod
@@ -386,10 +386,6 @@ See TIME FORMAT for valid times.
 
 Set to -1 to disable.
 
-=item B<ellipsize> (values: [start/middle/end], default: middle)
-
-Specifies where truncated lines should be ellipsized.
-
 =item B<ignore_newline> (values: [true/false], default: false)
 
 If set to true, replace newline characters in notifications with whitespace.
@@ -870,6 +866,10 @@ Specifies whether to wrap the text if the lines get longer than the maximum
 notification width. If it's set to true, long lines will be broken into multiple
 lines expanding the notification window height as necessary for them to fit. If
 the text doesn't fit in the window, it will be ellipsize according to ellipsize.
+
+=item B<ellipsize> (values: [start/middle/end], default: middle)
+
+Specifies where truncated lines should be ellipsized.
 
 =back
 

--- a/docs/dunst.5.pod
+++ b/docs/dunst.5.pod
@@ -388,8 +388,7 @@ Set to -1 to disable.
 
 =item B<ellipsize> (values: [start/middle/end], default: middle)
 
-If word_wrap is set to false, specifies where truncated lines should be
-ellipsized.
+Specifies where truncated lines should be ellipsized.
 
 =item B<ignore_newline> (values: [true/false], default: false)
 
@@ -864,6 +863,13 @@ Sets the name of the action to be invoked on do_action. If not specified, the
 action set as default action or the only available action will be invoked.
 
 Default: "default"
+
+=item B<word_wrap> (values: [true/false], default: true)
+
+Specifies whether to wrap the text if the lines get longer than the maximum
+notification width. If it's set to true, long lines will be broken into multiple
+lines expanding the notification window height as necessary for them to fit. If
+the text doesn't fit in the window, it will be ellipsize according to ellipsize.
 
 =back
 

--- a/src/draw.c
+++ b/src/draw.c
@@ -169,14 +169,20 @@ static void get_text_size(PangoLayout *l, int *w, int *h, double scale) {
 // Set up pango for a given layout.
 // @param width The avaiable text width in pixels, used for caluclating alignment and wrapping
 // @param height The maximum text height in pixels.
-static void layout_setup_pango(PangoLayout *layout, int width, int height)
+static void layout_setup_pango(PangoLayout *layout, int width, int height, bool word_wrap)
 {
         double scale = output->get_scale();
         pango_layout_set_wrap(layout, PANGO_WRAP_WORD_CHAR);
         pango_layout_set_width(layout, round(width * scale * PANGO_SCALE));
-        pango_layout_set_height(layout, round(height * scale * PANGO_SCALE));
+
+        // When no height is set, word wrap is turned off
+        if (word_wrap)
+                pango_layout_set_height(layout, round(height * scale * PANGO_SCALE));
+
         pango_layout_set_font_description(layout, pango_fdesc);
         pango_layout_set_spacing(layout, round(settings.line_height * scale * PANGO_SCALE));
+
+        pango_layout_set_ellipsize(layout, settings.ellipsize);
 
         PangoAlignment align;
         switch (settings.align) {
@@ -203,7 +209,7 @@ static void layout_setup(struct colored_layout *cl, int width, int height, doubl
         int text_width = width - icon_width - 2 * settings.h_padding;
         int progress_bar_height = have_progress_bar(cl->n) ? settings.progress_bar_height + settings.padding : 0;
         int max_text_height = MAX(0, settings.height - progress_bar_height - 2 * settings.padding);
-        layout_setup_pango(cl->l, text_width, max_text_height);
+        layout_setup_pango(cl->l, text_width, max_text_height, cl->n->word_wrap);
 }
 
 static void free_colored_layout(void *data)
@@ -233,6 +239,7 @@ static struct dimensions calculate_notification_dimensions(struct colored_layout
 
         dim.h = MIN(settings.height, dim.h + settings.padding * 2);
         dim.w = MAX(settings.width.min, dim.w);
+        dim.w = MIN(settings.width.max, dim.w);
 
         cl->n->displayed_height = dim.h;
         return dim;
@@ -279,8 +286,6 @@ static struct colored_layout *layout_init_shared(cairo_t *c, struct notification
 {
         struct colored_layout *cl = g_malloc(sizeof(struct colored_layout));
         cl->l = layout_create(c);
-
-        pango_layout_set_ellipsize(cl->l, settings.ellipsize);
 
         if (settings.icon_position != ICON_OFF && n->icon) {
                 cl->icon = gdk_pixbuf_to_cairo_surface(n->icon);

--- a/src/draw.c
+++ b/src/draw.c
@@ -169,7 +169,8 @@ static void get_text_size(PangoLayout *l, int *w, int *h, double scale) {
 // Set up pango for a given layout.
 // @param width The avaiable text width in pixels, used for caluclating alignment and wrapping
 // @param height The maximum text height in pixels.
-static void layout_setup_pango(PangoLayout *layout, int width, int height, bool word_wrap)
+static void layout_setup_pango(PangoLayout *layout, int width, int height,
+                bool word_wrap, PangoEllipsizeMode ellipsize_mode)
 {
         double scale = output->get_scale();
         pango_layout_set_wrap(layout, PANGO_WRAP_WORD_CHAR);
@@ -182,7 +183,7 @@ static void layout_setup_pango(PangoLayout *layout, int width, int height, bool 
         pango_layout_set_font_description(layout, pango_fdesc);
         pango_layout_set_spacing(layout, round(settings.line_height * scale * PANGO_SCALE));
 
-        pango_layout_set_ellipsize(layout, settings.ellipsize);
+        pango_layout_set_ellipsize(layout, ellipsize_mode);
 
         PangoAlignment align;
         switch (settings.align) {
@@ -209,7 +210,7 @@ static void layout_setup(struct colored_layout *cl, int width, int height, doubl
         int text_width = width - icon_width - 2 * settings.h_padding;
         int progress_bar_height = have_progress_bar(cl->n) ? settings.progress_bar_height + settings.padding : 0;
         int max_text_height = MAX(0, settings.height - progress_bar_height - 2 * settings.padding);
-        layout_setup_pango(cl->l, text_width, max_text_height, cl->n->word_wrap);
+        layout_setup_pango(cl->l, text_width, max_text_height, cl->n->word_wrap, cl->n->ellipsize);
 }
 
 static void free_colored_layout(void *data)

--- a/src/draw.c
+++ b/src/draw.c
@@ -170,7 +170,8 @@ static void get_text_size(PangoLayout *l, int *w, int *h, double scale) {
 // @param width The avaiable text width in pixels, used for caluclating alignment and wrapping
 // @param height The maximum text height in pixels.
 static void layout_setup_pango(PangoLayout *layout, int width, int height,
-                bool word_wrap, PangoEllipsizeMode ellipsize_mode)
+                bool word_wrap, PangoEllipsizeMode ellipsize_mode,
+                PangoAlignment alignment)
 {
         double scale = output->get_scale();
         pango_layout_set_wrap(layout, PANGO_WRAP_WORD_CHAR);
@@ -185,20 +186,7 @@ static void layout_setup_pango(PangoLayout *layout, int width, int height,
 
         pango_layout_set_ellipsize(layout, ellipsize_mode);
 
-        PangoAlignment align;
-        switch (settings.align) {
-        case ALIGN_LEFT:
-        default:
-                align = PANGO_ALIGN_LEFT;
-                break;
-        case ALIGN_CENTER:
-                align = PANGO_ALIGN_CENTER;
-                break;
-        case ALIGN_RIGHT:
-                align = PANGO_ALIGN_RIGHT;
-                break;
-        }
-        pango_layout_set_alignment(layout, align);
+        pango_layout_set_alignment(layout, alignment);
 }
 
 // Set up the layout of a single notification
@@ -210,7 +198,7 @@ static void layout_setup(struct colored_layout *cl, int width, int height, doubl
         int text_width = width - icon_width - 2 * settings.h_padding;
         int progress_bar_height = have_progress_bar(cl->n) ? settings.progress_bar_height + settings.padding : 0;
         int max_text_height = MAX(0, settings.height - progress_bar_height - 2 * settings.padding);
-        layout_setup_pango(cl->l, text_width, max_text_height, cl->n->word_wrap, cl->n->ellipsize);
+        layout_setup_pango(cl->l, text_width, max_text_height, cl->n->word_wrap, cl->n->ellipsize, cl->n->alignment);
 }
 
 static void free_colored_layout(void *data)

--- a/src/notification.c
+++ b/src/notification.c
@@ -380,6 +380,7 @@ struct notification *notification_create(void)
 
         n->transient = false;
         n->progress = -1;
+        n->word_wrap = true;
 
         n->script_run = false;
         n->dbus_valid = false;

--- a/src/notification.c
+++ b/src/notification.c
@@ -381,6 +381,7 @@ struct notification *notification_create(void)
         n->transient = false;
         n->progress = -1;
         n->word_wrap = true;
+        n->ellipsize = PANGO_ELLIPSIZE_MIDDLE;
 
         n->script_run = false;
         n->dbus_valid = false;

--- a/src/notification.c
+++ b/src/notification.c
@@ -382,6 +382,7 @@ struct notification *notification_create(void)
         n->progress = -1;
         n->word_wrap = true;
         n->ellipsize = PANGO_ELLIPSIZE_MIDDLE;
+        n->alignment = PANGO_ALIGN_LEFT;
 
         n->script_run = false;
         n->dbus_valid = false;

--- a/src/notification.h
+++ b/src/notification.h
@@ -5,6 +5,7 @@
 #include <gdk-pixbuf/gdk-pixbuf.h>
 #include <glib.h>
 #include <stdbool.h>
+#include <pango/pango-layout.h>
 
 #include "markup.h"
 
@@ -86,6 +87,7 @@ struct notification {
         bool script_run;        /**< Has the script been executed already? */
         guint8 marked_for_closure;
         bool word_wrap;
+        PangoEllipsizeMode ellipsize;
 
         /* derived fields */
         char *msg;            /**< formatted message */

--- a/src/notification.h
+++ b/src/notification.h
@@ -85,6 +85,7 @@ struct notification {
         enum behavior_fullscreen fullscreen; //!< The instruction what to do with it, when desktop enters fullscreen
         bool script_run;        /**< Has the script been executed already? */
         guint8 marked_for_closure;
+        bool word_wrap;
 
         /* derived fields */
         char *msg;            /**< formatted message */

--- a/src/notification.h
+++ b/src/notification.h
@@ -88,6 +88,7 @@ struct notification {
         guint8 marked_for_closure;
         bool word_wrap;
         PangoEllipsizeMode ellipsize;
+        PangoAlignment alignment;
 
         /* derived fields */
         char *msg;            /**< formatted message */

--- a/src/option_parser.c
+++ b/src/option_parser.c
@@ -447,7 +447,7 @@ void save_settings(struct ini *ini) {
                         if (is_special_section(curr_section.name)) {
                                 if (is_rule) {
                                         // set as a rule, but only if it's not a filter
-                                        if (rule_offset_is_action(curr_setting.rule_offset)) {
+                                        if (rule_offset_is_modifying(curr_setting.rule_offset)) {
                                                 LOG_D("Adding rule '%s = %s' to special section %s",
                                                                 curr_entry.key,
                                                                 curr_entry.value,

--- a/src/rules.c
+++ b/src/rules.c
@@ -156,7 +156,7 @@ struct rule *get_rule(const char* name) {
 /**
  * see rules.h
  */
-bool rule_offset_is_action(const size_t offset) {
+bool rule_offset_is_modifying(const size_t offset) {
         const size_t first_action = offsetof(struct rule, timeout);
         const size_t last_action = offsetof(struct rule, set_stack_tag);
         return (offset >= first_action) && (offset <= last_action);
@@ -167,7 +167,7 @@ bool rule_offset_is_action(const size_t offset) {
  */
 bool rule_offset_is_filter(const size_t offset) {
         const size_t first_filter = offsetof(struct rule, appname);
-        return (offset >= first_filter) && !rule_offset_is_action(offset);
+        return (offset >= first_filter) && !rule_offset_is_modifying(offset);
 }
 
 /* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/rules.c
+++ b/src/rules.c
@@ -34,6 +34,8 @@ void rule_apply(struct rule *r, struct notification *n)
                 n->word_wrap = r->word_wrap;
         if (r->ellipsize != -1)
                 n->ellipsize = r->ellipsize;
+        if (r->alignment != -1)
+                n->alignment = r->alignment;
         if (r->action_name) {
                 g_free(n->default_action_name);
                 n->default_action_name = g_strdup(r->action_name);

--- a/src/rules.c
+++ b/src/rules.c
@@ -32,6 +32,8 @@ void rule_apply(struct rule *r, struct notification *n)
                 n->skip_display = r->skip_display;
         if (r->word_wrap != -1)
                 n->word_wrap = r->word_wrap;
+        if (r->ellipsize != -1)
+                n->ellipsize = r->ellipsize;
         if (r->action_name) {
                 g_free(n->default_action_name);
                 n->default_action_name = g_strdup(r->action_name);

--- a/src/rules.c
+++ b/src/rules.c
@@ -30,6 +30,8 @@ void rule_apply(struct rule *r, struct notification *n)
                 n->transient = r->set_transient;
         if (r->skip_display != -1)
                 n->skip_display = r->skip_display;
+        if (r->word_wrap != -1)
+                n->word_wrap = r->word_wrap;
         if (r->action_name) {
                 g_free(n->default_action_name);
                 n->default_action_name = g_strdup(r->action_name);

--- a/src/rules.h
+++ b/src/rules.h
@@ -38,6 +38,7 @@ struct rule {
         int skip_display;
         int word_wrap;
         int ellipsize;
+        int alignment;
         char *new_icon;
         char *fg;
         char *bg;

--- a/src/rules.h
+++ b/src/rules.h
@@ -37,6 +37,7 @@ struct rule {
         int set_transient;
         int skip_display;
         int word_wrap;
+        int ellipsize;
         char *new_icon;
         char *fg;
         char *bg;

--- a/src/rules.h
+++ b/src/rules.h
@@ -27,8 +27,8 @@ struct rule {
         char *desktop_entry;
         int msg_urgency;
 
-        /* actions */
-        gint64 timeout; // this has to be the first action
+        /* modifying */
+        gint64 timeout; // this has to be the first modifying rule
         enum urgency urgency;
         char *action_name;
         enum markup_mode markup;
@@ -77,7 +77,7 @@ struct rule *get_rule(const char* name);
  *
  * @returns a boolean if the rule is an action
  */
-bool rule_offset_is_action(const size_t offset);
+bool rule_offset_is_modifying(const size_t offset);
 
 /**
  * Check if a rule is an filter

--- a/src/rules.h
+++ b/src/rules.h
@@ -36,6 +36,7 @@ struct rule {
         int match_transient;
         int set_transient;
         int skip_display;
+        int word_wrap;
         char *new_icon;
         char *fg;
         char *bg;

--- a/src/settings.h
+++ b/src/settings.h
@@ -3,7 +3,6 @@
 #define DUNST_SETTINGS_H
 
 #include <stdbool.h>
-#include <pango/pango-layout.h>
 
 #ifdef ENABLE_WAYLAND
 #include "wayland/protocols/wlr-layer-shell-unstable-v1-client-header.h"
@@ -16,7 +15,6 @@
 #define LIST_END (-1)
 
 enum alignment { ALIGN_LEFT, ALIGN_CENTER, ALIGN_RIGHT };
-enum ellipsize { ELLIPSE_START, ELLIPSE_MIDDLE, ELLIPSE_END };
 enum icon_position { ICON_LEFT, ICON_RIGHT, ICON_OFF };
 enum vertical_alignment { VERTICAL_TOP, VERTICAL_CENTER, VERTICAL_BOTTOM };
 enum separator_color { SEP_FOREGROUND, SEP_AUTO, SEP_FRAME, SEP_CUSTOM };
@@ -115,7 +113,6 @@ struct settings {
         int history_length;
         int show_indicators;
         int ignore_dbusclose;
-        PangoEllipsizeMode ellipsize;
         int ignore_newline;
         int line_height;
         int separator_height;

--- a/src/settings_data.h
+++ b/src/settings_data.h
@@ -115,6 +115,7 @@ static const struct rule empty_rule = {
         .skip_display    = -1,
         .word_wrap       = -1,
         .ellipsize       = -1,
+        .alignment       = -1,
         .new_icon        = NULL,
         .fg              = NULL,
         .bg              = NULL,
@@ -178,9 +179,9 @@ static const struct string_to_enum_def boolean_enum_data[] = {
 };
 
 static const struct string_to_enum_def horizontal_alignment_enum_data[] = {
-        {"left",   ALIGN_LEFT },
-        {"center", ALIGN_CENTER },
-        {"right",  ALIGN_RIGHT },
+        {"left",   PANGO_ALIGN_LEFT },
+        {"center", PANGO_ALIGN_CENTER },
+        {"right",  PANGO_ALIGN_RIGHT },
         ENUM_END,
 };
 
@@ -531,7 +532,7 @@ static const struct setting allowed_settings[] = {
         },
         {
                 .name = "ellipsize",
-                .section = "global",
+                .section = "*",
                 .description = "Ellipsize truncated lines on the start/middle/end",
                 .type = TYPE_CUSTOM,
                 .default_value = "*",
@@ -539,6 +540,17 @@ static const struct setting allowed_settings[] = {
                 .parser = string_parse_enum,
                 .parser_data = ellipsize_enum_data,
                 .rule_offset = offsetof(struct rule, ellipsize),
+        },
+        {
+                .name = "alignment",
+                .section = "*",
+                .description = "Text alignment left/center/right",
+                .type = TYPE_CUSTOM,
+                .default_value = "*",
+                .value = NULL,
+                .parser = string_parse_enum,
+                .parser_data = horizontal_alignment_enum_data,
+                .rule_offset = offsetof(struct rule, alignment),
         },
 
         // other settings below
@@ -943,16 +955,6 @@ static const struct setting allowed_settings[] = {
                 .value = &settings.scale,
                 .parser = NULL,
                 .parser_data = NULL,
-        },
-        {
-                .name = "alignment",
-                .section = "global",
-                .description = "Text alignment left/center/right",
-                .type = TYPE_CUSTOM,
-                .default_value = "left",
-                .value = &settings.align,
-                .parser = string_parse_enum,
-                .parser_data = horizontal_alignment_enum_data,
         },
         {
                 .name = "separator_color",

--- a/src/settings_data.h
+++ b/src/settings_data.h
@@ -114,6 +114,7 @@ static const struct rule empty_rule = {
         .set_transient   = -1,
         .skip_display    = -1,
         .word_wrap       = -1,
+        .ellipsize       = -1,
         .new_icon        = NULL,
         .fg              = NULL,
         .bg              = NULL,
@@ -528,6 +529,17 @@ static const struct setting allowed_settings[] = {
                 .parser_data = boolean_enum_data,
                 .rule_offset = offsetof(struct rule, word_wrap),
         },
+        {
+                .name = "ellipsize",
+                .section = "global",
+                .description = "Ellipsize truncated lines on the start/middle/end",
+                .type = TYPE_CUSTOM,
+                .default_value = "*",
+                .value = NULL,
+                .parser = string_parse_enum,
+                .parser_data = ellipsize_enum_data,
+                .rule_offset = offsetof(struct rule, ellipsize),
+        },
 
         // other settings below
         {
@@ -911,16 +923,6 @@ static const struct setting allowed_settings[] = {
                 .value = &settings.markup,
                 .parser = string_parse_enum,
                 .parser_data = markup_mode_enum_data,
-        },
-        {
-                .name = "ellipsize",
-                .section = "global",
-                .description = "Ellipsize truncated lines on the start/middle/end",
-                .type = TYPE_CUSTOM,
-                .default_value = "middle",
-                .value = &settings.ellipsize,
-                .parser = string_parse_enum,
-                .parser_data = ellipsize_enum_data,
         },
         {
                 .name = "follow",

--- a/src/settings_data.h
+++ b/src/settings_data.h
@@ -113,6 +113,7 @@ static const struct rule empty_rule = {
         .match_transient = -1,
         .set_transient   = -1,
         .skip_display    = -1,
+        .word_wrap       = -1,
         .new_icon        = NULL,
         .fg              = NULL,
         .bg              = NULL,
@@ -517,6 +518,19 @@ static const struct setting allowed_settings[] = {
                 .rule_offset = offsetof(struct rule, history_ignore),
         },
         {
+                .name = "word_wrap",
+                .section = "*",
+                .description = "Wrap long lines of text",
+                .type = TYPE_CUSTOM,
+                .default_value = "*",
+                .value = NULL,
+                .parser = string_parse_enum,
+                .parser_data = boolean_enum_data,
+                .rule_offset = offsetof(struct rule, word_wrap),
+        },
+
+        // other settings below
+        {
                 .name = "frame_color",
                 .section = "*",
                 .description = "Color of the frame around the window",
@@ -527,8 +541,6 @@ static const struct setting allowed_settings[] = {
                 .parser_data = NULL,
                 .rule_offset = offsetof(struct rule, fc),
         },
-
-        // other settings below
         {
                 .name = "per_monitor_dpi",
                 .section = "experimental",

--- a/test/option_parser.c
+++ b/test/option_parser.c
@@ -738,7 +738,6 @@ TEST test_enum_size(void)
 {
         TEST_ENUM(enum markup_mode);
         TEST_ENUM(enum alignment);
-        TEST_ENUM(enum ellipsize);
         TEST_ENUM(enum icon_position);
         TEST_ENUM(enum vertical_alignment);
         TEST_ENUM(enum follow_mode);


### PR DESCRIPTION
This time it's a rule. I changed ellipsize and alignment to a rule as well.
You don't need to change anything to your config, since you can also use rules in the [global] section now. But if you want, you can turn off word_wrap just word just for the notifications that need it.

@fitrh or @wael444 would you mind checking if this matches the desired behaviour?

fixes #921