### PR TITLE
Enforce g_malloc over malloc in project

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,18 @@ on:
       - master
 
 jobs:
+  # Enforce the standard of g_malloc instead of malloc in the project
+  enforce-g_malloc:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        # Clone the whole branch, we have to fetch tags later
+        fetch-depth: 0
+
+    - name: enforce-g_malloc
+      run: "! git grep -P '(?<!g_)malloc' ':!.valgrind.suppressions' ':!.github/workflows/main.yml'"
+
   build:
     strategy:
       matrix:

--- a/src/icon-lookup.c
+++ b/src/icon-lookup.c
@@ -3,7 +3,6 @@
 
 #include <glib.h>
 #include <stdio.h>
-#include <malloc.h>
 #include <unistd.h>
 #include <assert.h>
 

--- a/src/rules.c
+++ b/src/rules.c
@@ -168,7 +168,7 @@ static inline bool rule_field_matches_string(const char *value, const char *patt
                 int err = regcomp(&regex, pattern, REG_NEWLINE | REG_EXTENDED | REG_NOSUB);
                 if (err) {
                         size_t err_size = regerror(err, &regex, NULL, 0);
-                        char *err_buf = malloc(err_size);
+                        char *err_buf = g_malloc(err_size);
                         regerror(err, &regex, err_buf, err_size);
                         LOG_W("%s: \"%s\"", err_buf, pattern);
                         free(err_buf);

--- a/test/icon-lookup.c
+++ b/test/icon-lookup.c
@@ -73,7 +73,7 @@ TEST test_new_icon_overrides_raw_icon(void) {
         setup_test_theme();
 
         struct notification *n = test_notification_with_icon("new_icon", 10);
-        struct rule *rule = malloc(sizeof(struct rule));
+        struct rule *rule = g_malloc(sizeof(struct rule));
         *rule = empty_rule;
         rule->summary = g_strdup("new_icon");
         rule->new_icon = g_strdup("edit");


### PR DESCRIPTION
We need to use g_malloc since it handles the error conditions of malloc and terminates the program immediately. We do not have to check for error codes we could not handle anyways.