### PR TITLE
Add option to set icon image corner radius

### DIFF
--- a/docs/dunst.5.pod
+++ b/docs/dunst.5.pod
@@ -188,6 +188,11 @@ than half of the progress bar height.
 The corner radius of the progress bar in pixels. Gives the progress bar
 rounded corners. Set to 0 to disable.
 
+=item B<icon_corner_radius> (default: 0)
+
+The corner radius of the icon image in pixels. Gives the icon
+rounded corners. Set to 0 to disable.
+
 =item B<indicate_hidden> (values: [true/false], default: true)
 
 If this is set to true, a notification indicating how many notifications are

--- a/dunstrc
+++ b/dunstrc
@@ -63,6 +63,8 @@
     # Corner radius for the progress bar. 0 disables rounded corners.
     progress_bar_corner_radius = 0
 
+    # Corner radius for the icon image.
+    icon_corner_radius = 12
 
     # Show how many messages are currently hidden (because of
     # notification_limit).

--- a/dunstrc
+++ b/dunstrc
@@ -64,7 +64,7 @@
     progress_bar_corner_radius = 0
 
     # Corner radius for the icon image.
-    icon_corner_radius = 12
+    icon_corner_radius = 0
 
     # Show how many messages are currently hidden (because of
     # notification_limit).

--- a/src/draw.c
+++ b/src/draw.c
@@ -711,7 +711,7 @@ static void render_content(cairo_t *c, struct colored_layout *cl, int width, dou
                 } // else ICON_RIGHT
 
                 cairo_set_source_surface(c, cl->icon, round(image_x * scale), round(image_y * scale));
-                draw_rect(c, image_x, image_y, image_width, image_height, scale);
+                draw_rounded_rect(c, image_x, image_y, image_width, image_height, settings.icon_corner_radius, scale, true, true);
                 cairo_fill(c);
         }
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -148,6 +148,7 @@ struct settings {
         int progress_bar_max_width;
         int progress_bar_frame_width;
         int progress_bar_corner_radius;
+        int icon_corner_radius;
         bool progress_bar;
         enum zwlr_layer_shell_v1_layer layer;
         enum origin_values origin;

--- a/src/settings_data.h
+++ b/src/settings_data.h
@@ -1075,6 +1075,16 @@ static const struct setting allowed_settings[] = {
                 .parser_data = NULL,
         },
         {
+                .name = "icon_corner_radius",
+                .section = "global",
+                .description = "Icon corner radius",
+                .type = TYPE_INT,
+                .default_value = "0",
+                .value = &settings.icon_corner_radius,
+                .parser = NULL,
+                .parser_data = NULL,
+        },
+        {
                 .name = "progress_bar",
                 .section = "global",
                 .description = "Show the progress bar",


### PR DESCRIPTION
I added an option to set the icon image corner radius.

The variable name is `icon_corner_radius` and it would just have to be added to the `dunstrc` file.
It looks like this when used and it seems to work fine for me: 
![image](https://user-images.githubusercontent.com/82711105/216974961-d5332cf7-3ce5-4e0f-8c75-6c389c0be3ce.png)

Example:
![image](https://user-images.githubusercontent.com/82711105/216975518-552e118f-bb92-470e-a95b-77705fe0cea1.png)

