### PR TITLE
proof of concept: dunstctl reload

### DIFF
--- a/dunstctl
+++ b/dunstctl
@@ -62,6 +62,9 @@ case "${1:-}" in
 	"context")
 		method_call "${DBUS_IFAC_DUNST}.ContextMenuCall" >/dev/null
 		;;
+	"reload")
+		method_call "${DBUS_IFAC_DUNST}.ReloadConfig" >/dev/null
+		;;
 	"count")
 		[ $# -eq 1 ] || [ "${2}" = "displayed" ] || [ "${2}" = "history" ] || [ "${2}" = "waiting" ] \
 			|| die "Please give either 'displayed', 'history', 'waiting' or none as count parameter."

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -80,6 +80,7 @@ static const char *introspection_xml =
     "        <method name=\"NotificationCloseLast\" />"
     "        <method name=\"NotificationCloseAll\"  />"
     "        <method name=\"NotificationShow\"      />"
+    "        <method name=\"ReloadConfig\"          />"
     "        <method name=\"Ping\"                  />"
 
     "        <property name=\"paused\" type=\"b\" access=\"readwrite\">"
@@ -163,6 +164,7 @@ DBUS_METHOD(dunst_NotificationAction);
 DBUS_METHOD(dunst_NotificationCloseAll);
 DBUS_METHOD(dunst_NotificationCloseLast);
 DBUS_METHOD(dunst_NotificationShow);
+DBUS_METHOD(dunst_ReloadConfig);
 DBUS_METHOD(dunst_Ping);
 static struct dbus_method methods_dunst[] = {
         {"ContextMenuCall",        dbus_cb_dunst_ContextMenuCall},
@@ -170,6 +172,7 @@ static struct dbus_method methods_dunst[] = {
         {"NotificationCloseAll",   dbus_cb_dunst_NotificationCloseAll},
         {"NotificationCloseLast",  dbus_cb_dunst_NotificationCloseLast},
         {"NotificationShow",       dbus_cb_dunst_NotificationShow},
+        {"ReloadConfig",           dbus_cb_dunst_ReloadConfig},
         {"Ping",                   dbus_cb_dunst_Ping},
 };
 
@@ -279,6 +282,16 @@ static void dbus_cb_dunst_NotificationShow(GDBusConnection *connection,
         queues_history_pop();
         wake_up();
 
+        g_dbus_method_invocation_return_value(invocation, NULL);
+        g_dbus_connection_flush(connection, NULL, NULL, NULL);
+}
+
+static void dbus_cb_dunst_ReloadConfig(GDBusConnection *connection,
+                                           const gchar *sender,
+                                           GVariant *parameters,
+                                           GDBusMethodInvocation *invocation)
+{
+        reload();
         g_dbus_method_invocation_return_value(invocation, NULL);
         g_dbus_connection_flush(connection, NULL, NULL, NULL);
 }

--- a/src/draw.c
+++ b/src/draw.c
@@ -804,6 +804,7 @@ void draw(void)
 
 void draw_deinit(void)
 {
+        pango_font_description_free(pango_fdesc);
         output->win_destroy(win);
         output->deinit();
         if (settings.enable_recursive_icon_lookup)

--- a/src/dunst.c
+++ b/src/dunst.c
@@ -161,6 +161,8 @@ void reload(void)
         load_settings(cmdline_config_path);
         draw_setup();
 
+        queues_reapply_all_rules();
+
         status = save;
         queues_update(status);
         wake_up();

--- a/src/dunst.c
+++ b/src/dunst.c
@@ -145,6 +145,27 @@ static void teardown(void)
         draw_deinit();
 }
 
+char *cmdline_config_path;
+
+void reload(void)
+{
+        LOG_W("Reloading config");
+
+        // temporarily pause dunst
+        struct dunst_status save = status;
+        dunst_status(S_RUNNING, false);
+        queues_update(status);
+        wake_up();
+
+        draw_deinit();
+        load_settings(cmdline_config_path);
+        draw_setup();
+
+        status = save;
+        queues_update(status);
+        wake_up();
+}
+
 int dunst_main(int argc, char *argv[])
 {
 
@@ -166,7 +187,6 @@ int dunst_main(int argc, char *argv[])
         log_set_level_from_string(verbosity);
         g_free(verbosity);
 
-        char *cmdline_config_path;
         cmdline_config_path =
             cmdline_get_string("-conf/-config", NULL,
                                "Path to configuration file");

--- a/src/dunst.h
+++ b/src/dunst.h
@@ -34,6 +34,7 @@ void dunst_status(const enum dunst_status_field field,
 struct dunst_status dunst_status_get(void);
 
 void wake_up(void);
+void reload(void);
 
 int dunst_main(int argc, char *argv[]);
 

--- a/src/queues.c
+++ b/src/queues.c
@@ -26,6 +26,7 @@
 #include "settings.h"
 #include "utils.h"
 #include "output.h" // For checking if wayland is active.
+#include "rules.h"
 
 /* notification lists */
 static GQueue *waiting   = NULL; /**< all new notifications get into here */
@@ -531,6 +532,21 @@ struct notification* queues_get_by_id(int id)
                         struct notification *cur = iter->data;
                         if (cur->id == id)
                                 return cur;
+                }
+        }
+
+        return NULL;
+}
+
+/* see queues.h */
+void queues_reapply_all_rules(void)
+{
+        GQueue *recqueues[] = { displayed, waiting, history };
+        for (int i = 0; i < sizeof(recqueues)/sizeof(GQueue*); i++) {
+                for (GList *iter = g_queue_peek_head_link(recqueues[i]); iter;
+                     iter = iter->next) {
+                        struct notification *cur = iter->data;
+                        rule_apply_all(cur);
                 }
         }
 

--- a/src/queues.h
+++ b/src/queues.h
@@ -156,6 +156,9 @@ gint64 queues_get_next_datachange(gint64 time);
 struct notification* queues_get_by_id(int id);
 
 
+void queues_reapply_all_rules(void) ;
+
+
 /**
  * Remove all notifications from all list and free the notifications
  *

--- a/src/rules.c
+++ b/src/rules.c
@@ -70,8 +70,8 @@ void rule_apply(struct rule *r, struct notification *n)
                 n->format = r->format;
         if (r->script){
                 n->scripts = g_renew(const char*,n->scripts,n->script_count + 1);
-                n->scripts[n->script_count] = r->script;
-
+                // FIXME free this as well
+                n->scripts[n->script_count] = g_strdup(r->script);
                 n->script_count++;
         }
         if (r->set_stack_tag) {

--- a/src/wayland/wl.c
+++ b/src/wayland/wl.c
@@ -528,10 +528,10 @@ void wl_deinit() {
         // could have been aborted half way through, or the compositor doesn't
         // support some of these features.
         if (ctx.layer_surface != NULL) {
-                zwlr_layer_surface_v1_destroy(ctx.layer_surface);
+                g_clear_pointer(&ctx.layer_surface, zwlr_layer_surface_v1_destroy);
         }
         if (ctx.surface != NULL) {
-                wl_surface_destroy(ctx.surface);
+                g_clear_pointer(&ctx.surface, wl_surface_destroy);
         }
         finish_buffer(&ctx.buffers[0]);
         finish_buffer(&ctx.buffers[1]);
@@ -542,39 +542,40 @@ void wl_deinit() {
         wl_list_for_each_safe(output, output_tmp, &ctx.outputs, link) {
                 destroy_output(output);
         }
+        ctx.outputs = (struct wl_list) {0};
+
+        if (ctx.pointer.wl_pointer)
+                g_clear_pointer(&ctx.pointer.wl_pointer, wl_pointer_release);
 
         if (ctx.seat) {
-                if (ctx.pointer.wl_pointer)
-                        wl_pointer_release(ctx.pointer.wl_pointer);
-                wl_seat_release(ctx.seat);
-                ctx.seat = NULL;
+                g_clear_pointer(&ctx.seat, wl_seat_release);
         }
 
         if (ctx.idle_handler)
-                org_kde_kwin_idle_destroy(ctx.idle_handler);
+                g_clear_pointer(&ctx.idle_handler, org_kde_kwin_idle_destroy);
 
         if (ctx.idle_timeout)
-                org_kde_kwin_idle_timeout_release(ctx.idle_timeout);
+                g_clear_pointer(&ctx.idle_timeout, org_kde_kwin_idle_timeout_release);
 
         if (ctx.layer_shell)
-                zwlr_layer_shell_v1_destroy(ctx.layer_shell);
+                g_clear_pointer(&ctx.layer_shell, zwlr_layer_shell_v1_destroy);
 
         if (ctx.compositor)
-                wl_compositor_destroy(ctx.compositor);
+                g_clear_pointer(&ctx.compositor, wl_compositor_destroy);
 
         if (ctx.shm)
-                wl_shm_destroy(ctx.shm);
+                g_clear_pointer(&ctx.shm, wl_shm_destroy);
 
         if (ctx.registry)
-                wl_registry_destroy(ctx.registry);
+                g_clear_pointer(&ctx.registry, wl_registry_destroy);
 
-        if (ctx.cursor_theme != NULL) {
-                wl_cursor_theme_destroy(ctx.cursor_theme);
-                wl_surface_destroy(ctx.cursor_surface);
+        if (ctx.cursor_theme) {
+                g_clear_pointer(&ctx.cursor_theme, wl_cursor_theme_destroy);
+                g_clear_pointer(&ctx.cursor_surface, wl_surface_destroy);
         }
 
         // this also disconnects the wl_display
-        g_water_wayland_source_free(ctx.esrc);
+        g_clear_pointer(&ctx.esrc, g_water_wayland_source_free);
 }
 
 static void schedule_frame_and_commit();
@@ -751,7 +752,7 @@ window wl_win_create(void) {
 
 void wl_win_destroy(window winptr) {
         struct window_wl *win = (struct window_wl*)winptr;
-        // FIXME: Dealloc everything
+        wl_win_hide(win);
         g_free(win);
 }
 


### PR DESCRIPTION
This is just a proof of concept that reloading can be done pretty easily. It's not completely stable. I've noticed that sometimes the window disappears and doesn't come back anymore.

On reload, all rules are reapplied. When a notification's properties were already changed by a rule this won't be undone. So this might give a different result for existing notification than when re-sending the notification.

Fixes #719