### PR TITLE
Fix manual page typo

### DIFF
--- a/docs/dunst.1.pod
+++ b/docs/dunst.1.pod
@@ -100,7 +100,7 @@ missed notifications after returning to the computer.
 =head1 FILES
 
 These are the base directories dunst searches for configuration files in
-I<descending order of imortance>:
+I<descending order of importance>:
 
 =over 8
 


### PR DESCRIPTION
A simple spelling fix in man page dunst(1).