### PR TITLE
Fix commandline handling

### DIFF
--- a/contrib/_dunst.zshcomp
+++ b/contrib/_dunst.zshcomp
@@ -16,6 +16,8 @@ case $state in
       {-v,--version,-version}"[Print version]" \
       '(-verbosity)-verbosity[Minimum level for message]' \
       {-conf,--config}"[Path to configuration file]:file:_files" \
+      {-print,--print}"[Print notifications to stdout]" \
+      {-startup_notification,--startup_notification}"[Display a notification on startup]" \
       {-h,-help,--help}"[Print help]"
       ;;
 

--- a/contrib/dunst.bashcomp
+++ b/contrib/dunst.bashcomp
@@ -2,7 +2,7 @@ _dunst() {
     local opts cur prev split=false
     _get_comp_words_by_ref cur prev
     COMPREPLY=()
-    opts='-v -version --version -verbosity -conf -config -h --help' 
+    opts='-v -version --version -verbosity -conf -config -print --print -startup_notification --startup_notification -h -help --help' 
 
     case "$prev" in
         -verbosity) COMPREPLY=("crit" "warn" "mesg" "info" "debug") 

--- a/docs/dunst.1.pod
+++ b/docs/dunst.1.pod
@@ -4,7 +4,7 @@ dunst - A customizable and lightweight notification-daemon
 
 =head1 SYNOPSIS
 
-dunst [-conf file] [-verbosity v] [-print] [--startup-notification]
+dunst [-conf file] [-verbosity v] [-print] [--startup_notification]
 
 =head1 DESCRIPTION
 
@@ -23,7 +23,7 @@ systemd service.
 
 =over 4
 
-=item B<-h/--help>
+=item B<-h/-help/--help>
 
 List all command line flags
 
@@ -36,7 +36,7 @@ defaults.
 (Hint: `dunst -conf - </dev/null` can be used to enforce the defaults, i.e. for
 testing)
 
-=item B<-v/--version>
+=item B<-v/-version/--version>
 
 Print version information.
 
@@ -46,12 +46,12 @@ Do not display log messages, which have lower precedence than specified
 verbosity. This won't affect printing notifications on the terminal. Use
 the '-print' option for this.
 
-=item B<-print>
+=item B<-print/--print>
 
 Print notifications to stdout. This might be useful for logging, setting up
 rules or using the output in other scripts.
 
-=item B<--startup_notification> (values: [true/false], default: false)
+=item B<-startup_notification/--startup_notification>
 
 Display a notification on startup.
 

--- a/src/dunst.c
+++ b/src/dunst.c
@@ -179,16 +179,17 @@ int dunst_main(int argc, char *argv[])
                                "Path to configuration file");
         load_settings(cmdline_config_path);
 
-        if (cmdline_get_bool("-h/-help/--help", false, "Print help")) {
-                usage(EXIT_SUCCESS);
-        }
-
         if (cmdline_get_bool("-print/--print", false, "Print notifications to stdout")) {
                 settings.print_notifications = true;
         }
 
         settings.startup_notification = cmdline_get_bool("--startup_notification",
                         0, "Display a notification on startup.");
+
+        /* Help should always be the last to set up as calls to cmdline_get_* (as a side effect) add entries to the usage list. */
+        if (cmdline_get_bool("-h/-help/--help", false, "Print help")) {
+                usage(EXIT_SUCCESS);
+        }
 
         int dbus_owner_id = dbus_init();
 

--- a/src/dunst.c
+++ b/src/dunst.c
@@ -183,8 +183,8 @@ int dunst_main(int argc, char *argv[])
                 settings.print_notifications = true;
         }
 
-        settings.startup_notification = cmdline_get_bool("--startup_notification",
-                        0, "Display a notification on startup.");
+        settings.startup_notification = cmdline_get_bool("-startup_notification/--startup_notification",
+                        false, "Display a notification on startup.");
 
         /* Help should always be the last to set up as calls to cmdline_get_* (as a side effect) add entries to the usage list. */
         if (cmdline_get_bool("-h/-help/--help", false, "Print help")) {

--- a/src/dunst.c
+++ b/src/dunst.c
@@ -165,8 +165,7 @@ int dunst_main(int argc, char *argv[])
 
         dunst_log_init(false);
 
-        if (cmdline_get_bool("-v/-version", false, "Print version")
-            || cmdline_get_bool("--version", false, "Print version")) {
+        if (cmdline_get_bool("-v/-version/--version", false, "Print version")) {
                 print_version();
         }
 
@@ -180,13 +179,11 @@ int dunst_main(int argc, char *argv[])
                                "Path to configuration file");
         load_settings(cmdline_config_path);
 
-        if (cmdline_get_bool("-h/-help", false, "Print help")
-            || cmdline_get_bool("--help", false, "Print help")) {
+        if (cmdline_get_bool("-h/-help/--help", false, "Print help")) {
                 usage(EXIT_SUCCESS);
         }
 
-        if (cmdline_get_bool("-print", false, "Print notifications to stdout")
-            || cmdline_get_bool("--print", false, "Print notifications to stdout")) {
+        if (cmdline_get_bool("-print/--print", false, "Print notifications to stdout")) {
                 settings.print_notifications = true;
         }
 

--- a/src/option_parser.c
+++ b/src/option_parser.c
@@ -482,33 +482,18 @@ int cmdline_find_option(const char *key)
 {
         ASSERT_OR_RET(key, -1);
 
-        char *key1 = g_strdup(key);
-        char *key2 = strchr(key1, '/');
+        gchar **keys = g_strsplit(key, "/", -1);
 
-        if (key2) {
-                *key2 = '\0';
-                key2++;
-        }
-
-        /* look for first key */
-        for (int i = 0; i < cmdline_argc; i++) {
-                if (STR_EQ(key1, cmdline_argv[i])) {
-                        g_free(key1);
-                        return i;
-                }
-        }
-
-        /* look for second key if one was specified */
-        if (key2) {
-                for (int i = 0; i < cmdline_argc; i++) {
-                        if (STR_EQ(key2, cmdline_argv[i])) {
-                                g_free(key1);
-                                return i;
+        for (int i = 0; keys[i] != NULL; i++) {
+                for (int j = 0; j < cmdline_argc; j++) {
+                        if (STR_EQ(keys[i], cmdline_argv[j])) {
+                                g_strfreev(keys);
+                                return j;
                         }
                 }
         }
 
-        g_free(key1);
+        g_strfreev(keys);
         return -1;
 }
 

--- a/src/option_parser.c
+++ b/src/option_parser.c
@@ -608,14 +608,14 @@ void cmdline_usage_append(const char *key, const char *type, const char *descrip
 
         if (!usage_str) {
                 usage_str =
-                    g_strdup_printf("%-40s - %s\n", key_type, description);
+                    g_strdup_printf("%-50s - %s\n", key_type, description);
                 g_free(key_type);
                 return;
         }
 
         char *tmp;
         tmp =
-            g_strdup_printf("%s%-40s - %s\n", usage_str, key_type, description);
+            g_strdup_printf("%s%-50s - %s\n", usage_str, key_type, description);
         g_free(key_type);
 
         g_free(usage_str);


### PR DESCRIPTION
The output of `dunst -h` differs from the one of `dunst --help` due to how the usage string is constructed. Furthermore, the options `-print` and `--startup_notification` are not listed at all (due to incorrect ordering of options).

This PR refactors `cmdline_find_option` to handle more than two alternatives (which fixes the first issue, when calls to `cmdline_get_*` are merged) and reorders command line parsing in a way, that all currently available options are listed.

NB: I've added `-startup_notification` as alternative to `--startup_notification` as it was the only option only available with to hyphens and thus breaking consistency.