### PR TITLE
DBus PropertiesChanged signal not being emitted for *Length PropertiesChanged

### DIFF
--- a/src/dbus.c
+++ b/src/dbus.c
@@ -25,7 +25,7 @@
 
 #define PROPERTIES_IFAC "org.freedesktop.DBus.Properties"
 
-GDBusConnection *dbus_conn;
+GDBusConnection *dbus_conn = NULL;
 
 static GDBusNodeInfo *introspection_data = NULL;
 
@@ -1184,6 +1184,7 @@ void dbus_teardown(int owner_id)
         g_clear_pointer(&introspection_data, g_dbus_node_info_unref);
 
         g_bus_unown_name(owner_id);
+        dbus_conn = NULL;
 }
 
 /* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/dbus.h
+++ b/src/dbus.h
@@ -20,6 +20,7 @@ int dbus_init(void);
 void dbus_teardown(int id);
 void signal_notification_closed(struct notification *n, enum reason reason);
 void signal_action_invoked(const struct notification *n, const char *identifier);
+void signal_length_propertieschanged();
 
 #endif
 /* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/draw.c
+++ b/src/draw.c
@@ -716,7 +716,7 @@ static void render_content(cairo_t *c, struct colored_layout *cl, int width, dou
         }
 
         // progress bar positioning
-        if (have_progress_bar(cl)){
+        if (have_progress_bar(cl)) {
                 int progress = MIN(cl->n->progress, 100);
                 unsigned int frame_x = 0;
                 unsigned int frame_width = settings.progress_bar_frame_width,

--- a/src/dunst.c
+++ b/src/dunst.c
@@ -59,8 +59,7 @@ void wake_up(void)
 {
         // If wake_up is being called before the output has been setup we should
         // return.
-        if (!setup_done)
-        {
+        if (!setup_done) {
                 LOG_D("Ignoring wake up");
                 return;
         }

--- a/src/icon-lookup.c
+++ b/src/icon-lookup.c
@@ -18,7 +18,7 @@ int default_themes_count = 0;
 
 int get_icon_theme(char *name) {
         for (int i = 0; i < icon_themes_count; i++) {
-                if (STR_EQ(icon_themes[i].subdir_theme, name)){
+                if (STR_EQ(icon_themes[i].subdir_theme, name)) {
                         return i;
                 }
         }
@@ -78,7 +78,7 @@ int load_icon_theme_from_dir(const char *icon_dir, const char *subdir_theme) {
                 // read optional scale, defaulting to 1
                 const char *scale_str = section_get_value(ini, &section, "Scale");
                 icon_themes[index].dirs[i].scale = 1;
-                if (scale_str){
+                if (scale_str) {
                         safe_string_to_int(&icon_themes[index].dirs[i].scale, scale_str);
                 }
 
@@ -112,7 +112,7 @@ int load_icon_theme_from_dir(const char *icon_dir, const char *subdir_theme) {
                 } else if (icon_themes[index].dirs[i].type == THEME_DIR_THRESHOLD) {
                         icon_themes[index].dirs[i].threshold = 2;
                         const char *threshold = section_get_value(ini, &section, "Threshold");
-                        if (threshold){
+                        if (threshold) {
                                 safe_string_to_int(&icon_themes[index].dirs[i].threshold, threshold);
                         }
                 }
@@ -120,8 +120,7 @@ int load_icon_theme_from_dir(const char *icon_dir, const char *subdir_theme) {
 
 
         // load inherited themes
-        if (!STR_EQ(icon_themes[index].name, "Hicolor"))
-        {
+        if (!STR_EQ(icon_themes[index].name, "Hicolor")) {
                 char **inherits = string_to_array(get_value(ini, "Icon Theme", "Inherits"), ",");
                 icon_themes[index].inherits_count = string_array_length(inherits);
                 LOG_D("Theme has %i inherited themes\n", icon_themes[index].inherits_count);

--- a/src/notification.c
+++ b/src/notification.c
@@ -299,7 +299,7 @@ void notification_unref(struct notification *n)
 
         notification_private_free(n->priv);
 
-        if (n->script_count > 0){
+        if (n->script_count > 0) {
                 g_free(n->scripts);
         }
 

--- a/src/option_parser.c
+++ b/src/option_parser.c
@@ -30,7 +30,7 @@ static int cmdline_find_option(const char *key);
 int string_parse_enum(const void *data, const char *s, void * ret) {
         struct string_to_enum_def *string_to_enum = (struct string_to_enum_def*)data;
         for (int i = 0; string_to_enum[i].string != NULL; i++) {
-                if (strcmp(s, string_to_enum[i].string) == 0){
+                if (strcmp(s, string_to_enum[i].string) == 0) {
                         *(int*) ret = string_to_enum[i].enum_value;
                         LOG_D("Setting enum to %i (%s)", *(int*) ret, string_to_enum[i].string);
                         return true;
@@ -246,8 +246,7 @@ int string_parse_length(void *ret_in, const char *s) {
         struct length *ret = (struct length*) ret_in;
         int val = 0;
         char *s_stripped = string_strip_brackets(s);
-        if (!s_stripped)
-        {
+        if (!s_stripped) {
                 // single int without brackets
                 bool success = safe_string_to_int(&val, s);
                 if (success && val > 0) {
@@ -435,7 +434,7 @@ void save_settings(struct ini *ini) {
                         const struct entry curr_entry = curr_section.entries[j];
                         int setting_id = get_setting_id(curr_entry.key, curr_section.name);
                         struct setting curr_setting = allowed_settings[setting_id];
-                        if (setting_id < 0){
+                        if (setting_id < 0) {
                                 if (setting_id == -1) {
                                         LOG_W("Setting %s in section %s doesn't exist", curr_entry.key, curr_section.name);
                                 }

--- a/src/queues.c
+++ b/src/queues.c
@@ -464,7 +464,7 @@ void queues_update(struct dunst_status status, gint64 time)
                 }
 
 
-                if (queues_notification_is_finished(n, status, time)){
+                if (queues_notification_is_finished(n, status, time)) {
                         queues_notification_close(n, REASON_TIME);
                         iter = nextiter;
                         continue;

--- a/src/queues.c
+++ b/src/queues.c
@@ -547,6 +547,7 @@ void queues_update(struct dunst_status status, gint64 time)
                         }
                 }
         }
+        signal_length_propertieschanged();
 }
 
 /* see queues.h */

--- a/src/rules.c
+++ b/src/rules.c
@@ -89,7 +89,7 @@ void rule_apply(struct rule *r, struct notification *n)
                 notification_icon_replace_path(n, r->new_icon);
                 n->receiving_raw_icon = false;
         }
-        if (r->script){
+        if (r->script) {
                 n->scripts = g_renew(const char*,n->scripts,n->script_count + 1);
                 n->scripts[n->script_count] = r->script;
 

--- a/src/settings.c
+++ b/src/settings.c
@@ -172,7 +172,7 @@ void print_rule(struct rule* r) {
 void check_and_correct_settings(struct settings *s) {
 
 #ifndef ENABLE_WAYLAND
-        if (is_running_wayland()){
+        if (is_running_wayland()) {
                 /* We are using xwayland now. Setting force_xwayland to make sure
                  * the idle workaround below is activated */
                 settings.force_xwayland = true;
@@ -189,13 +189,13 @@ void check_and_correct_settings(struct settings *s) {
 
         // check sanity of the progress bar options
         {
-                if (s->progress_bar_height < (2 * s->progress_bar_frame_width)){
+                if (s->progress_bar_height < (2 * s->progress_bar_frame_width)) {
                         DIE("setting progress_bar_frame_width is bigger than half of progress_bar_height");
                 }
-                if (s->progress_bar_max_width < (2 * s->progress_bar_frame_width)){
+                if (s->progress_bar_max_width < (2 * s->progress_bar_frame_width)) {
                         DIE("setting progress_bar_frame_width is bigger than half of progress_bar_max_width");
                 }
-                if (s->progress_bar_max_width < s->progress_bar_min_width){
+                if (s->progress_bar_max_width < s->progress_bar_min_width) {
                         DIE("setting progress_bar_max_width is smaller than progress_bar_min_width");
                 }
                 if (s->progress_bar_min_width > s->width.max) {

--- a/src/utils.c
+++ b/src/utils.c
@@ -137,7 +137,7 @@ void string_strip_delimited(char *str, char a, char b)
                         cskip = 0;
                         str[iwrite++] = str[iread];
                 }
-                if (copen > 0){
+                if (copen > 0) {
                         cskip++;
                 }
         }
@@ -156,7 +156,7 @@ char **string_to_array(const char *string, const char *delimiter)
         char **arr = NULL;
         if (string) {
                 arr = g_strsplit(string, delimiter, 0);
-                for (int i = 0; arr[i]; i++){
+                for (int i = 0; arr[i]; i++) {
                         g_strstrip(arr[i]);
                 }
         }

--- a/src/wayland/foreign_toplevel.c
+++ b/src/wayland/foreign_toplevel.c
@@ -46,7 +46,7 @@ static void toplevel_handle_output_leave(void *data,
         struct dunst_output *output = wl_output_get_user_data(wl_output);
         struct toplevel_output *pos, *tmp;
         wl_list_for_each_safe(pos, tmp, &toplevel->output_list, link){
-                if (pos->dunst_output->name == output->name){
+                if (pos->dunst_output->name == output->name) {
                         wl_list_remove(&pos->link);
                 }
         }

--- a/src/wayland/libgwater-wayland.c
+++ b/src/wayland/libgwater-wayland.c
@@ -56,8 +56,7 @@ _g_water_wayland_source_prepare(GSource *source, gint *timeout)
     *timeout = 0;
     if ( wl_display_prepare_read(self->display) != 0 )
         return TRUE;
-    else if ( wl_display_flush(self->display) < 0 )
-    {
+    else if ( wl_display_flush(self->display) < 0 ) {
         self->error = errno;
         return TRUE;
     }
@@ -77,8 +76,7 @@ _g_water_wayland_source_check(GSource *source)
     GIOCondition revents;
     revents = g_source_query_unix_fd(source, self->fd);
 
-    if ( revents & G_IO_IN )
-    {
+    if ( revents & G_IO_IN ) {
         if ( wl_display_read_events(self->display) < 0 )
             self->error = errno;
     }
@@ -95,8 +93,7 @@ _g_water_wayland_source_dispatch(GSource *source, GSourceFunc callback, gpointer
     GIOCondition revents;
 
     revents = g_source_query_unix_fd(source, self->fd);
-    if ( ( self->error > 0 ) || ( revents & (G_IO_ERR | G_IO_HUP) ) )
-    {
+    if ( ( self->error > 0 ) || ( revents & (G_IO_ERR | G_IO_HUP) ) ) {
         errno = self->error;
         self->error = 0;
         if ( callback != NULL )
@@ -104,8 +101,7 @@ _g_water_wayland_source_dispatch(GSource *source, GSourceFunc callback, gpointer
         return G_SOURCE_REMOVE;
     }
 
-    if ( wl_display_dispatch_pending(self->display) < 0 )
-    {
+    if ( wl_display_dispatch_pending(self->display) < 0 ) {
         if ( callback != NULL )
             return callback(user_data);
         return G_SOURCE_REMOVE;

--- a/src/wayland/wl.c
+++ b/src/wayland/wl.c
@@ -355,7 +355,7 @@ static const struct org_kde_kwin_idle_timeout_listener idle_timeout_listener = {
 };
 
 static void add_seat_to_idle_handler(struct wl_seat *seat) {
-        if (!ctx.idle_handler){
+        if (!ctx.idle_handler) {
                 return;
         }
         if (settings.idle_threshold > 0) {

--- a/src/x11/screen.c
+++ b/src/x11/screen.c
@@ -243,7 +243,7 @@ bool window_is_fullscreen(Window window)
         ASSERT_OR_RET(window, false);
 
         Atom has_wm_state = XInternAtom(xctx.dpy, "_NET_WM_STATE", True);
-        if (has_wm_state == None){
+        if (has_wm_state == None) {
                 return false;
         }
 

--- a/test/dbus.c
+++ b/test/dbus.c
@@ -21,6 +21,14 @@ struct signal_actioninvoked {
         GDBusConnection *conn;
 };
 
+struct signal_propertieschanged {
+        gchar *interface;
+        GVariant *array_dict_sv_data;
+        GVariant *array_s_data;
+        guint subscription_id;
+        GDBusConnection *conn;
+};
+
 struct signal_closed {
         guint32 id;
         guint32 reason;
@@ -79,6 +87,73 @@ void dbus_signal_unsubscribe_actioninvoked(struct signal_actioninvoked *actionin
 
         actioninvoked->conn = NULL;
         actioninvoked->subscription_id = -1;
+}
+
+void dbus_signal_cb_propertieschanged(GDBusConnection *connection,
+                                  const gchar *sender_name,
+                                  const gchar *object_path,
+                                  const gchar *interface_name,
+                                  const gchar *signal_name,
+                                  GVariant *parameters,
+                                  gpointer user_data)
+{
+        g_return_if_fail(user_data);
+
+        gchar *interface;
+        GVariant *array_dict_sv_data;
+        GVariant *array_s_data;
+
+        struct signal_propertieschanged *sig = (struct signal_propertieschanged*) user_data;
+
+        g_variant_get(parameters, "(s@a{sv}@as)", &interface, &array_dict_sv_data, &array_s_data);
+
+        if (g_strcmp0(interface, DUNST_IFAC) == 0) {
+                sig->interface = interface;
+                sig->array_dict_sv_data = array_dict_sv_data;
+                sig->array_s_data = array_s_data;
+        }
+
+}
+
+void dbus_signal_subscribe_propertieschanged(struct signal_propertieschanged *propertieschanged)
+{
+        assert(propertieschanged);
+
+        propertieschanged->conn = g_bus_get_sync(G_BUS_TYPE_SESSION, NULL, NULL);
+        propertieschanged->subscription_id =
+                g_dbus_connection_signal_subscribe(
+                        // GDBusConnection *connection,
+                        propertieschanged->conn,
+                        // const gchar *sender,
+                        FDN_NAME,
+                        // const gchar *interface_name,
+                        PROPERTIES_IFAC,
+                        // const gchar *member,
+                        "PropertiesChanged",
+                        // const gchar *object_path,
+                        FDN_PATH,
+                        // const gchar *arg0,
+                        NULL,
+                        // GDBusSignalFlags flags,
+                        G_DBUS_SIGNAL_FLAGS_NONE,
+                        // GDBusSignalCallback callback,
+                        dbus_signal_cb_propertieschanged,
+                        // gpointer user_data,
+                        propertieschanged,
+                        // GDestroyNotify user_data_free_func
+                        NULL);
+
+}
+
+void dbus_signal_unsubscribe_propertieschanged(struct signal_propertieschanged *propertieschanged)
+{
+        assert(propertieschanged);
+
+        g_dbus_connection_signal_unsubscribe(propertieschanged->conn, propertieschanged->subscription_id);
+        g_object_unref(propertieschanged->conn);
+
+        propertieschanged->conn = NULL;
+        propertieschanged->subscription_id = -1;
 }
 
 void dbus_signal_cb_closed(GDBusConnection *connection,
@@ -740,6 +815,47 @@ TEST test_signal_actioninvoked(void)
         PASS();
 }
 
+TEST test_signal_length_propertieschanged(void)
+{
+        struct dbus_notification *n_dbus;
+        struct signal_propertieschanged sig = {NULL, NULL, NULL, -1};
+
+        dbus_signal_subscribe_propertieschanged(&sig);
+
+        n_dbus = dbus_notification_new();
+        n_dbus->app_name = "dunstteststack";
+        n_dbus->app_icon = "NONE2";
+        n_dbus->summary = "Headline for New";
+        n_dbus->body = "Text";
+        g_hash_table_insert(n_dbus->actions, g_strdup("actionkey"), g_strdup("Print this text"));
+
+        guint id;
+        ASSERT(dbus_notification_fire(n_dbus, &id));
+        ASSERT(id != 0);
+
+        queues_update(STATUS_NORMAL, time_monotonic_now());
+
+        uint waiting = 0;
+        while (!sig.interface && waiting < 2000) {
+                usleep(500);
+                waiting++;
+        }
+
+        ASSERT_STR_EQ(sig.interface, DUNST_IFAC);
+
+        guint32 displayed_length;
+        g_variant_lookup(sig.array_dict_sv_data, "displayedLength", "u", &displayed_length);
+
+        ASSERT_EQ(displayed_length, queues_length_displayed());
+
+        g_free(sig.interface);
+        g_variant_unref(sig.array_dict_sv_data);
+        g_variant_unref(sig.array_s_data);
+        dbus_notification_free(n_dbus);
+        dbus_signal_unsubscribe_propertieschanged(&sig);
+        PASS();
+}
+
 TEST test_close_and_signal(void)
 {
         GVariant *data, *ret;
@@ -928,6 +1044,7 @@ gpointer run_threaded_tests(gpointer data)
         RUN_TESTp(test_server_caps, MARKUP_NO);
         RUN_TEST(test_close_and_signal);
         RUN_TEST(test_signal_actioninvoked);
+        RUN_TEST(test_signal_length_propertieschanged);
         RUN_TEST(test_timeout_overflow);
         RUN_TEST(test_override_dbus_timeout);
         RUN_TEST(test_match_dbus_timeout);

--- a/test/dbus.c
+++ b/test/dbus.c
@@ -371,6 +371,52 @@ TEST test_invalid_notification(void)
         PASS();
 }
 
+TEST test_dbus_cb_dunst_Properties_Get(void)
+{
+
+        GDBusConnection *connection_client;
+        GError *error = NULL;
+
+        connection_client = g_bus_get_sync(G_BUS_TYPE_SESSION, NULL, NULL);
+
+        GVariant *pause_variant = dbus_cb_dunst_Properties_Get(connection_client,
+                                      FDN_NAME,
+                                      FDN_PATH,
+                                      DUNST_IFAC,
+                                      "paused",
+                                      &error,
+                                      NULL);
+
+        if (error) {
+                printf("Error while calling dbus_cb_dunst_Properties_Get: %s\n", error->message);
+                g_error_free(error);
+        }
+
+        ASSERT_FALSE(g_variant_get_boolean(pause_variant));
+        g_variant_unref(pause_variant);
+
+        dunst_status(S_RUNNING, false);
+
+        pause_variant = dbus_cb_dunst_Properties_Get(connection_client,
+                                      FDN_NAME,
+                                      FDN_PATH,
+                                      DUNST_IFAC,
+                                      "paused",
+                                      &error,
+                                      NULL);
+
+        if (error) {
+                printf("Error while calling dbus_cb_dunst_Properties_Get: %s\n", error->message);
+                g_error_free(error);
+        }
+
+        ASSERT(g_variant_get_boolean(pause_variant));
+        g_variant_unref(pause_variant);
+
+        g_object_unref(connection_client);
+        PASS();
+}
+
 TEST test_dbus_cb_dunst_Properties_Set(void)
 {
 
@@ -1077,6 +1123,7 @@ gpointer run_threaded_tests(gpointer data)
         RUN_TEST(test_dbus_init);
 
         RUN_TEST(test_get_fdn_daemon_info);
+        RUN_TEST(test_dbus_cb_dunst_Properties_Get);
         RUN_TEST(test_dbus_cb_dunst_Properties_Set);
 
         RUN_TEST(test_empty_notification);

--- a/test/icon-lookup.c
+++ b/test/icon-lookup.c
@@ -104,7 +104,7 @@ TEST test_bench_search(void)
         add_default_theme(index);
         printf("Benchmarking icons\n");
         clock_t start_time = clock();
-        for (int i = 0; i < 1000; i++){
+        for (int i = 0; i < 1000; i++) {
                 // icon is part of papirus, right at the end of index.theme
                 char *icon = find_icon_path("weather-windy-symbolic", 512);
                 ASSERT(icon);
@@ -126,7 +126,7 @@ TEST test_bench_multiple_search(void)
         add_default_theme(index);
         printf("Benchmarking icons\n");
         clock_t start_time = clock();
-        for (int i = 0; i < 1000; i++){
+        for (int i = 0; i < 1000; i++) {
                 // icon is part of papirus, right at the end of index.theme
                 char *icon = find_icon_path("view-wrapped-rtl-symbolic", 512);
                 /* printf("%s\n", icon); */
@@ -149,7 +149,7 @@ TEST test_bench_doesnt_exist(void)
         add_default_theme(index);
         printf("Benchmarking icons\n");
         clock_t start_time = clock();
-        for (int i = 0; i < 1000; i++){
+        for (int i = 0; i < 1000; i++) {
                 // Icon size is chosen as some common icon size.
                 char *icon = find_icon_path("doesn't exist", 48);
                 /* printf("%s\n", icon); */

--- a/test/input.c
+++ b/test/input.c
@@ -145,7 +145,8 @@ TEST test_notification_at(void)
         ASSERT(result != NULL);
         ASSERT(result == bottom_notification);
 
-        g_slist_free_full(notifications, free_dummy_notification);
+        queues_teardown();
+        g_slist_free(notifications);
         PASS();
 }
 

--- a/test/option_parser.c
+++ b/test/option_parser.c
@@ -10,7 +10,7 @@ enum greatest_test_res ARRAY_EQ(char **a, char **b){
         ASSERT(a);
         ASSERT(b);
         int i = 0;
-        while (a[i] && b[i]){
+        while (a[i] && b[i]) {
                 ASSERT_STR_EQ(a[i], b[i]);
                 i++;
         }
@@ -388,7 +388,7 @@ TEST test_string_to_list(void)
                 sprintf(buf, "Failed in round %i", i);
                 ASSERTm(buf, set_from_string(s.value, s, inputs[i]));
                 ASSERT_EQm(buf, get_list_len(val), get_list_len(results[i]));
-                for (int j = 0; val[j] != MOUSE_ACTION_END; j++){
+                for (int j = 0; val[j] != MOUSE_ACTION_END; j++) {
                         sprintf(buf, "Failed in round %i, element %i. Is %i, should be %i", i, j, val[j], results[i][j]);
                         ASSERT_EQm(buf, val[j], results[i][j]);
                 }

--- a/test/utils.c
+++ b/test/utils.c
@@ -175,7 +175,7 @@ TEST test_string_to_time(void)
         gint64  exp[] = {      5000,     5000, 100000, 10000, 120000, 39600000, 777600000,     5,         0};
 
         int i = 0;
-        while (input[i]){
+        while (input[i]) {
                 ASSERT_EQ_FMT(string_to_time(input[i]), exp[i]*1000, "%ld");
                 i++;
         }


### PR DESCRIPTION
Similarly to what @ammgws noted in #765, for `paused`, the various Length PropertiesChanged were not emitting PropertiesChanged when notifications were opened/closed. This change makes sure that these values are always kept up to date.