### PR TITLE
x11: fixes for dpi scaling

### DIFF
--- a/src/draw.c
+++ b/src/draw.c
@@ -163,9 +163,9 @@ static void get_text_size(PangoLayout *l, int *w, int *h, double scale) {
         // scale the size down, because it may be rendered at higher DPI
 
         if (w)
-                *w = round(*w / scale);
+                *w = ceil(*w / scale);
         if (h)
-                *h = round(*h / scale);
+                *h = ceil(*h / scale);
 }
 
 // Set up pango for a given layout.

--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -446,7 +446,9 @@ static void x_handle_click(XEvent ev)
                 button_state = true; // button is down
         }
 
-        input_handle_click(linux_code, button_state, ev.xbutton.x, ev.xbutton.y);
+        float scale = x_get_scale();
+        input_handle_click(linux_code, button_state, ev.xbutton.x/scale,
+                        ev.xbutton.y/scale);
 }
 
 void x_free(void)


### PR DESCRIPTION
This may solve issue with incorrect window sizes.
It also fixes mouse position calculations. So the correct notification will be closed again when clicking on it.

Fixes: #950 #966