### PR TITLE
Fix dunstctl action dbus error

### DIFF
--- a/dunstctl
+++ b/dunstctl
@@ -56,7 +56,7 @@ command -v dbus-send >/dev/null 2>/dev/null || \
 
 case "${1:-}" in
 	"action")
-		method_call "${DBUS_IFAC_DUNST}.NotificationAction" "uint32:${2:-0}" >/dev/null
+		method_call "${DBUS_IFAC_DUNST}.NotificationAction" "int32:${2:-0}" >/dev/null
 		;;
 	"close")
 		method_call "${DBUS_IFAC_DUNST}.NotificationCloseLast" >/dev/null


### PR DESCRIPTION
Calling `dunstctl action` after the `1.7.2` release would result in an error
```
Error org.freedesktop.DBus.Error.InvalidArgs: Type of message, “(u)”, does not match expected type “(i)”
Failed to communicate with dunst, is it running? Or maybe the version is outdated. You can try 'dunstctl debug' as a next debugging step.
```

This fixes it.