### PR TITLE
Always scale icons to `icon_size`

### DIFF
--- a/src/dbus.c
+++ b/src/dbus.c
@@ -584,16 +584,6 @@ static struct notification *dbus_message_to_notification(const gchar *sender, GV
                 g_variant_unref(dict_value);
         }
 
-        dict_value = g_variant_lookup_value(hints, "image-data", G_VARIANT_TYPE("(iiibiiay)"));
-        if (!dict_value)
-                dict_value = g_variant_lookup_value(hints, "image_data", G_VARIANT_TYPE("(iiibiiay)"));
-        if (!dict_value)
-                dict_value = g_variant_lookup_value(hints, "icon_data", G_VARIANT_TYPE("(iiibiiay)"));
-        if (dict_value) {
-                notification_icon_replace_data(n, dict_value);
-                g_variant_unref(dict_value);
-        }
-
         if ((dict_value = g_variant_lookup_value(hints, "image-path", G_VARIANT_TYPE_STRING))) {
                 g_free(n->iconname);
                 n->iconname = g_variant_dup_string(dict_value, NULL);
@@ -604,6 +594,21 @@ static struct notification *dbus_message_to_notification(const gchar *sender, GV
         // so we can initialize the notification. This applies all rules that
         // are defined and applies the formatting to the message.
         notification_init(n);
+
+
+        // Set raw icon data only after initializing the notification, so the
+        // desired icon size is known. This way the buffer can be immediately
+        // rescaled. If at some point you might want to match by if a
+        // notificaton has an image, this has to be reworked.
+        dict_value = g_variant_lookup_value(hints, "image-data", G_VARIANT_TYPE("(iiibiiay)"));
+        if (!dict_value)
+                dict_value = g_variant_lookup_value(hints, "image_data", G_VARIANT_TYPE("(iiibiiay)"));
+        if (!dict_value)
+                dict_value = g_variant_lookup_value(hints, "icon_data", G_VARIANT_TYPE("(iiibiiay)"));
+        if (dict_value) {
+                notification_icon_replace_data(n, dict_value);
+                g_variant_unref(dict_value);
+        }
 
         // Modify these values after the notification is initialized and all rules are applied.
         if ((dict_value = g_variant_lookup_value(hints, "fgcolor", G_VARIANT_TYPE_STRING))) {

--- a/src/icon.c
+++ b/src/icon.c
@@ -209,7 +209,7 @@ static GdkPixbuf *icon_pixbuf_scale_to_size(GdkPixbuf *pixbuf, int icon_size, do
         return pixbuf;
 }
 
-GdkPixbuf *get_pixbuf_from_file(const char *filename, double scale)
+GdkPixbuf *get_pixbuf_from_file(const char *filename, int icon_size, double scale)
 {
         char *path = string_to_path(g_strdup(filename));
         GError *error = NULL;
@@ -220,13 +220,24 @@ GdkPixbuf *get_pixbuf_from_file(const char *filename, double scale)
                 g_free(path);
                 return NULL;
         }
-        // TODO immediately rescale icon upon scale changes
-        icon_size_clamp(&w, &h);
-        GdkPixbuf *pixbuf = gdk_pixbuf_new_from_file_at_scale(path,
-                                                              round(w * scale),
-                                                              round(h * scale),
-                                                              TRUE,
-                                                              &error);
+        GdkPixbuf *pixbuf = NULL;
+        if (settings.enable_recursive_icon_lookup)
+        {
+                icon_size_clamp2(&w, &h, icon_size, scale);
+                pixbuf = gdk_pixbuf_new_from_file_at_scale(path,
+                                w,
+                                h,
+                                TRUE,
+                                &error);
+        } else {
+                // TODO immediately rescale icon upon scale changes
+                icon_size_clamp(&w, &h);
+                pixbuf = gdk_pixbuf_new_from_file_at_scale(path,
+                                round(w * scale),
+                                round(h * scale),
+                                TRUE,
+                                &error);
+        }
 
         if (error) {
                 LOG_W("%s", error->message);

--- a/src/icon.c
+++ b/src/icon.c
@@ -149,6 +149,17 @@ static bool icon_size_clamp(int *w, int *h) {
         return FALSE;
 }
 
+static bool icon_size_clamp2(int *w, int *h, int desired_size, double scale) {
+        int largest_size = MAX(*w, *h);
+        int new_size = desired_size * scale;
+        if (largest_size != new_size) {
+                double scale = (double) new_size / (double) largest_size;
+                *w = round(*w * scale);
+                *h = round(*h * scale);
+                return true;
+        }
+        return false;
+}
 /**
  * Scales the given GdkPixbuf to a given size.. If the image is not square, the
  * largest size will be scaled up to the given size.
@@ -173,13 +184,8 @@ static GdkPixbuf *icon_pixbuf_scale_to_size(GdkPixbuf *pixbuf, int icon_size, do
 
         if (settings.enable_recursive_icon_lookup)
         {
-                int largest_size = MAX(w, h);
-                int new_size = icon_size * dpi_scale;
-                if (largest_size != new_size) {
-                        double scale = (double) new_size / (double) largest_size;
-                        w = round(w * scale);
-                        h = round(h * scale);
-                        needs_change = true;
+                needs_change = icon_size_clamp2(&w, &h, icon_size, dpi_scale);
+                if (needs_change) {
                         LOG_D("Scaling to a size of %ix%i", w, h);
                         LOG_D("While the icon size and scale are %ix%f", icon_size, dpi_scale);
                 }

--- a/src/icon.h
+++ b/src/icon.h
@@ -58,7 +58,7 @@ char *get_path_from_icon_name(const char *iconname, int size);
  * @return an instance of `GdkPixbuf` derived from the GVariant
  * @retval NULL: GVariant parameter nulled, invalid or in wrong format
  */
-GdkPixbuf *icon_get_for_data(GVariant *data, char **id, double scale);
+GdkPixbuf *icon_get_for_data(GVariant *data, char **id, double scale, int icon_size);
 
 #endif
 /* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/icon.h
+++ b/src/icon.h
@@ -11,12 +11,13 @@ cairo_surface_t *gdk_pixbuf_to_cairo_surface(GdkPixbuf *pixbuf);
 /** Retrieve an icon by its full filepath, scaled according to settings.
  *
  * @param filename A string representing a readable file path
+ * @param icon_size An iteger representing the desired unscaled icon size.
  * @param scale An integer representing the output dpi scaling.
  *
  * @return an instance of `GdkPixbuf`
  * @retval NULL: file does not exist, not readable, etc..
  */
-GdkPixbuf *get_pixbuf_from_file(const char *filename, double scale);
+GdkPixbuf *get_pixbuf_from_file(const char *filename, int icon_size, double scale);
 
 
 /**
@@ -55,6 +56,7 @@ char *get_path_from_icon_name(const char *iconname, int size);
  * @param id   (necessary) A unique identifier of the returned pixbuf.
  *             Only filled, if the return value is non-NULL.
  * @param scale An integer representing the output dpi scaling.
+ * @param icon_size An integer representing the desired unscaled icon size.
  * @return an instance of `GdkPixbuf` derived from the GVariant
  * @retval NULL: GVariant parameter nulled, invalid or in wrong format
  */

--- a/src/notification.c
+++ b/src/notification.c
@@ -358,7 +358,8 @@ void notification_icon_replace_data(struct notification *n, GVariant *new_icon)
         n->icon = NULL;
         g_clear_pointer(&n->icon_id, g_free);
 
-        GdkPixbuf *icon = icon_get_for_data(new_icon, &n->icon_id, draw_get_scale());
+        GdkPixbuf *icon = icon_get_for_data(new_icon, &n->icon_id,
+                        draw_get_scale(), n->icon_size);
         n->icon = gdk_pixbuf_to_cairo_surface(icon);
         g_object_unref(icon);
 }

--- a/src/notification.c
+++ b/src/notification.c
@@ -339,7 +339,8 @@ void notification_icon_replace_path(struct notification *n, const char *new_icon
         g_free(n->icon_path);
         n->icon_path = get_path_from_icon_name(new_icon, n->icon_size);
         if (n->icon_path) {
-                GdkPixbuf *pixbuf = get_pixbuf_from_file(n->icon_path, draw_get_scale());
+                GdkPixbuf *pixbuf = get_pixbuf_from_file(n->icon_path,
+                                n->icon_size, draw_get_scale());
                 if (pixbuf) {
                         n->icon = gdk_pixbuf_to_cairo_surface(pixbuf);
                         g_object_unref(pixbuf);


### PR DESCRIPTION
This PR fixes two cases where the resulting icon size would not be the same as `icon_size`. 