### PR TITLE
Clamp maximum notification width to screen width

### DIFF
--- a/docs/dunst.5.pod
+++ b/docs/dunst.5.pod
@@ -73,6 +73,11 @@ Examples:
         width = 300      # constant width of 300
         width = (0, 300) # width between 0 and 300
 
+When setting a width bigger than the screen, dunst will clamp the width to the
+screen width. So if you want the notifcation to stretch the entire screen
+dynamically, you may set the width to a high enough number, which none of your
+screens exceed (e.g. 10000).
+
 =item B<height>
 
 The maximum height of a single notification.

--- a/src/draw.c
+++ b/src/draw.c
@@ -284,8 +284,9 @@ static struct dimensions calculate_dimensions(GSList *layouts)
 
         /* clamp max width to screen width */
         const struct screen_info *scr = output->get_active_screen();
-        if (dim.w > scr->w) {
-                dim.w = scr->w;
+        int max_width = scr->w - settings.offset.x;
+        if (dim.w > max_width) {
+                dim.w = max_width;
         }
 
         return dim;

--- a/src/draw.c
+++ b/src/draw.c
@@ -281,6 +281,13 @@ static struct dimensions calculate_dimensions(GSList *layouts)
 
         dim.w += 2 * settings.frame_width;
         dim.corner_radius = MIN(dim.corner_radius, dim.h/2);
+
+        /* clamp max width to screen width */
+        const struct screen_info *scr = output->get_active_screen();
+        if (dim.w > scr->w) {
+                dim.w = scr->w;
+        }
+
         return dim;
 }
 

--- a/src/wayland/wl.c
+++ b/src/wayland/wl.c
@@ -803,8 +803,8 @@ cairo_t* wl_win_get_context(window winptr) {
 
 const struct screen_info* wl_get_active_screen(void) {
         static struct screen_info scr = {
-                .w = 1920,
-                .h = 1080,
+                .w = 3840,
+                .h = 2160,
                 .x = 0,
                 .y = 0,
                 .id = 0,

--- a/src/wayland/wl.c
+++ b/src/wayland/wl.c
@@ -107,6 +107,12 @@ static void output_handle_geometry(void *data, struct wl_output *wl_output,
         struct dunst_output *output = data;
         output->subpixel = subpixel;
 }
+static void output_handle_mode(void *data, struct wl_output *wl_output, uint32_t flags,
+                int32_t width, int32_t height, int32_t refresh) {
+        struct dunst_output *output = data;
+        output->width = width;
+        output->height = height;
+}
 
 static void output_handle_scale(void *data, struct wl_output *wl_output,
                 int32_t factor) {
@@ -118,7 +124,7 @@ static void output_handle_scale(void *data, struct wl_output *wl_output,
 
 static const struct wl_output_listener output_listener = {
         .geometry = output_handle_geometry,
-        .mode = noop,
+        .mode = output_handle_mode,
         .done = noop,
         .scale = output_handle_scale,
 };
@@ -796,7 +802,6 @@ cairo_t* wl_win_get_context(window winptr) {
 }
 
 const struct screen_info* wl_get_active_screen(void) {
-        // TODO Screen size detection
         static struct screen_info scr = {
                 .w = 1920,
                 .h = 1080,
@@ -806,7 +811,18 @@ const struct screen_info* wl_get_active_screen(void) {
                 .mmh = 500
         };
         scr.dpi = wl_get_scale() * 96;
-        return &scr;
+
+        struct dunst_output *current_output = get_configured_output();
+        if (current_output != NULL) {
+                scr.w = current_output->width;
+                scr.h = current_output->height;
+                return &scr;
+        } else {
+                // Using auto output. We don't know on which output we are
+                // (although we might find it out by looking at the list of
+                // toplevels).
+                return &scr;
+        }
 }
 
 bool wl_is_idle(void) {

--- a/src/wayland/wl_output.h
+++ b/src/wayland/wl_output.h
@@ -12,6 +12,7 @@ struct dunst_output {
 
         uint32_t scale;
         uint32_t subpixel; // TODO do something with it
+        int32_t width, height;
         bool fullscreen;
         struct zwlr_foreign_toplevel_handle_v1 *fullscreen_toplevel; // the toplevel that is fullscreened on this output
 };


### PR DESCRIPTION
This fixes the notification bleeding into other screens as discussed in #951.

This fixes the main issue described in ticket for X11.
This code will work for Wayland eventually once `get_active_screen` is implemented correctly in `wl.c`.
For now we increase the stub resolution to a value which does not get exceeded with "common" screen resolutions.

Thanks an best regards