### PR TITLE
Fix 'icon_position = off' not being respected

### DIFF
--- a/src/draw.c
+++ b/src/draw.c
@@ -335,7 +335,12 @@ static struct colored_layout *layout_from_notification(cairo_t *c, struct notifi
 
         struct colored_layout *cl = layout_init_shared(c, n);
 
-        cl->icon = n->icon;
+        if (settings.icon_position != ICON_OFF && n->icon) {
+                cl->icon = n->icon;
+        } else {
+                cl->icon = NULL;
+        }
+
         /* markup */
         GError *err = NULL;
         pango_parse_markup(n->text_to_render, -1, 0, &(cl->attr), &(cl->text), NULL, &err);


### PR DESCRIPTION
Hey again,

noticed today that my notifications looked all wonky with a huge icon on the right side.

Turns out that with 0b1cf92960df3f39bb732056c37af03e6c676df6 the `icon_position` was not being evaluated correctly.
The check for `icon_position = off` was patched out with no replacement (`settings.icon_position != ICON_OFF && n->icon`).
This commit fixes this by reapplying the needed checks.

Maybe the tests in https://github.com/dunst-project/dunst/blob/master/test/notification.c need some adjustment for `ICON_OFF` to catch issues with this next time.

Best regards,
Michael