### PR TITLE
follow=keyboard: Fix regression where we don't fall back to mouse

### DIFF
--- a/src/x11/screen.c
+++ b/src/x11/screen.c
@@ -389,12 +389,12 @@ sc_cleanup:
  */
 static Window get_focused_window(void)
 {
-        Window focused;
+        Window focused, root = RootWindow(xctx.dpy, DefaultScreen(xctx.dpy));
         int ignored;
 
         XGetInputFocus(xctx.dpy, &focused, &ignored);
 
-        if (focused == None || focused == PointerRoot)
+        if (focused == None || focused == PointerRoot || focused == root)
                 focused = 0;
         return focused;
 }


### PR DESCRIPTION
Commit e8fc45da6371 ("follow=keyboard: Fall back to follow=mouse instead
of XDefaultScreen()", PR#708) introduced the behaviour that we fall
back to follow=mouse if there is no focused client in order to
accommodate for window managers where sitting on the root window is
normalised, like dwm.

Commmit ebcd20d8d040 ("Fix process of gettign the active monitor",
PR#809) added support for multiple X screens on one display. However, it
broke the functionality introduced in the previous PR, because
explicitly focusing the root window results in XGetInputFocus()
returning the root window, not PointerRoot.

Fix this by explicitly checking if the focused window is the root
window.