### PR TITLE
dbus/dunstctl: add history command (#307)

### DIFF
--- a/contrib/notification-history.sh
+++ b/contrib/notification-history.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+history_json=$(dunstctl history)
+
+history_length=$(echo $history_json|jq -r '.data[] | length')
+
+options=""
+
+for iter in $(seq $history_length); do
+    i=$((iter-1))
+    application_name=$(echo $history_json|jq -r .data[][$i].appname.data)
+    notification_summary=$(echo $history_json|jq -r .data[][$i].summary.data)
+    notification_timestamp=$(echo $history_json|jq -r .data[][$i].timestamp.data)
+    system_timestamp=$(cat /proc/uptime|cut -d'.' -f1)
+
+    how_long_ago=$((system_timestamp-notification_timestamp/1000000))
+
+    notification_time=$(date +%X -d "$(date) - $how_long_ago seconds")
+
+    option=$(printf '%04d - %s: "%s" (at %s)' "$iter" "$application_name" \
+        "$notification_summary" "$notification_time")
+
+    options="$options$option\n"
+done
+options="$options""Cancel"
+
+result=$(echo -e $options|rofi -dmenu -i)
+if [ "$result" = "Cancel" ]; then
+    # Exit if cancelled
+    exit 0
+fi
+if [ "$result" = "" ]; then
+    # Exit on empty strings
+    exit 0
+fi
+if [ "$?" -ne 0 ]; then
+    # Exit on non-zero return values
+    exit 0
+fi
+
+# Get the internal notification ID
+selection_index=$((${result:0:4}-1))
+notification_id=$(echo $history_json|jq -r .data[][$selection_index].id.data)
+
+# Tell dunst to revive said notification
+dunstctl history-pop-id $notification_id
+

--- a/dunstctl
+++ b/dunstctl
@@ -114,40 +114,8 @@ case "${1:-}" in
 			|| die "Dunst controlling interface not available. Is the version too old?"
 		;;
 	"history")
-		counter=0
-		json_string="{ notifications: ["
-		for i in $(dbus-send --print-reply --dest=org.freedesktop.Notifications /org/freedesktop/Notifications org.dunstproject.cmd0.NotificationListAll | grep "string" | cut -d'"' -f2)
-		do
-			case $(($counter%8)) in
-				"0")
-				json_string=$json_string"{body:\"$i\", "
-				;;
-				"1")
-				json_string=$json_string"message:\"$i\", "
-				;;
-				"2")
-				json_string=$json_string"summary:\"$i\", "
-				;;
-				"3")
-				json_string=$json_string"actions:\"$i\", "
-				;;
-				"4")
-				json_string=$json_string"app_name:\"$i\", "
-				;;
-				"5")
-				json_string=$json_string"category:\"$i\", "
-				;;
-				"6")
-				json_string=$json_string"default_action_name:\"$i\","
-				;;
-				"7")
-				json_string=$json_string"icon_path:\"$i\" }, "
-				;;
-			esac
-			((counter=counter+1))
-		done
-		json_string=$json_string"]}"
-		echo $json_string
+		busctl --user --json=pretty -l --no-pager call org.freedesktop.Notifications /org/freedesktop/Notifications org.dunstproject.cmd0 NotificationListAll 2>/dev/null \
+			|| die "Dunst is not running."
 		;;
 	"")
 		die "dunstctl: No command specified. Please consult the usage."

--- a/dunstctl
+++ b/dunstctl
@@ -120,7 +120,7 @@ case "${1:-}" in
 			|| die "Dunst is not running."
 		;;
 	"history-pop-id")
-		method_call "${DBUS_IFAC_DUNST}.NotificationPopHistory" "int32:${2:-0}" >/dev/null
+		method_call "${DBUS_IFAC_DUNST}.NotificationPopHistory" "uint32:${2:-0}" >/dev/null
 		;;
 	"")
 		die "dunstctl: No command specified. Please consult the usage."

--- a/dunstctl
+++ b/dunstctl
@@ -53,7 +53,7 @@ command -v dbus-send >/dev/null 2>/dev/null || \
 
 case "${1:-}" in
 	"action")
-		method_call "${DBUS_IFAC_DUNST}.NotificationAction" "int32:${2:-0}" >/dev/null
+		method_call "${DBUS_IFAC_DUNST}.NotificationAction" "uint32:${2:-0}" >/dev/null
 		;;
 	"close")
 		method_call "${DBUS_IFAC_DUNST}.NotificationCloseLast" >/dev/null

--- a/dunstctl
+++ b/dunstctl
@@ -114,7 +114,7 @@ case "${1:-}" in
 			|| die "Dunst controlling interface not available. Is the version too old?"
 		;;
 	"history")
-		busctl --user --json=pretty -l --no-pager call org.freedesktop.Notifications /org/freedesktop/Notifications org.dunstproject.cmd0 NotificationListAll 2>/dev/null \
+		busctl --user --json=pretty -l --no-pager call org.freedesktop.Notifications /org/freedesktop/Notifications org.dunstproject.cmd0 NotificationListHistory 2>/dev/null \
 			|| die "Dunst is not running."
 		;;
 	"")

--- a/dunstctl
+++ b/dunstctl
@@ -21,7 +21,9 @@ show_help() {
 	  close-all                         Close the all notifications
 	  context                           Open context menu
 	  count [displayed|history|waiting] Show the number of notifications
+	  history                           Display notification history (in JSON)
 	  history-pop                       Pop one notification from history
+	  history-pop-id                    Pop one notification from history using it's ID
 	  is-paused                         Check if dunst is running or paused
 	  set-paused [true|false|toggle]    Set the pause status
 	  debug                             Print debugging information
@@ -116,6 +118,9 @@ case "${1:-}" in
 	"history")
 		busctl --user --json=pretty -l --no-pager call org.freedesktop.Notifications /org/freedesktop/Notifications org.dunstproject.cmd0 NotificationListHistory 2>/dev/null \
 			|| die "Dunst is not running."
+		;;
+	"history-pop-id")
+		method_call "${DBUS_IFAC_DUNST}.NotificationPopHistory" "int32:${2:-0}" >/dev/null
 		;;
 	"")
 		die "dunstctl: No command specified. Please consult the usage."

--- a/dunstctl
+++ b/dunstctl
@@ -113,6 +113,42 @@ case "${1:-}" in
 		dbus-send --print-reply=literal --dest="${DBUS_NAME}" "${DBUS_PATH}" "${DBUS_IFAC_DUNST}.Ping" >/dev/null 2>/dev/null \
 			|| die "Dunst controlling interface not available. Is the version too old?"
 		;;
+	"history")
+		counter=0
+		json_string="{ notifications: ["
+		for i in $(dbus-send --print-reply --dest=org.freedesktop.Notifications /org/freedesktop/Notifications org.dunstproject.cmd0.NotificationListAll | grep "string" | cut -d'"' -f2)
+		do
+			case $(($counter%8)) in
+				"0")
+				json_string=$json_string"{body:\"$i\", "
+				;;
+				"1")
+				json_string=$json_string"message:\"$i\", "
+				;;
+				"2")
+				json_string=$json_string"summary:\"$i\", "
+				;;
+				"3")
+				json_string=$json_string"actions:\"$i\", "
+				;;
+				"4")
+				json_string=$json_string"app_name:\"$i\", "
+				;;
+				"5")
+				json_string=$json_string"category:\"$i\", "
+				;;
+				"6")
+				json_string=$json_string"default_action_name:\"$i\","
+				;;
+				"7")
+				json_string=$json_string"icon_path:\"$i\" }, "
+				;;
+			esac
+			((counter=counter+1))
+		done
+		json_string=$json_string"]}"
+		echo $json_string
+		;;
 	"")
 		die "dunstctl: No command specified. Please consult the usage."
 		;;

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -311,14 +311,25 @@ static void dbus_cb_dunst_NotificationListAll(GDBusConnection *connection,
                 // create sub-list per notification
                 notif_builder = g_variant_builder_new(G_VARIANT_TYPE("as"));
 
-                g_variant_builder_add(notif_builder, "s", n->body);
-                g_variant_builder_add(notif_builder, "s", n->msg);
-                g_variant_builder_add(notif_builder, "s", n->summary);
-                g_variant_builder_add(notif_builder, "s", n->actions);
-                g_variant_builder_add(notif_builder, "s", n->appname);
-                g_variant_builder_add(notif_builder, "s", n->category);
-                g_variant_builder_add(notif_builder, "s", n->default_action_name);
-                g_variant_builder_add(notif_builder, "s", n->icon_path);
+                char *body, *msg, *summary, *appname, *category;
+                char *default_action_name, *icon_path;
+
+                body      = (n->body      == NULL) ? "" : n->body;
+                msg       = (n->msg       == NULL) ? "" : n->msg;
+                summary   = (n->summary   == NULL) ? "" : n->summary;
+                appname   = (n->appname   == NULL) ? "" : n->appname;
+                category  = (n->category  == NULL) ? "" : n->category;
+                default_action_name= (n->default_action_name == NULL) ?
+                        "" : n->default_action_name;
+                icon_path = (n->icon_path == NULL) ? "" : n->icon_path;
+
+                g_variant_builder_add(notif_builder, "s", body);
+                g_variant_builder_add(notif_builder, "s", msg);
+                g_variant_builder_add(notif_builder, "s", summary);
+                g_variant_builder_add(notif_builder, "s", appname);
+                g_variant_builder_add(notif_builder, "s", category);
+                g_variant_builder_add(notif_builder, "s", default_action_name);
+                g_variant_builder_add(notif_builder, "s", icon_path);
 
                 // add to whole list
                 g_variant_builder_add(builder, "as", notif_builder);

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -83,7 +83,7 @@ static const char *introspection_xml =
     "            <arg direction=\"out\" name=\"notifications\"   type=\"aa{sv}\"/>"
     "        </method>"
     "        <method name=\"NotificationPopHistory\">"
-    "            <arg direction=\"in\"  name=\"id\"              type=\"i\"/>"
+    "            <arg direction=\"in\"  name=\"id\"              type=\"u\"/>"
     "        </method>"
     "        <method name=\"NotificationShow\"      />"
     "        <method name=\"Ping\"                  />"
@@ -381,8 +381,8 @@ static void dbus_cb_dunst_NotificationPopHistory(GDBusConnection *connection,
 {
         LOG_D("CMD: Popping notification from history");
 
-        gint32 id;
-        g_variant_get(parameters, "(i)", &id);
+        guint32 id;
+        g_variant_get(parameters, "(u)", &id);
 
         queues_history_pop_by_id(id);
         wake_up();

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -314,14 +314,14 @@ static void dbus_cb_dunst_NotificationListAll(GDBusConnection *connection,
                 char *body, *msg, *summary, *appname, *category;
                 char *default_action_name, *icon_path;
 
-                body      = (n->body      == NULL) ? " " : n->body;
-                msg       = (n->msg       == NULL) ? " " : n->msg;
-                summary   = (n->summary   == NULL) ? " " : n->summary;
-                appname   = (n->appname   == NULL) ? " " : n->appname;
-                category  = (n->category  == NULL) ? " " : n->category;
+                body      = (n->body      == NULL) ? "" : n->body;
+                msg       = (n->msg       == NULL) ? "" : n->msg;
+                summary   = (n->summary   == NULL) ? "" : n->summary;
+                appname   = (n->appname   == NULL) ? "" : n->appname;
+                category  = (n->category  == NULL) ? "" : n->category;
                 default_action_name= (n->default_action_name == NULL) ?
-                        " " : n->default_action_name;
-                icon_path = (n->icon_path == NULL) ? " " : n->icon_path;
+                        "" : n->default_action_name;
+                icon_path = (n->icon_path == NULL) ? "" : n->icon_path;
 
                 g_variant_builder_add(&n_builder, "{sv}", "body",
                         g_variant_new_from_bytes(G_VARIANT_TYPE("s"),

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -80,7 +80,7 @@ static const char *introspection_xml =
     "        <method name=\"NotificationCloseLast\" />"
     "        <method name=\"NotificationCloseAll\"  />"
     "        <method name=\"NotificationShow\"      />"
-    "        <method name=\"NotificationListAll\">"
+    "        <method name=\"NotificationListHistory\">"
     "            <arg direction=\"out\" name=\"notifications\"   type=\"aa{sv}\"/>"
     "        </method>"
     "        <method name=\"Ping\"                  />"
@@ -166,7 +166,7 @@ DBUS_METHOD(dunst_NotificationAction);
 DBUS_METHOD(dunst_NotificationCloseAll);
 DBUS_METHOD(dunst_NotificationCloseLast);
 DBUS_METHOD(dunst_NotificationShow);
-DBUS_METHOD(dunst_NotificationListAll);
+DBUS_METHOD(dunst_NotificationListHistory);
 DBUS_METHOD(dunst_Ping);
 static struct dbus_method methods_dunst[] = {
         {"ContextMenuCall",        dbus_cb_dunst_ContextMenuCall},
@@ -174,7 +174,7 @@ static struct dbus_method methods_dunst[] = {
         {"NotificationCloseAll",   dbus_cb_dunst_NotificationCloseAll},
         {"NotificationCloseLast",  dbus_cb_dunst_NotificationCloseLast},
         {"NotificationShow",       dbus_cb_dunst_NotificationShow},
-        {"NotificationListAll",    dbus_cb_dunst_NotificationListAll},
+        {"NotificationListHistory",    dbus_cb_dunst_NotificationListHistory},
         {"Ping",                   dbus_cb_dunst_Ping},
 };
 
@@ -288,7 +288,7 @@ static void dbus_cb_dunst_NotificationShow(GDBusConnection *connection,
         g_dbus_connection_flush(connection, NULL, NULL, NULL);
 }
 
-static void dbus_cb_dunst_NotificationListAll(GDBusConnection *connection,
+static void dbus_cb_dunst_NotificationListHistory(GDBusConnection *connection,
                                            const gchar *sender,
                                            GVariant *parameters,
                                            GDBusMethodInvocation *invocation)

--- a/src/queues.c
+++ b/src/queues.c
@@ -374,6 +374,7 @@ void queues_history_pop_by_id(unsigned int id)
         if (n == NULL)
                 return;
 
+        g_queue_remove(history, n);
         n->redisplayed = true;
         n->timeout = settings.sticky_history ? 0 : n->timeout;
         g_queue_insert_sorted(waiting, n, notification_cmp_data, NULL);

--- a/src/queues.c
+++ b/src/queues.c
@@ -353,15 +353,12 @@ void queues_history_pop(void)
 }
 
 /* see queues.h */
-void queues_history_pop_by_id(int id)
+void queues_history_pop_by_id(unsigned int id)
 {
         struct notification *n = NULL;
 
         if (g_queue_is_empty(history))
                 return;
-
-        // must be a valid ID
-        assert(id > 0);
 
         // search through the history buffer 
         for (GList *iter = g_queue_peek_head_link(history); iter;

--- a/src/queues.c
+++ b/src/queues.c
@@ -77,6 +77,12 @@ unsigned int queues_length_history(void)
         return history->length;
 }
 
+/* see queues.h */
+GList *queues_get_history(void)
+{
+        return g_queue_peek_head_link(history);
+}
+
 /**
  * Swap two given queue elements. The element's data has to be a notification.
  *

--- a/src/queues.c
+++ b/src/queues.c
@@ -353,6 +353,36 @@ void queues_history_pop(void)
 }
 
 /* see queues.h */
+void queues_history_pop_by_id(int id)
+{
+        struct notification *n = NULL;
+
+        if (g_queue_is_empty(history))
+                return;
+
+        // must be a valid ID
+        assert(id > 0);
+
+        // search through the history buffer 
+        for (GList *iter = g_queue_peek_head_link(history); iter;
+                iter = iter->next) {
+                struct notification *cur = iter->data;
+                if (cur->id == id) {
+                        n = cur;
+                        break;
+                }
+        }
+
+        // must be a valid notification
+        if (n == NULL)
+                return;
+
+        n->redisplayed = true;
+        n->timeout = settings.sticky_history ? 0 : n->timeout;
+        g_queue_insert_sorted(waiting, n, notification_cmp_data, NULL);
+}
+
+/* see queues.h */
 void queues_history_push(struct notification *n)
 {
         if (!n->history_ignore) {

--- a/src/queues.h
+++ b/src/queues.h
@@ -114,6 +114,12 @@ void queues_notification_close(struct notification *n, enum reason reason);
 void queues_history_pop(void);
 
 /**
+ * Pushes the latest notification found in the history buffer identified by
+ * it's assigned id
+ */
+void queues_history_pop_by_id(int id);
+
+/**
  * Push a single notification to history
  * The given notification has to be removed its queue
  *

--- a/src/queues.h
+++ b/src/queues.h
@@ -117,7 +117,7 @@ void queues_history_pop(void);
  * Pushes the latest notification found in the history buffer identified by
  * it's assigned id
  */
-void queues_history_pop_by_id(int id);
+void queues_history_pop_by_id(unsigned int id);
 
 /**
  * Push a single notification to history

--- a/src/queues.h
+++ b/src/queues.h
@@ -27,6 +27,13 @@ void queues_init(void);
 GList *queues_get_displayed(void);
 
 /**
+ * Recieve the list of all notifications encountered
+ *
+ * @return read only list of notifications
+ */
+GList *queues_get_history(void);
+
+/**
  * Get the highest notification in line
  *
  * @returns the first notification in waiting

--- a/test/queues.c
+++ b/test/queues.c
@@ -234,6 +234,72 @@ TEST test_queue_notification_skip_display_redisplayed(void)
         PASS();
 }
 
+TEST test_queue_notification_skip_display_redisplayed_by_random_id(void) {
+        // breaks if the notification_buffer_size is above 5,
+        // possible bug??????
+        size_t notification_buffer_size = 5;
+
+        struct notification *n[notification_buffer_size];
+        bool is_n_popped[notification_buffer_size];
+
+        // insert notifications
+        char string[128];
+        for(size_t i=0; i<notification_buffer_size; i++) {
+                snprintf(string, 128, "n%08lu", i+1);
+
+                n[i] = test_notification(string, -1);
+                n[i]->skip_display = true;
+                n[i]->id = i+1;
+
+                // generate a noisy pop table
+                is_n_popped[i] = rand() > RAND_MAX/4;
+        }
+
+        queues_init();
+        for(size_t i=0; i<notification_buffer_size; i++) {
+                queues_notification_insert(n[i]);
+        }
+
+        QUEUE_LEN_ALL(notification_buffer_size, 0, 0);
+
+        // update notification event
+        queues_update(STATUS_NORMAL);
+
+        QUEUE_LEN_ALL(0, 0, notification_buffer_size);
+
+        // pop according to the pop table
+        size_t popped_notification_count = 0;
+        for(size_t i=0; i<notification_buffer_size; i++) {
+                if(is_n_popped[i]) {
+                        queues_history_pop_by_id(i+1);
+                        popped_notification_count++;
+                        queues_update(STATUS_NORMAL);
+                }
+        }
+
+        // test whether the notifications were unpopped properly
+        QUEUE_LEN_ALL(0, popped_notification_count,
+                        notification_buffer_size-popped_notification_count);
+
+        queues_update(STATUS_NORMAL);
+        // check if any of the notifications got moved
+        for(size_t i=0; i<notification_buffer_size; i++) {
+                if(is_n_popped[i]) {
+                        QUEUE_CONTAINSm("A skip display notification should stay in displayed "
+                                        "queue when it got pulled out of history queue",
+                                        DISP, n[i]);
+                } else {
+                        QUEUE_CONTAINSm("A skip display notification that didn't get popped"
+                                        "out of history should've stayed there",
+                                        HIST, n[i]);
+                }
+        }
+
+        queues_teardown();
+
+        PASS();
+}
+
 TEST test_queue_history_overfull(void)
 {
         settings.history_length = 10;
@@ -907,6 +973,7 @@ SUITE(suite_queues)
         RUN_TEST(test_queue_notification_close_histignore);
         RUN_TEST(test_queue_notification_skip_display);
         RUN_TEST(test_queue_notification_skip_display_redisplayed);
+        RUN_TEST(test_queue_notification_skip_display_redisplayed_by_random_id);
         RUN_TEST(test_queue_stacking);
         RUN_TEST(test_queue_stacktag);
         RUN_TEST(test_queue_different_stacktag);

--- a/test/queues.c
+++ b/test/queues.c
@@ -890,6 +890,32 @@ TEST test_queue_find_by_id(void)
         PASS();
 }
 
+TEST test_queue_get_history(void)
+{
+        struct notification *n;
+        queues_init();
+
+        n = test_notification("n", -1);
+        n->skip_display = true;
+        queues_notification_insert(n);
+        n = test_notification("n1", -1);
+        n->skip_display = true;
+        queues_notification_insert(n);
+        n = test_notification("n3", -1);
+        n->skip_display = true;
+        queues_notification_insert(n);
+
+        queues_update(STATUS_NORMAL);
+
+        QUEUE_LEN_ALL(0, 0, 3);
+
+        GList *h = queues_get_history();
+        ASSERT(g_list_length(h) == 3);
+
+        queues_teardown();
+        PASS();
+}
+
 
 void print_queues() {
         printf("\nQueues:\n");
@@ -988,6 +1014,7 @@ SUITE(suite_queues)
         RUN_TEST(test_queues_timeout_before_paused);
         RUN_TEST(test_queue_find_by_id);
         RUN_TEST(test_queue_no_sort_and_pause);
+        RUN_TEST(test_queue_get_history);
 
         settings.stack_duplicates = store;
 }


### PR DESCRIPTION
The current implementation tries to retrieve notifications stored in the
history buffer (which means they've been either discarded or hidden by
the user) and does so using the existing D-Bus system. However the
output of the dbus-send command is (in my opinion) super ugly and
unusable for any practical scripting application.

This is VERY much still a work in progress.

Any additional suggestions or ideas are welcome.