### PR TITLE
Feature: Enable or disable rules on the fly

### DIFF
--- a/dunstctl
+++ b/dunstctl
@@ -97,14 +97,14 @@ case "${1:-}" in
 		fi
 		;;
         "rule")
-                [ "${2:-}" ] \
-                        || die "No rule name parameter specified. Please give the rule name"
-                state=nope
-                [ "${3}" = "disable" ] && state=0
-                [ "${3}" = "enable" ]  && state=1
-                [ "${3}" = "toggle" ]  && state=2
-                [ "${state}" = "nope" ] \
-                        && die "No valid rule state parameter specified. Please give either 'enable', 'disable' or 'toggle'"
+		[ "${2:-}" ] \
+			|| die "No rule name parameter specified. Please give the rule name"
+		state=nope
+		[ "${3}" = "disable" ] && state=0
+		[ "${3}" = "enable" ]  && state=1
+		[ "${3}" = "toggle" ]  && state=2
+		[ "${state}" = "nope" ] \
+			&& die "No valid rule state parameter specified. Please give either 'enable', 'disable' or 'toggle'"
 		method_call "${DBUS_IFAC_DUNST}.RuleEnable" "string:${2:-1}" "int32:${state}" >/dev/null
 		;;
 	"help"|"--help"|"-h")

--- a/dunstctl
+++ b/dunstctl
@@ -24,6 +24,7 @@ show_help() {
 	  history-pop                       Pop one notification from history
 	  is-paused                         Check if dunst is running or paused
 	  set-paused [true|false|toggle]    Set the pause status
+	  rule name [enable|disable|toggle] Enable or disable a rule by its name
 	  debug                             Print debugging information
 	  help                              Show this help
 	EOH
@@ -94,6 +95,17 @@ case "${1:-}" in
 		else
 			property_set paused variant:boolean:"$2"
 		fi
+		;;
+        "rule")
+                [ "${2:-}" ] \
+                        || die "No rule name parameter specified. Please give the rule name"
+                state=nope
+                [ "${3}" = "disable" ] && state=0
+                [ "${3}" = "enable" ]  && state=1
+                [ "${3}" = "toggle" ]  && state=2
+                [ "${state}" = "nope" ] \
+                        && die "No valid rule state parameter specified. Please give either 'enable', 'disable' or 'toggle'"
+		method_call "${DBUS_IFAC_DUNST}.RuleEnable" "string:${2:-1}" "int32:${state}" >/dev/null
 		;;
 	"help"|"--help"|"-h")
 		show_help

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -175,8 +175,8 @@ static struct dbus_method methods_dunst[] = {
         {"NotificationCloseAll",   dbus_cb_dunst_NotificationCloseAll},
         {"NotificationCloseLast",  dbus_cb_dunst_NotificationCloseLast},
         {"NotificationShow",       dbus_cb_dunst_NotificationShow},
-        {"RuleEnable",             dbus_cb_dunst_RuleEnable},
         {"Ping",                   dbus_cb_dunst_Ping},
+        {"RuleEnable",             dbus_cb_dunst_RuleEnable},
 };
 
 void dbus_cb_dunst_methods(GDBusConnection *connection,

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -80,6 +80,10 @@ static const char *introspection_xml =
     "        <method name=\"NotificationCloseLast\" />"
     "        <method name=\"NotificationCloseAll\"  />"
     "        <method name=\"NotificationShow\"      />"
+    "        <method name=\"RuleEnable\">"
+    "            <arg name=\"name\"     type=\"s\"/>"
+    "            <arg name=\"state\"    type=\"i\"/>"
+    "        </method>"
     "        <method name=\"Ping\"                  />"
 
     "        <property name=\"paused\" type=\"b\" access=\"readwrite\">"
@@ -163,6 +167,7 @@ DBUS_METHOD(dunst_NotificationAction);
 DBUS_METHOD(dunst_NotificationCloseAll);
 DBUS_METHOD(dunst_NotificationCloseLast);
 DBUS_METHOD(dunst_NotificationShow);
+DBUS_METHOD(dunst_RuleEnable);
 DBUS_METHOD(dunst_Ping);
 static struct dbus_method methods_dunst[] = {
         {"ContextMenuCall",        dbus_cb_dunst_ContextMenuCall},
@@ -170,6 +175,7 @@ static struct dbus_method methods_dunst[] = {
         {"NotificationCloseAll",   dbus_cb_dunst_NotificationCloseAll},
         {"NotificationCloseLast",  dbus_cb_dunst_NotificationCloseLast},
         {"NotificationShow",       dbus_cb_dunst_NotificationShow},
+        {"RuleEnable",             dbus_cb_dunst_RuleEnable},
         {"Ping",                   dbus_cb_dunst_Ping},
 };
 
@@ -282,6 +288,51 @@ static void dbus_cb_dunst_NotificationShow(GDBusConnection *connection,
         g_dbus_method_invocation_return_value(invocation, NULL);
         g_dbus_connection_flush(connection, NULL, NULL, NULL);
 }
+
+static void dbus_cb_dunst_RuleEnable(GDBusConnection *connection,
+                                     const gchar *sender,
+                                     GVariant *parameters,
+                                     GDBusMethodInvocation *invocation)
+{
+        // dbus param state: 0 → disable, 1 → enable, 2 → toggle.
+
+        int state = 0;
+        char *name = NULL;
+        g_variant_get(parameters, "(si)", &name, &state);
+
+        LOG_D("CMD: Changing rule \"%s\" enable state to %d", name, state);
+
+        if (state < 0 || state > 2) {
+                g_dbus_method_invocation_return_error(invocation,
+                        G_DBUS_ERROR,
+                        G_DBUS_ERROR_INVALID_ARGS,
+                        "Couldn't understand state %d. It must be 0, 1 or 2",
+                        state);
+                return;
+        }
+
+        struct rule *target_rule = get_rule(name);
+
+        if (target_rule == NULL) {
+                g_dbus_method_invocation_return_error(invocation,
+                        G_DBUS_ERROR,
+                        G_DBUS_ERROR_INVALID_ARGS,
+                        "There is no rule named \"%s\"",
+                        name);
+                return;
+        }
+
+        if (state == 0)
+                target_rule->enable = false;
+        else if (state == 1)
+                target_rule->enable = true;
+        else if (state == 2)
+                target_rule->enable = !target_rule->enable;
+
+        g_dbus_method_invocation_return_value(invocation, NULL);
+        g_dbus_connection_flush(connection, NULL, NULL, NULL);
+}
+
 
 /* Just a simple Ping command to give the ability to dunstctl to test for the existence of this interface
  * Any other way requires parsing the XML of the Introspection or other foo. Just calling the Ping on an old dunst version will fail. */

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -323,11 +323,11 @@ static void dbus_cb_dunst_RuleEnable(GDBusConnection *connection,
         }
 
         if (state == 0)
-                target_rule->enable = false;
+                target_rule->enabled = false;
         else if (state == 1)
-                target_rule->enable = true;
+                target_rule->enabled = true;
         else if (state == 2)
-                target_rule->enable = !target_rule->enable;
+                target_rule->enabled = !target_rule->enabled;
 
         g_dbus_method_invocation_return_value(invocation, NULL);
         g_dbus_connection_flush(connection, NULL, NULL, NULL);

--- a/src/rules.c
+++ b/src/rules.c
@@ -142,7 +142,7 @@ static inline bool rule_field_matches_string(const char *value, const char *patt
  */
 bool rule_matches_notification(struct rule *r, struct notification *n)
 {
-        return  r->enable
+        return  r->enabled
                 && (r->msg_urgency == URG_NONE || r->msg_urgency == n->urgency)
                 && (r->match_transient == -1 || (r->match_transient == n->transient))
                 && rule_field_matches_string(n->appname,        r->appname)

--- a/src/rules.c
+++ b/src/rules.c
@@ -142,7 +142,8 @@ static inline bool rule_field_matches_string(const char *value, const char *patt
  */
 bool rule_matches_notification(struct rule *r, struct notification *n)
 {
-        return     (r->msg_urgency == URG_NONE || r->msg_urgency == n->urgency)
+        return  r->enable
+                && (r->msg_urgency == URG_NONE || r->msg_urgency == n->urgency)
                 && (r->match_transient == -1 || (r->match_transient == n->transient))
                 && rule_field_matches_string(n->appname,        r->appname)
                 && rule_field_matches_string(n->desktop_entry,  r->desktop_entry)

--- a/src/rules.h
+++ b/src/rules.h
@@ -50,7 +50,7 @@ struct rule {
         const char *script;
         enum behavior_fullscreen fullscreen;
         char *set_stack_tag; // this has to be the last action
-        bool enable;
+        bool enabled;
 };
 
 extern GSList *rules;

--- a/src/rules.h
+++ b/src/rules.h
@@ -50,6 +50,7 @@ struct rule {
         const char *script;
         enum behavior_fullscreen fullscreen;
         char *set_stack_tag; // this has to be the last action
+        bool enable;
 };
 
 extern GSList *rules;

--- a/src/settings_data.h
+++ b/src/settings_data.h
@@ -122,6 +122,7 @@ static const struct rule empty_rule = {
         .bg              = NULL,
         .format          = NULL,
         .script          = NULL,
+        .enable          = true,
 };
 
 
@@ -585,6 +586,17 @@ static const struct setting allowed_settings[] = {
                 .parser = NULL,
                 .parser_data = NULL,
                 .rule_offset = offsetof(struct rule, set_icon_size),
+        },
+        {
+                .name = "enable",
+                .section = "*",
+                .description = "Enable or disable a rule",
+                .type = TYPE_CUSTOM,
+                .default_value = "true",
+                .value = NULL,
+                .parser = string_parse_bool,
+                .parser_data = boolean_enum_data,
+                .rule_offset = offsetof(struct rule, enable),
         },
 
         // other settings below

--- a/src/settings_data.h
+++ b/src/settings_data.h
@@ -122,7 +122,7 @@ static const struct rule empty_rule = {
         .bg              = NULL,
         .format          = NULL,
         .script          = NULL,
-        .enable          = true,
+        .enabled         = true,
 };
 
 
@@ -596,7 +596,7 @@ static const struct setting allowed_settings[] = {
                 .value = NULL,
                 .parser = string_parse_bool,
                 .parser_data = boolean_enum_data,
-                .rule_offset = offsetof(struct rule, enable),
+                .rule_offset = offsetof(struct rule, enabled),
         },
 
         // other settings below

--- a/src/settings_data.h
+++ b/src/settings_data.h
@@ -588,7 +588,7 @@ static const struct setting allowed_settings[] = {
                 .rule_offset = offsetof(struct rule, set_icon_size),
         },
         {
-                .name = "enable",
+                .name = "enabled",
                 .section = "*",
                 .description = "Enable or disable a rule",
                 .type = TYPE_CUSTOM,


### PR DESCRIPTION
# Feature: Enable or disable rules on the fly
This feature allows to enable or disable rules through dunstctl whenever you please.
Its main use case for me is muting certain notifications for a period of time, or changing the color of notifications depending on which "mode" I want. Instead of changing the configuration and reloading dunst (which is tedious), with this feature I can easily script it and apply it to new notifications.

# Example:
In configuration:
```
[red]
    background = "#ff0000"
    summary = "*"
    enable = false
```

Then you might enable it whenever you want with
```
dunstctl rule red enable
```

Or disable it when you're tired
```
dunstctl rule red disable
```

Rules are enabled by default unless you explicitly disable them.

# Comment
I created it for myself, but maybe someone else can take advantage of it, so I'm sharing the code. Its a simple  implementation, it doesn't require many lines of code, it hardly changes the current code, and it shouldn't cause any problems with existing configurations, nor with people who will not use the feature.

I'm kinda new to Github so if there is something I'm doing wrong, don't hesitate to teach me ^.^
