### PR TITLE
High CPU usage when show_age_threshold = -1

### DIFF
--- a/src/dunst.c
+++ b/src/dunst.c
@@ -82,18 +82,17 @@ static gboolean run(void *data)
 
         queues_update(status, now);
 
-        bool active = queues_length_displayed() > 0;
-
-        if (active) {
-                // Call draw before showing the window to avoid flickering
-                draw();
-                output->win_show(win);
-        } else {
+        if (!queues_length_displayed()) {
                 output->win_hide(win);
+                return G_SOURCE_REMOVE;
         }
 
-        if (active) {
-                gint64 timeout_at = queues_get_next_datachange(now);
+        // Call draw before showing the window to avoid flickering
+        draw();
+        output->win_show(win);
+
+        gint64 timeout_at = queues_get_next_datachange(now);
+        if (timeout_at != -1) {
                 // Previous computations may have taken time, update `now`
                 // This might mean that `timeout_at` is now before `now`, so
                 // we have to make sure that `sleep` is still positive.


### PR DESCRIPTION
The show_age_threshold can be set to -1 to disable the feature that updates notifications with their age.

In this scenario the `queues_get_next_datachange` may return -1 to indicate that there is no next wakeup time (e.g. when there are permanent / critical notifications).

The code that calls `queues_get_next_datachange` should take this scenario into account and not schedule another timeout if -1 is returned.

Addresses #1163.