### PR TITLE
Add guard against realloc fail in icon-lookup.c

### DIFF
--- a/src/icon-lookup.c
+++ b/src/icon-lookup.c
@@ -53,8 +53,14 @@ int load_icon_theme_from_dir(const char *icon_dir, const char *subdir_theme) {
                 return -1;
         }
 
+		struct icon_theme *temp_icon_themes = realloc(icon_themes, (icon_themes_count + 1) * sizeof(struct icon_theme));
+		if (temp_icon_themes == NULL) {
+			LOG_W("Reallocation failed when loading icon theme...");
+			return -1;
+		}
+		icon_themes = temp_icon_themes;
+
         icon_themes_count++;
-        icon_themes = realloc(icon_themes, icon_themes_count * sizeof(struct icon_theme));
         int index = icon_themes_count - 1;
         icon_themes[index].name = g_strdup(section_get_value(ini, &ini->sections[0], "Name"));
         icon_themes[index].location = g_strdup(icon_dir);
@@ -234,9 +240,15 @@ void add_default_theme(int theme_index) {
                                 theme_index);
                 return;
         }
+
+		int *temp_default_themes_index = realloc(default_themes_index,
+                        (default_themes_count + 1) * sizeof(int));
+		if (temp_default_themes_index == NULL) {
+			LOG_W("Reallocation failed when adding default theme...");
+			return;
+		}
         default_themes_count++;
-        default_themes_index = realloc(default_themes_index,
-                        default_themes_count * sizeof(int));
+		default_themes_index = temp_default_themes_index;
         default_themes_index[default_themes_count - 1] = theme_index;
 }
 


### PR DESCRIPTION
If realloc fails, its return value will be NULL. In the two calls to realloc in icon-lookup.c, this means the global icon_themes and default_themes_index will be overwritten, producing not only a probable error, but a memory leak as well.

This pull request aims to fix that by adding a couple of guards and keeping the global arrays intact, in case of failure.

Bugs found with cppcheck. It is really minor, I doubt it will ever happen. But it is in theory possible.