### PR TITLE
Add multiple pause levels

### DIFF
--- a/dunstctl
+++ b/dunstctl
@@ -29,8 +29,9 @@ show_help() {
 	                                    notification with given ID.
 	  history-rm [ID]                   Remove the notification from
 	                                    history with given ID.
-	  is-paused                         Check if dunst is running or paused
-	  set-paused [true|false|toggle]    Set the pause status
+	  is-paused                         Check if pause level is > 0
+	  get-paused-level    Get the current pause level
+	  set-paused-level [level]    Set the pause level
 	  rule name [enable|disable|toggle] Enable or disable a rule by its name
 	  debug                             Print debugging information
 	  help                              Show this help
@@ -122,6 +123,27 @@ case "${1:-}" in
 		fi
 		;;
         "rule")
+		[ "${2:-}" ] \
+			|| die "No rule name parameter specified. Please give the rule name"
+		state=nope
+		[ "${3}" = "disable" ] && state=0
+		[ "${3}" = "enable" ]  && state=1
+		[ "${3}" = "toggle" ]  && state=2
+		[ "${state}" = "nope" ] \
+			&& die "No valid rule state parameter specified. Please give either 'enable', 'disable' or 'toggle'"
+		method_call "${DBUS_IFAC_DUNST}.RuleEnable" "string:${2:-1}" "int32:${state}" >/dev/null
+		;;
+	"get-paused-level")
+		property_get pauseLevel | ( read -r _ _ paused; printf "%s\n" "${paused}"; )
+		;;
+	"set-paused-level")
+		[ "${2:-}" ] \
+			|| die "No status parameter specified. Please give a number as paused parameter."
+		[ "$2" ] && [ -z "${2//[0-9]}" ] \
+			|| die "Please give a number as paused level parameter."
+		property_set pauseLevel variant:uint32:"$2"
+		;;
+	"rule")
 		[ "${2:-}" ] \
 			|| die "No rule name parameter specified. Please give the rule name"
 		state=nope

--- a/src/dunst.c
+++ b/src/dunst.c
@@ -37,11 +37,21 @@ void dunst_status(const enum dunst_status_field field,
         case S_IDLE:
                 status.idle = value;
                 break;
-        case S_RUNNING:
-                status.running = value;
+        default:
+                LOG_E("Invalid %s enum value in %s:%d for bool type", "dunst_status", __FILE__, __LINE__);
+                break;
+        }
+}
+
+void dunst_status_int(const enum dunst_status_field field,
+                  int value)
+{
+        switch (field) {
+        case S_PAUSE_LEVEL:
+                status.pause_level = value;
                 break;
         default:
-                LOG_E("Invalid %s enum value in %s:%d", "dunst_status", __FILE__, __LINE__);
+                LOG_E("Invalid %s enum value in %s:%d fot int type", "dunst_status", __FILE__, __LINE__);
                 break;
         }
 }
@@ -123,7 +133,7 @@ static gboolean run(void *data)
 
 gboolean pause_signal(gpointer data)
 {
-        dunst_status(S_RUNNING, false);
+        dunst_status_int(S_PAUSE_LEVEL, 100);
         wake_up();
 
         return G_SOURCE_CONTINUE;
@@ -131,7 +141,7 @@ gboolean pause_signal(gpointer data)
 
 gboolean unpause_signal(gpointer data)
 {
-        dunst_status(S_RUNNING, true);
+        dunst_status_int(S_PAUSE_LEVEL, 0);
         wake_up();
 
         return G_SOURCE_CONTINUE;
@@ -156,7 +166,7 @@ static void teardown(void)
 int dunst_main(int argc, char *argv[])
 {
 
-        dunst_status(S_RUNNING, true);
+        dunst_status_int(S_PAUSE_LEVEL, 0);
         dunst_status(S_IDLE, false);
 
         queues_init();

--- a/src/dunst.h
+++ b/src/dunst.h
@@ -13,14 +13,14 @@
 //!< A structure to describe dunst's global window status
 struct dunst_status {
         bool fullscreen; //!< a fullscreen window is currently focused
-        bool running;    //!< set true if dunst is currently running
+        int pause_level;    //!< set true if dunst is currently running
         bool idle;       //!< set true if the user is idle
 };
 
 enum dunst_status_field {
         S_FULLSCREEN,
         S_IDLE,
-        S_RUNNING,
+        S_PAUSE_LEVEL,
 };
 
 /**
@@ -30,6 +30,8 @@ enum dunst_status_field {
  */
 void dunst_status(const enum dunst_status_field field,
                   bool value);
+void dunst_status_int(const enum dunst_status_field field,
+                  int value);
 
 struct dunst_status dunst_status_get(void);
 

--- a/src/notification.c
+++ b/src/notification.c
@@ -488,6 +488,8 @@ void notification_init(struct notification *n)
         if (n->progress < 0)
                 n->progress = -1;
 
+        n->override_pause_level = 0;
+
         /* Process rules */
         rule_apply_all(n);
 

--- a/src/notification.h
+++ b/src/notification.h
@@ -56,6 +56,7 @@ struct notification {
         char *category;
         char *desktop_entry;     /**< The desktop entry hint sent via every GApplication */
         enum urgency urgency;
+        int override_pause_level;
 
         cairo_surface_t *icon;         /**< The raw cached icon data used to draw */
         char *icon_id;           /**< Plain icon information, which acts as the icon's id.

--- a/src/queues.c
+++ b/src/queues.c
@@ -120,7 +120,10 @@ static void queues_swap_notifications(GQueue *queueA,
  */
 static bool queues_notification_is_ready(const struct notification *n, struct dunst_status status, bool shown)
 {
-        ASSERT_OR_RET(status.running, false);
+        if (status.pause_level > n->override_pause_level) {
+                return false;
+        }
+
         if (status.fullscreen && shown)
                 return n && n->fullscreen != FS_PUSHBACK;
         else if (status.fullscreen && !shown)

--- a/src/rules.c
+++ b/src/rules.c
@@ -99,6 +99,9 @@ void rule_apply(struct rule *r, struct notification *n)
                 g_free(n->stack_tag);
                 n->stack_tag = g_strdup(r->set_stack_tag);
         }
+        if (r->override_pause_level != -1) {
+                n->override_pause_level = r->override_pause_level;
+        }
 }
 
 /*

--- a/src/rules.h
+++ b/src/rules.h
@@ -45,6 +45,7 @@ struct rule {
         int icon_position;
         int min_icon_size;
         int max_icon_size;
+        int override_pause_level;
         char *new_icon;
         char *fg;
         char *bg;

--- a/src/settings_data.h
+++ b/src/settings_data.h
@@ -165,6 +165,7 @@ static const struct rule empty_rule = {
         .progress_bar_alignment   = -1,
         .min_icon_size   = -1,
         .max_icon_size   = -1,
+        .override_pause_level = -1
 };
 
 
@@ -759,6 +760,17 @@ static const struct setting allowed_settings[] = {
                 .parser = NULL,
                 .parser_data = NULL,
                 .rule_offset = offsetof(struct rule, max_icon_size),
+        },
+        {
+                .name = "override_pause_level",
+                .section = "*",
+                .description = "TODO",
+                .type = TYPE_INT,
+                .default_value = "-1",
+                .value = NULL,
+                .parser = NULL,
+                .parser_data = NULL,
+                .rule_offset = offsetof(struct rule, override_pause_level),
         },
         // end of modifying rules
 


### PR DESCRIPTION
This fixes #865, specifically by introducing multiple pause levels (as outlined in https://github.com/dunst-project/dunst/issues/865#issuecomment-1378273947).

Instead of pause being a toggle, it is now a number and notification rules can set `override_pause_level` which determines minimum pause level at which the notification is displayed.

Old `is-paused` and `set-paused` commands are deprecated, but they still function to maintain backwards compatibility (`set-paused true` sets paused level to 100, which is an arbitrary number, we could pick any other if desired).

PR is not finished yet, I still need to update tests and documentation, but I only edited the core for now to get feedback on my approach. Does this look like something we would want in dunst?