### PR TITLE
Use correct variable for the configuration file paths

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -448,7 +448,7 @@ FILE *fopen_verbose(const char * const path)
 
 /* see utils.h */
 void add_paths_from_env(GPtrArray *arr, char *env_name, char *subdir, char *alternative) {
-        const char *xdg_data_dirs = g_getenv("XDG_DATA_DIRS");
+        const char *xdg_data_dirs = g_getenv(env_name);
         if (!xdg_data_dirs)
                 xdg_data_dirs = alternative;
 


### PR DESCRIPTION
Found this while preparing update for Fedora - as we have `XDG_DATA_DIRS` set in the systemd environment, dunst wasn't reading the system-wide config.

Fixes #1041