### PR TITLE
Turn of second threshold tolerance

### DIFF
--- a/src/notification.c
+++ b/src/notification.c
@@ -673,7 +673,9 @@ void notification_update_text_to_render(struct notification *n)
         /* print age */
         gint64 hours, minutes, seconds;
         // Timestamp is floored to the second for display purposes -- see queues.c
-        gint64 t_delta = time_monotonic_now() - (n->timestamp - n->timestamp % S2US(1));
+        gint64 t_delta = time_monotonic_now()
+                - (n->timestamp - n->timestamp % S2US(1))
+                + TURN_OF_SECOND_THRESHOLD_US;
 
         if (settings.show_age_threshold >= 0
             && t_delta >= settings.show_age_threshold) {

--- a/src/queues.c
+++ b/src/queues.c
@@ -555,6 +555,14 @@ gint64 queues_get_next_datachange(gint64 time)
 {
         gint64 wakeup_time = G_MAXINT64;
         gint64 next_second = time + S2US(1) - (time % S2US(1));
+        if(next_second - time < TURN_OF_SECOND_THRESHOLD_US) {
+                /* Sometimes, the actual sleep will be a few microseconds
+                   shorter than requested. If we were sleeping until next
+                   second, this new run will be just before the turn of second,
+                   and next_second will be less than this threshold away: in
+                   this case, just sleep 1s more. */
+                next_second += S2US(1);
+        }
 
         for (GList *iter = g_queue_peek_head_link(displayed); iter;
                         iter = iter->next) {

--- a/src/queues.h
+++ b/src/queues.h
@@ -12,6 +12,15 @@
 #include "notification.h"
 
 /**
+ * If the current update is less than this constant away from the next turn of
+ * second (in microseconds), then the notification's displayed age will be
+ * updated as if the turn of second passed. This prevents weird behaviours when
+ * the sleep between two main loop runs is slightly shorter than what was
+ * requested.
+ */
+#define TURN_OF_SECOND_THRESHOLD_US 10000
+
+/**
  * Initialise necessary queues
  *
  * @pre Do not call consecutively to avoid memory leaks

--- a/test/queues.c
+++ b/test/queues.c
@@ -525,16 +525,22 @@ TEST test_datachange_agethreshold_at_second(void)
         ASSERTm("Age threshold is activated, first wakeup should be at 5.5s",
                         queues_get_next_datachange(cur_time) == S2US(5) + 500000);
 
-        const int NB_MICROSECS = 6;
-        const gint64 MICROSECS[] = {
-                0, 10, NOTIF_DELTA, NOTIF_DELTA + 1, 124131, S2US(1)-1
+        const int NB_MICROSECS = 7;
+        const gint64 MICROSECS[] = { // Do not re-order!
+                S2US(1) - 1, 0, 10, NOTIF_DELTA, NOTIF_DELTA + 1, 124131, S2US(1)-TURN_OF_SECOND_THRESHOLD_US
         };
         for(gint64 base_time = S2US(5); base_time <= S2US(7); base_time += S2US(1)) {
                 for(int musec_id = 0; musec_id < NB_MICROSECS; ++musec_id) {
                         cur_time = base_time + MICROSECS[musec_id];
                         gint64 next_wakeup = queues_get_next_datachange(cur_time);
+                        gint64 expected_next_wakeup = base_time + S2US(1);
+                        if(musec_id == 0) {
+                                // If cur_time is less than 1ms away from the
+                                // next turn of second, wait one second more.
+                                expected_next_wakeup += S2US(1);
+                        }
                         ASSERTm("Age threshold is activated, next wakeup should be at next turn of second",
-                                        next_wakeup == base_time + S2US(1));
+                                        next_wakeup == expected_next_wakeup);
                 }
         }
 


### PR DESCRIPTION
This patch was first included in PR #1158. The notifications' age is updated at each turn of second, but sometimes, the sleep between two loop turns will be slightly (a fraction of ms most of the time) shorter than what was requested, resulting in a loop run just before the turn of second. In this case, to avoid doing nothing and requesting a very short sleep until the turn of second, this PR introduces a slight tolerance:

* request a sleep until the exact turn of second,
* yet update the notification if the turn of second is very close ahead, and do not wake up until the next turn of second (unless some other event requires it).