### PR TITLE
Add fish completions

### DIFF
--- a/contrib/dunst.fishcomp
+++ b/contrib/dunst.fishcomp
@@ -1,0 +1,8 @@
+complete -c dunst -s v -l version -o version -d 'Print version'
+complete -c dunst -o verbosity -x -a 'crit warn mesg info debug' -d 'Minimum level for message'
+complete -c dunst -o conf -o config -d 'Path to configuration file'
+complete -c dunst -o print -l print -d 'Print notifications to stdout'
+complete -c dunst -o startup_notification -l startup_notification -d 'Display a notification on startup'
+complete -c dunst -s h -l help -o help -d 'Print help'
+
+# ex: filetype=fish

--- a/contrib/dunstctl.fishcomp
+++ b/contrib/dunstctl.fishcomp
@@ -1,0 +1,35 @@
+if command -q jq
+    function __fish_dunstctl_history
+        dunstctl history | jq -r '.data[][] | "\(.id.data)\t\(.appname.data)"'
+    end
+else
+    function __fish_dunstctl_history
+        dunstctl history | awk '/"id" :/ {getline; getline; print $3}'
+    end
+end
+
+# commands
+complete -c dunstctl -f -n __fish_use_subcommand -a action -d 'Perform the default action, or open the context menu of the notification at the given position'
+complete -c dunstctl -f -n __fish_use_subcommand -a close -d 'Close the last notification'
+complete -c dunstctl -f -n __fish_use_subcommand -a close-all -d 'Close the all notifications'
+complete -c dunstctl -f -n __fish_use_subcommand -a context -d 'Open context menu'
+complete -c dunstctl -f -n __fish_use_subcommand -a count -d 'Show the number of notifications'
+complete -c dunstctl -f -n __fish_use_subcommand -a history -d 'Display notification history (in JSON)'
+complete -c dunstctl -f -n __fish_use_subcommand -a history-clear -d 'Delete all notifications from history'
+complete -c dunstctl -f -n __fish_use_subcommand -a history-pop -d 'Pop the latest notification from history or optionally the notification with given ID'
+complete -c dunstctl -f -n __fish_use_subcommand -a history-rm -d 'Remove the notification from history with given ID'
+complete -c dunstctl -f -n __fish_use_subcommand -a is-paused -d 'Check if dunst is running or paused'
+complete -c dunstctl -f -n __fish_use_subcommand -a set-paused -d 'Set the pause status'
+complete -c dunstctl -f -n __fish_use_subcommand -a rule -d 'Enable or disable a rule by its name'
+complete -c dunstctl -f -n __fish_use_subcommand -a debug -d 'Print debugging information'
+complete -c dunstctl -f -n __fish_use_subcommand -a help -d 'Show this help'
+
+# command specific arguments
+complete -c dunstctl -x -n '__fish_seen_subcommand_from action close close-all context history history-clear is-paused debug help'
+complete -c dunstctl -x -n '__fish_seen_subcommand_from count' -a 'displayed history waiting'
+complete -c dunstctl -x -n '__fish_seen_subcommand_from history-pop history-rm' -a '(__fish_dunstctl_history)'
+complete -c dunstctl -x -n '__fish_seen_subcommand_from set-paused' -a 'true false toggle'
+
+# TODO: add completion for rule when there is a proper way to get configured rules
+
+# ex: filetype=fish

--- a/contrib/dunstify.fishcomp
+++ b/contrib/dunstify.fishcomp
@@ -1,0 +1,26 @@
+if command -q jq
+    function __fish_dunstify_history
+        dunstctl history | jq -r '.data[][] | "\(.id.data)\t\(.appname.data)"'
+    end
+else
+    function __fish_dunstify_history
+        dunstctl history | awk '/"id" :/ {getline; getline; print $3}'
+    end
+end
+
+complete -c dunstify -s '?' -l help -d 'Show help options'
+complete -c dunstify -s a -l appname -r -d 'Name of your application'
+complete -c dunstify -s u -l urgency -x -a 'low normal critical' -d 'The urgency of this notification'
+complete -c dunstify -s h -l hints -x -d 'User specified hints'
+complete -c dunstify -s A -l action -x -d 'Actions the user can invoke'
+complete -c dunstify -s t -l timeout -x -d 'The time in milliseconds until the notification expires'
+complete -c dunstify -s i -l icon -x -d 'An Icon that should be displayed with the notification'
+complete -c dunstify -s I -l raw_icon -r -d 'Path to the icon to be sent as raw image data'
+complete -c dunstify -s c -l capabilities -d 'Print the server capabilities and exit'
+complete -c dunstify -s s -l serverinfo -d 'Print server information and exit'
+complete -c dunstify -s p -l printid -d 'Print id, which can be used to update/replace this notification'
+complete -c dunstify -s r -l replace -x -a '(__fish_dunstify_history)' -d 'Set id of this notification.'
+complete -c dunstify -s C -l close -x -a '(__fish_dunstify_history)' -d 'Close the notification with the specified ID'
+complete -c dunstify -s b -l block -d 'Block until notification is closed and print close reason'
+
+# ex: filetype=fish


### PR DESCRIPTION
Add completion files for all commands for [fish-shell](https://github.com/fish-shell/fish-shell).

NB: I left out completion for the `rule` subcommand of `dunstctl` as there currently is no way of getting defined rules in a generic way (e.g. both the completions for bash and zsh try to parse the default config, which might not be the configuration being used and also ignores drop-in files altogether).