### PR TITLE
Change option description string

### DIFF
--- a/dunstify.c
+++ b/dunstify.c
@@ -108,7 +108,7 @@ void parse_commandline(int argc, char *argv[])
     GError *error = NULL;
     GOptionContext *context;
 
-    context = g_option_context_new("- Dunstify");
+    context = g_option_context_new("SUMMARY BODY");
     g_option_context_add_main_entries(context, entries, NULL);
     if (!g_option_context_parse(context, &argc, &argv, &error)){
         g_printerr("Invalid commandline: %s\n", error->message);


### PR DESCRIPTION
It took very long time for me to figure out what is that "summary" dunstify says it needs.

```
$ dunstify
I need at least a summary
$ dunstify --help
Usage:
  dunstify [OPTION…] - Dunstify

Help Options:
  -?, --help                  Show help options

Application Options:
  -a, --appname=NAME          Name of your application
  -u, --urgency=URG           The urgency of this notification
  -h, --hints=HINT            User specified hints
  -A, --action=ACTION         Actions the user can invoke
  -t, --timeout=TIMEOUT       The time in milliseconds until the notification expires
  -i, --icon=ICON             An Icon that should be displayed with the notification
  -I, --raw_icon=RAW_ICON     Path to the icon to be sent as raw image data
  -c, --capabilities          Print the server capabilities and exit
  -s, --serverinfo            Print server information and exit
  -p, --printid               Print id, which can be used to update/replace this notification
  -r, --replace=ID            Set id of this notification.
  -C, --close=ID              Close the notification with the specified ID
  -b, --block                 Block until notification is closed and print close reason
```

Now I understand "- Dunstify" is an example of usage. It wasn't so obvious for me though. Typical error says about some "summary" which I don't see in the --help output. This patch would change --help output to mention this word and eliminate possible confusion.

```
$ dunstify
I need at least a summary
$ dunstify --help
Usage:
  dunstify [OPTION…] SUMMARY BODY
  ...
```