### PR TITLE
Fix default `format` value in documentation

### DIFF
--- a/docs/dunst.5.pod
+++ b/docs/dunst.5.pod
@@ -292,7 +292,7 @@ This options is parsed as a Pango font description.
 The amount of extra spacing between text lines in pixels. Set to 0 to
 disable.
 
-=item B<format> (default: "%s %b")
+=item B<format> (default: "<b>%s</b>\n%b")
 
 Specifies how the various attributes of the notification should be formatted on
 the notification window.


### PR DESCRIPTION
It was last changed in https://github.com/dunst-project/dunst/commit/a7b65b2e7b4919039d687232c3cd10f533c256b0 but the documentation was never updated.