### PR TITLE
Implement SVG coloring

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -52,6 +52,7 @@ LDFLAGS_DEBUG  :=
 pkg_config_packs := gio-2.0 \
                     gdk-pixbuf-2.0 \
                     "glib-2.0 >= 2.44" \
+                    librsvg-2.0 \
                     pangocairo \
                     x11 \
                     xinerama \

--- a/src/icon.h
+++ b/src/icon.h
@@ -18,7 +18,7 @@ cairo_surface_t *gdk_pixbuf_to_cairo_surface(GdkPixbuf *pixbuf);
  * @return an instance of `GdkPixbuf`
  * @retval NULL: file does not exist, not readable, etc..
  */
-GdkPixbuf *get_pixbuf_from_file(const char *filename, int min_size, int max_size, double scale);
+GdkPixbuf *get_pixbuf_from_notification(struct notification *n, double scale);
 
 
 /**

--- a/src/icon.h
+++ b/src/icon.h
@@ -18,7 +18,7 @@ cairo_surface_t *gdk_pixbuf_to_cairo_surface(GdkPixbuf *pixbuf);
  * @return an instance of `GdkPixbuf`
  * @retval NULL: file does not exist, not readable, etc..
  */
-GdkPixbuf *get_pixbuf_from_notification(struct notification *n, double scale);
+cairo_surface_t *get_cairo_surface_from_notification(struct notification *n, double scale);
 
 
 /**

--- a/src/notification.c
+++ b/src/notification.c
@@ -339,9 +339,7 @@ void notification_icon_replace_path(struct notification *n, const char *new_icon
         g_free(n->icon_path);
         n->icon_path = get_path_from_icon_name(new_icon, n->min_icon_size);
         if (n->icon_path) {
-                GdkPixbuf *pixbuf = get_pixbuf_from_file(n->icon_path,
-                                n->min_icon_size, n->max_icon_size,
-                                draw_get_scale());
+                GdkPixbuf *pixbuf = get_pixbuf_from_notification(n, draw_get_scale());
                 if (pixbuf) {
                         n->icon = gdk_pixbuf_to_cairo_surface(pixbuf);
                         g_object_unref(pixbuf);
@@ -704,7 +702,7 @@ void notification_update_text_to_render(struct notification *n)
 void notification_do_action(struct notification *n)
 {
         assert(n->default_action_name);
-        
+
         if (g_hash_table_size(n->actions)) {
                 if (g_hash_table_contains(n->actions, n->default_action_name)) {
                         signal_action_invoked(n, n->default_action_name);

--- a/src/notification.c
+++ b/src/notification.c
@@ -339,10 +339,9 @@ void notification_icon_replace_path(struct notification *n, const char *new_icon
         g_free(n->icon_path);
         n->icon_path = get_path_from_icon_name(new_icon, n->min_icon_size);
         if (n->icon_path) {
-                GdkPixbuf *pixbuf = get_pixbuf_from_notification(n, draw_get_scale());
-                if (pixbuf) {
-                        n->icon = gdk_pixbuf_to_cairo_surface(pixbuf);
-                        g_object_unref(pixbuf);
+                cairo_surface_t* icon_surface = get_cairo_surface_from_notification(n, draw_get_scale());
+                if (icon_surface) {
+                        n->icon = icon_surface;
                 } else {
                         LOG_W("No icon found in path: '%s'", n->icon_path);
                 }


### PR DESCRIPTION
This PR aims to solve #1076. It does so by doing a simple string substitution of 'currentColor' with the raised notification's foreground colour.

A better way would have been to let the SVG renderer (librsvg) take care of this but it [doesn't support](https://gitlab.gnome.org/GNOME/librsvg/-/blob/main/FEATURES.md) specifying a custom 'currentColor' through the API AFAIK.