### PR TITLE
docs: update default notification_limit

### DIFF
--- a/docs/dunst.5.pod
+++ b/docs/dunst.5.pod
@@ -108,7 +108,7 @@ screens exceed (e.g. 10000).
 
 The maximum height of a single notification.
 
-=item B<notification_limit> (default: 0)
+=item B<notification_limit> (default: 20)
 
 The number of notifications that can appear at one time. When this
 limit is reached any additional notifications will be queued and displayed when


### PR DESCRIPTION
I saw that the docs weren't up to date, and fixed it. See 2117544e7c11e9b49f184a6f5b0ddb0de1a9eb4f