### PR TITLE
Replace realloc with g_realloc in icon-lookup.c

### DIFF
--- a/src/icon-lookup.c
+++ b/src/icon-lookup.c
@@ -49,12 +49,12 @@ int load_icon_theme_from_dir(const char *icon_dir, const char *subdir_theme) {
         fclose(theme_index);
         if (ini->section_count == 0) {
                 finish_ini(ini);
-                free(ini);
+                g_free(ini);
                 return -1;
         }
 
         icon_themes_count++;
-        icon_themes = realloc(icon_themes, icon_themes_count * sizeof(struct icon_theme));
+        icon_themes = g_realloc(icon_themes, icon_themes_count * sizeof(struct icon_theme));
         int index = icon_themes_count - 1;
         icon_themes[index].name = g_strdup(section_get_value(ini, &ini->sections[0], "Name"));
         icon_themes[index].location = g_strdup(icon_dir);
@@ -64,7 +64,7 @@ int load_icon_theme_from_dir(const char *icon_dir, const char *subdir_theme) {
 
         // load theme directories
         icon_themes[index].dirs_count = ini->section_count - 1;
-        icon_themes[index].dirs = calloc(icon_themes[index].dirs_count, sizeof(struct icon_theme_dir));
+        icon_themes[index].dirs = g_malloc0(icon_themes[index].dirs_count * sizeof(struct icon_theme_dir));
 
         for (int i = 0; i < icon_themes[index].dirs_count; i++) {
                 struct section section = ini->sections[i+1];
@@ -126,13 +126,13 @@ int load_icon_theme_from_dir(const char *icon_dir, const char *subdir_theme) {
                 if (icon_themes[index].inherits_count <= 0) {
                         // set fallback theme to hicolor if there are no inherits
                         g_strfreev(inherits);
-                        inherits = calloc(2, sizeof(char*));
+                        inherits = g_malloc(2 * sizeof(char*));
                         inherits[0] = g_strdup("hicolor");
                         inherits[1] = NULL;
                         icon_themes[index].inherits_count = 1;
                 }
 
-                icon_themes[index].inherits_index = calloc(icon_themes[index].inherits_count, sizeof(int));
+                icon_themes[index].inherits_index = g_malloc0(icon_themes[index].inherits_count * sizeof(int));
 
                 for (int i = 0; inherits[i] != NULL; i++) {
                         LOG_D("inherits: %s\n", inherits[i]);
@@ -150,7 +150,7 @@ int load_icon_theme_from_dir(const char *icon_dir, const char *subdir_theme) {
 
 
         finish_ini(ini);
-        free(ini);
+        g_free(ini);
         return index;
 }
 
@@ -192,7 +192,7 @@ int load_icon_theme(char *name) {
 void finish_icon_theme_dir(struct icon_theme_dir *dir) {
         if (!dir)
                 return;
-        free(dir->name);
+        g_free(dir->name);
 }
 
 void finish_icon_theme(struct icon_theme *theme) {
@@ -201,22 +201,22 @@ void finish_icon_theme(struct icon_theme *theme) {
         for (int i = 0; i < theme->dirs_count; i++) {
                 finish_icon_theme_dir(&theme->dirs[i]);
         }
-        free(theme->name);
-        free(theme->location);
-        free(theme->subdir_theme);
-        free(theme->inherits_index);
-        free(theme->dirs);
+        g_free(theme->name);
+        g_free(theme->location);
+        g_free(theme->subdir_theme);
+        g_free(theme->inherits_index);
+        g_free(theme->dirs);
 }
 
 void free_all_themes() {
-        free(default_themes_index);
+        g_free(default_themes_index);
         default_themes_index = NULL;
         default_themes_count = 0;
         LOG_D("Finishing %i themes\n", icon_themes_count);
         for (int i = 0; i < icon_themes_count; i++) {
                 finish_icon_theme(&icon_themes[i]);
         }
-        free(icon_themes);
+        g_free(icon_themes);
         icon_themes_count = 0;
         icon_themes = NULL;
         g_ptr_array_unref(theme_path);
@@ -235,7 +235,7 @@ void add_default_theme(int theme_index) {
                 return;
         }
         default_themes_count++;
-        default_themes_index = realloc(default_themes_index,
+        default_themes_index = g_realloc(default_themes_index,
                         default_themes_count * sizeof(int));
         default_themes_index[default_themes_count - 1] = theme_index;
 }

--- a/src/icon-lookup.c
+++ b/src/icon-lookup.c
@@ -64,7 +64,7 @@ int load_icon_theme_from_dir(const char *icon_dir, const char *subdir_theme) {
 
         // load theme directories
         icon_themes[index].dirs_count = ini->section_count - 1;
-        icon_themes[index].dirs = g_malloc0(icon_themes[index].dirs_count * sizeof(struct icon_theme_dir));
+        icon_themes[index].dirs = g_malloc0_n(icon_themes[index].dirs_count, sizeof(struct icon_theme_dir));
 
         for (int i = 0; i < icon_themes[index].dirs_count; i++) {
                 struct section section = ini->sections[i+1];
@@ -126,13 +126,13 @@ int load_icon_theme_from_dir(const char *icon_dir, const char *subdir_theme) {
                 if (icon_themes[index].inherits_count <= 0) {
                         // set fallback theme to hicolor if there are no inherits
                         g_strfreev(inherits);
-                        inherits = g_malloc(2 * sizeof(char*));
+                        inherits = g_malloc0_n(2, sizeof(char*));
                         inherits[0] = g_strdup("hicolor");
                         inherits[1] = NULL;
                         icon_themes[index].inherits_count = 1;
                 }
 
-                icon_themes[index].inherits_index = g_malloc0(icon_themes[index].inherits_count * sizeof(int));
+                icon_themes[index].inherits_index = g_malloc0_n(icon_themes[index].inherits_count, sizeof(int));
 
                 for (int i = 0; inherits[i] != NULL; i++) {
                         LOG_D("inherits: %s\n", inherits[i]);

--- a/src/ini.c
+++ b/src/ini.c
@@ -84,7 +84,7 @@ struct ini *load_ini_file(FILE *fp)
         if (!fp)
                 return NULL;
 
-        struct ini *ini = calloc(1, sizeof(struct ini));
+        struct ini *ini = g_malloc0(sizeof(struct ini));
         char *line = NULL;
         size_t line_len = 0;
 

--- a/src/option_parser.c
+++ b/src/option_parser.c
@@ -104,7 +104,7 @@ bool string_parse_int_list(char **s, int **ret, bool allow_empty) {
                 bool success = safe_string_to_int(&tmp[i], s[i]);
                 if (!success) {
                         LOG_W("Invalid int value: '%s'", s[i]);
-                        free(tmp);
+                        g_free(tmp);
                         return false;
                 }
 

--- a/src/rules.c
+++ b/src/rules.c
@@ -171,7 +171,7 @@ static inline bool rule_field_matches_string(const char *value, const char *patt
                         char *err_buf = g_malloc(err_size);
                         regerror(err, &regex, err_buf, err_size);
                         LOG_W("%s: \"%s\"", err_buf, pattern);
-                        free(err_buf);
+                        g_free(err_buf);
                         return false;
                 }
 

--- a/src/settings.c
+++ b/src/settings.c
@@ -96,9 +96,9 @@ static void config_files_add_drop_ins(GPtrArray *config_files, const char *path)
                                 drop_ins[n]->d_name, NULL);
                 LOG_D("Found drop-in: %s\n", drop_in);
                 g_ptr_array_insert(config_files, insert_index, drop_in);
-                free(drop_ins[n]);
+                g_free(drop_ins[n]);
         }
-        free(drop_ins);
+        g_free(drop_ins);
 }
 
 /** @brief Find all config files.
@@ -140,14 +140,14 @@ static GPtrArray* get_conf_files(const char *path) {
 FILE *fopen_conf(char * const path)
 {
         FILE *f = NULL;
-        char *real_path = string_to_path(strdup(path));
+        char *real_path = string_to_path(g_strdup(path));
 
         if (is_readable_file(real_path) && (f = fopen(real_path, "r")))
                 LOG_I(MSG_FOPEN_SUCCESS(path, f));
         else
                 LOG_W(MSG_FOPEN_FAILURE(path));
 
-        free(real_path);
+        g_free(real_path);
         return f;
 }
 
@@ -256,7 +256,7 @@ static void process_conf_file(const gpointer conf_fname, gpointer n_success) {
         check_and_correct_settings(&settings);
 
         finish_ini(ini);
-        free(ini);
+        g_free(ini);
 
         ++(*(int *) n_success);
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -435,14 +435,14 @@ bool is_readable_file(const char * const path)
 FILE *fopen_verbose(const char * const path)
 {
         FILE *f = NULL;
-        char *real_path = string_to_path(strdup(path));
+        char *real_path = string_to_path(g_strdup(path));
 
         if (is_readable_file(real_path) && (f = fopen(real_path, "r")))
                 LOG_I(MSG_FOPEN_SUCCESS(path, f));
         else
                 LOG_W(MSG_FOPEN_FAILURE(path));
 
-        free(real_path);
+        g_free(real_path);
         return f;
 }
 


### PR DESCRIPTION
The purpose is to avoid any failure in realloc, leading to null pointer dereferences/memory leaks. Failure in g_realloc will also terminate Dunst.
@bebehei, waiting for any further suggestions/reviews. :)