### PR TITLE
Changes "the" to "them" in man pages 5 under the "follow" heading

### DIFF
--- a/docs/dunst.5.pod
+++ b/docs/dunst.5.pod
@@ -37,7 +37,7 @@ Defines where the notifications should be placed in a multi-monitor setup. All
 values except I<none> override the B<monitor> setting.
 
 On Wayland there is no difference between mouse and keyboard focus. When either
-of the is used, the compositor will choose an output. This will generally be
+of them is used, the compositor will choose an output. This will generally be
 the output last interacted with.
 
 =over 4


### PR DESCRIPTION
This is a quick fix for a grammatical error in the docs. In man pages 5 under the "Global section: follow" heading, change the sentence "When either of the is used..." to "When either of them is used..."