### PR TITLE
Make get_notification_at work with Y offset

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -7,7 +7,7 @@
 #include <linux/input-event-codes.h>
 
 struct notification *get_notification_at(const int y) {
-        int curr_y = settings.frame_width;
+        int curr_y = settings.frame_width + settings.offset.y;
         for (const GList *iter = queues_get_displayed(); iter;
                         iter = iter->next) {
                 struct notification *current = iter->data;


### PR DESCRIPTION
Currently this doesn't work, and the get_notification_at code assumes that the notification is at the top of the screen. This is not correct considering the user can arbitrarily position the notification.

TODO: support bottom-left and bottom-right origin.