### PR TITLE
dunstctl fixes for "Add multiple pause levels" (bashisms, whitespace, …)

### DIFF
--- a/dunstctl
+++ b/dunstctl
@@ -123,7 +123,7 @@ case "${1:-}" in
 			property_set paused variant:boolean:"$2"
 		fi
 		;;
-        "rule")
+	"rule")
 		[ "${2:-}" ] \
 			|| die "No rule name parameter specified. Please give the rule name"
 		state=nope
@@ -143,17 +143,6 @@ case "${1:-}" in
 		[ "$2" ] && [ -z "${2//[0-9]}" ] \
 			|| die "Please give a number as paused level parameter."
 		property_set pauseLevel variant:uint32:"$2"
-		;;
-	"rule")
-		[ "${2:-}" ] \
-			|| die "No rule name parameter specified. Please give the rule name"
-		state=nope
-		[ "${3}" = "disable" ] && state=0
-		[ "${3}" = "enable" ]  && state=1
-		[ "${3}" = "toggle" ]  && state=2
-		[ "${state}" = "nope" ] \
-			&& die "No valid rule state parameter specified. Please give either 'enable', 'disable' or 'toggle'"
-		method_call "${DBUS_IFAC_DUNST}.RuleEnable" "string:${2:-1}" "int32:${state}" >/dev/null
 		;;
 	"help"|"--help"|"-h")
 		show_help

--- a/dunstctl
+++ b/dunstctl
@@ -140,8 +140,12 @@ case "${1:-}" in
 	"set-pause-level")
 		[ "${2:-}" ] \
 			|| die "No status parameter specified. Please give a number as paused parameter."
-		[ "$2" ] && [ -z "${2//[0-9]}" ] \
-			|| die "Please give a number as paused level parameter."
+		case "$2" in
+			(*[!0123456789]*)
+				die "Please give a number as paused level parameter." ;;
+			('')
+				die "Please give a number as paused level parameter." ;;
+		esac
 		property_set pauseLevel variant:uint32:"$2"
 		;;
 	"help"|"--help"|"-h")

--- a/dunstctl
+++ b/dunstctl
@@ -23,14 +23,14 @@ show_help() {
 	  context                           Open context menu
 	  count [displayed|history|waiting] Show the number of notifications
 	  history                           Display notification history (in JSON)
-	  history-clear                     Delete all notifications from history                   
+	  history-clear                     Delete all notifications from history
 	  history-pop [ID]                  Pop the latest notification from
 	                                    history or optionally the
 	                                    notification with given ID.
 	  history-rm [ID]                   Remove the notification from
 	                                    history with given ID.
 	  is-paused                         Check if pause level is > 0
-	  set-paused [true|false|toggle]   Set the pause status	  
+	  set-paused [true|false|toggle]    Set the pause status
 	  get-pause-level                   Get the current pause level
 	  set-pause-level [level]           Set the pause level
 	  rule name [enable|disable|toggle] Enable or disable a rule by its name


### PR DESCRIPTION
#### [dunstctl: Drop duplicated "rule") case](../commit/dd313773b44cd6ca2f15bf24e3fd7345ab980ccb)

Fixes: 6d250b583485 ("add multiple pause levels")

#### [dunstctl: Fix whitespace in help](../commit/5bfb8c4f58ddda7928490411cd5f0e6b814fef0d)

Fixes: dbe836731127 ("Add history-clear command (#1131)")
Fixes: 82fb1d996ef0 ("remove d from pause level commands")

#### [dunstctl: Fix bashism in set-pause-level](../commit/adf4bc527285b276d745456819963f02217e98f2)

Fixes: 6d250b583485 ("add multiple pause levels")
