### PR TITLE
Fixes dunstctl history command

### DIFF
--- a/dunstctl
+++ b/dunstctl
@@ -138,7 +138,7 @@ case "${1:-}" in
 			|| die "Dunst controlling interface not available. Is the version too old?"
 		;;
 	"history")
-		busctl --user --json=pretty -l --no-pager call org.freedesktop.Notifications /org/freedesktop/Notifications org.dunstproject.cmd0 NotificationListHistory 2>/dev/null \
+		busctl --user --json=pretty --no-pager call org.freedesktop.Notifications /org/freedesktop/Notifications org.dunstproject.cmd0 NotificationListHistory 2>/dev/null \
 			|| die "Dunst is not running."
 		;;
 	"")


### PR DESCRIPTION
Removes `-l` option from the `busctl` invocation since it's only relevant to the `list` outputs.
That fixes the command to fail on invocation with an internal error
```
busctl: invalid option -- 'l'
```
See [buctl(1)](https://www.freedesktop.org/software/systemd/man/busctl.html)