### PR TITLE
Allow negative offsets (fixes issue #1026)

### DIFF
--- a/docs/dunst.5.pod
+++ b/docs/dunst.5.pod
@@ -136,8 +136,7 @@ Origin can be one of:
 =item B<offset> format: (horizontal, vertical)
 
 Respectively the horizontal and vertical offset in pixels from the corner
-of the screen specified by B<origin>. Both values should always be positive or
-zero.
+of the screen specified by B<origin>.
 
 Examples:
         origin = top-right

--- a/docs/dunst.5.pod
+++ b/docs/dunst.5.pod
@@ -136,7 +136,8 @@ Origin can be one of:
 =item B<offset> format: (horizontal, vertical)
 
 Respectively the horizontal and vertical offset in pixels from the corner
-of the screen specified by B<origin>.
+of the screen specified by B<origin>. A negative offset will lead to the
+notification being off screen.
 
 Examples:
         origin = top-right

--- a/src/option_parser.c
+++ b/src/option_parser.c
@@ -140,14 +140,6 @@ int string_parse_list(const void *data, const char *s, void *ret) {
                         if (!success)
                                 break;
 
-                        // We can safely assume the length is 2, since the
-                        // string array also had length 2
-                        if (int_arr[0] < 0 || int_arr[1] < 0) {
-                                LOG_W("Offset has to be positive. Correcting...");
-                                int_arr[0] = abs(int_arr[0]);
-                                int_arr[1] = abs(int_arr[1]);
-                        }
-
                         struct position* offset = (struct position*) ret;
                         offset->x = int_arr[0];
                         offset->y = int_arr[1];


### PR DESCRIPTION
Not sure if you want that feature in dunst or not, but this PR fixes regression introduced in 1a456a56 which made it impossible to use negative offsets (issue #1026). I personally think it's useful. Tested on X11 only. I don't have Wayland around, sorry.

fixes #1026