### PR TITLE
Fix compiler warnings

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -42,7 +42,7 @@ endif
 
 # flags
 DEFAULT_CPPFLAGS = -Wno-gnu-zero-variadic-macro-arguments -D_DEFAULT_SOURCE -DVERSION=\"${VERSION}\" -DSYSCONFDIR=\"${SYSCONFDIR}\"
-DEFAULT_CFLAGS   = -g -std=gnu99 -pedantic -Wall -Wno-overlength-strings -Os ${ENABLE_WAYLAND} ${EXTRA_CFLAGS}
+DEFAULT_CFLAGS   = -g -std=gnu11 -pedantic -Wall -Wno-overlength-strings -Os ${ENABLE_WAYLAND} ${EXTRA_CFLAGS}
 DEFAULT_LDFLAGS  = -lm -lrt
 
 CPPFLAGS_DEBUG := -DDEBUG_BUILD

--- a/src/icon-lookup.c
+++ b/src/icon-lookup.c
@@ -157,7 +157,7 @@ int load_icon_theme_from_dir(const char *icon_dir, const char *subdir_theme) {
 // a list of directories where icon themes might be located
 GPtrArray *theme_path = NULL;
 
-void get_theme_path() {
+void get_theme_path(void) {
         theme_path = g_ptr_array_new_full(5, g_free);
         const char *home = g_get_home_dir();
         g_ptr_array_add(theme_path, g_build_filename(home, ".icons", NULL));
@@ -208,7 +208,7 @@ void finish_icon_theme(struct icon_theme *theme) {
         g_free(theme->dirs);
 }
 
-void free_all_themes() {
+void free_all_themes(void) {
         g_free(default_themes_index);
         default_themes_index = NULL;
         default_themes_count = 0;

--- a/src/icon-lookup.h
+++ b/src/icon-lookup.h
@@ -76,7 +76,7 @@ char *find_icon_path(const char *name, int size);
 /**
  * Free all icon themes.
  */
-void free_all_themes();
+void free_all_themes(void);
 
 #endif
 /* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/option_parser.c
+++ b/src/option_parser.c
@@ -403,7 +403,7 @@ bool set_rule(struct setting setting, char* value, char* section) {
         return set_rule_value(r, setting, value);
 }
 
-void set_defaults() {
+void set_defaults(void) {
         for (int i = 0; i < G_N_ELEMENTS(allowed_settings); i++) {
                 // FIXME Rule settings can only have a default if they have an
                 // working entry in the settings struct as well. Make an

--- a/src/option_parser.h
+++ b/src/option_parser.h
@@ -14,7 +14,7 @@ int string_parse_enum(const void* data, const char *s, void * ret);
 int string_parse_sepcolor(const void *data, const char *s, void *ret);
 int string_parse_bool(const void *data, const char *s, void *ret);
 
-void set_defaults();
+void set_defaults(void);
 void save_settings(struct ini *ini);
 
 void cmdline_load(int argc, char *argv[]);

--- a/src/output.c
+++ b/src/output.c
@@ -57,7 +57,7 @@ const struct output output_wl = {
 };
 #endif
 
-const struct output* get_x11_output() {
+const struct output* get_x11_output(void) {
         const struct output* output = &output_x11;
         if (output->init()) {
                 return output;
@@ -67,7 +67,7 @@ const struct output* get_x11_output() {
 }
 
 #ifdef ENABLE_WAYLAND
-const struct output* get_wl_output() {
+const struct output* get_wl_output(void) {
         const struct output* output = &output_wl;
         if (output->init()) {
                 return output;

--- a/src/rules.c
+++ b/src/rules.c
@@ -178,7 +178,7 @@ static inline bool rule_field_matches_string(const char *value, const char *patt
                         return false;
                 }
 
-                for (int i = 0; ; i++) {
+                while (true) {
                         if (regexec(&regex, value, 0, NULL, 0))
                                 break;
                         regfree(&regex);

--- a/src/settings.c
+++ b/src/settings.c
@@ -60,7 +60,7 @@ static int is_drop_in(const struct dirent *dent) {
  * The result @e must @e not be freed! The array is cached in a static variable,
  * so it is OK to call this again instead of caching its return value.
  */
-static GPtrArray *get_xdg_conf_basedirs() {
+static GPtrArray *get_xdg_conf_basedirs(void) {
         GPtrArray *arr = g_ptr_array_new_full(4, g_free);
         g_ptr_array_add(arr, g_build_filename(g_get_user_config_dir(), "dunst", NULL));
 
@@ -151,7 +151,7 @@ FILE *fopen_conf(char * const path)
         return f;
 }
 
-void settings_init() {
+void settings_init(void) {
         static bool init_done = false;
         if (!init_done) {
                 LOG_D("Initializing settings");

--- a/src/wayland/foreign_toplevel.c
+++ b/src/wayland/foreign_toplevel.c
@@ -12,10 +12,6 @@
 
 struct wl_list toplevel_list;
 
-static void noop() {
-        // This space intentionally left blank
-}
-
 static void copy_state(struct toplevel_state *current,
                 struct toplevel_state *pending) {
         if (!(pending->state & TOPLEVEL_STATE_INVALID)) {
@@ -98,9 +94,19 @@ static void toplevel_handle_closed(void *data,
         zwlr_foreign_toplevel_handle_v1_destroy(zwlr_toplevel);
 }
 
+static void toplevel_handle_title(void *data,
+                struct zwlr_foreign_toplevel_handle_v1 *zwlr_foreign_toplevel_handle_v1,
+                const char *title) {
+}
+
+static void toplevel_handle_app_id(void *data,
+                struct zwlr_foreign_toplevel_handle_v1 *zwlr_foreign_toplevel_handle_v1,
+                const char *title) {
+}
+
 static const struct zwlr_foreign_toplevel_handle_v1_listener toplevel_impl = {
-        .title = noop,
-        .app_id = noop,
+        .title = toplevel_handle_title,
+        .app_id = toplevel_handle_app_id,
         .output_enter = toplevel_handle_output_enter,
         .output_leave = toplevel_handle_output_leave,
         .state = toplevel_handle_state,

--- a/test/draw.c
+++ b/test/draw.c
@@ -5,7 +5,7 @@
 
 cairo_t *c;
 
-double get_dummy_scale() { return 1; }
+double get_dummy_scale(void) { return 1; }
 
 const struct screen_info* noop_screen(void) {
         static struct screen_info i;

--- a/test/icon-lookup.c
+++ b/test/icon-lookup.c
@@ -7,7 +7,7 @@
 extern const char *base;
 #define ICONPREFIX "data", "icons"
 
-int setup_test_theme(){
+int setup_test_theme(void) {
         char *theme_path = g_build_filename(base, ICONPREFIX,  NULL);
         int theme_index = load_icon_theme_from_dir(theme_path, "theme");
         add_default_theme(theme_index);

--- a/test/option_parser.c
+++ b/test/option_parser.c
@@ -139,7 +139,7 @@ TEST test_string_to_int(void)
         struct setting s;
         s.type = TYPE_INT;
 
-        char buf[50];
+        static char buf[50];
         for (int i = 0; i < G_N_ELEMENTS(inputs); i++) {
                 sprintf(buf, "Failed in round %i", i);
                 ASSERTm(buf, set_from_string(&val, s, inputs[i]));
@@ -166,7 +166,7 @@ TEST test_string_to_int_invalid(void)
         s.type = TYPE_INT;
         s.name = "test_int";
 
-        char buf[50];
+        static char buf[50];
         for (int i = 0; i < G_N_ELEMENTS(inputs); i++) {
                 sprintf(buf, "Failed in round %i", i);
                 ASSERT_FALSEm(buf, set_from_string(&val, s, inputs[i]));
@@ -199,7 +199,7 @@ TEST test_string_to_double(void)
         struct setting s;
         s.type = TYPE_DOUBLE;
 
-        char buf[50];
+        static char buf[50];
         for (int i = 0; i < G_N_ELEMENTS(inputs); i++) {
                 sprintf(buf, "Failed in round %i", i);
                 ASSERTm(buf, set_from_string(&val, s, inputs[i]));
@@ -225,7 +225,7 @@ TEST test_string_to_double_invalid(void)
         s.type = TYPE_DOUBLE;
         s.name = "test_double";
 
-        char buf[50];
+        static char buf[50];
         for (int i = 0; i < G_N_ELEMENTS(inputs); i++) {
                 sprintf(buf, "Failed in round %i", i);
                 ASSERT_FALSEm(buf, set_from_string(&val, s, inputs[i]));
@@ -263,7 +263,7 @@ TEST test_string_to_boolean(void)
 
         ARRAY_SAME_LENGTH(inputs, results);
 
-        char buf[50];
+        static char buf[50];
         for (int i = 0; i < G_N_ELEMENTS(inputs); i++) {
                 sprintf(buf, "Failed in round %i", i);
                 ASSERTm(buf, set_from_string(&val, s, inputs[i]));
@@ -291,7 +291,7 @@ TEST test_string_to_boolean_invalid(void)
                 "else",
         };
 
-        char buf[50];
+        static char buf[50];
 
         for (int i = 0; i < G_N_ELEMENTS(invalid_inputs); i++) {
                 sprintf(buf, "Failed in round %i", i);
@@ -312,7 +312,7 @@ TEST test_string_to_enum(void)
         s.parser = string_parse_enum;
         s.parser_data = ellipsize_enum_data;
 
-        char buf[50];
+        static char buf[50];
 
         // do not go until last element, since it's ENUM_END (all 0)
         for (int i = 0; i < G_N_ELEMENTS(ellipsize_enum_data)-1; i++) {
@@ -342,7 +342,7 @@ TEST test_string_to_enum_invalid(void)
                 "else"
         };
 
-        char buf[50];
+        static char buf[50];
 
         for (int i = 0; i < G_N_ELEMENTS(invalid_inputs); i++) {
                 sprintf(buf, "Failed in round %i", i);
@@ -383,7 +383,7 @@ TEST test_string_to_list(void)
                 {MOUSE_CLOSE_ALL, MOUSE_CLOSE_CURRENT, MOUSE_CLOSE_ALL, MOUSE_ACTION_END},
         };
 
-        char buf[50];
+        static char buf[50];
         for (int i = 0; i < G_N_ELEMENTS(inputs); i++) {
                 sprintf(buf, "Failed in round %i", i);
                 ASSERTm(buf, set_from_string(s.value, s, inputs[i]));
@@ -425,7 +425,7 @@ TEST test_string_to_list_invalid(void)
                 "close_all,invalid,close_current,close_all",
         };
 
-        char buf[256];
+        static char buf[256];
 
         for (int i = 0; i < G_N_ELEMENTS(invalid_inputs); i++) {
                 sprintf(buf, "Failed in round %i", i);
@@ -465,7 +465,7 @@ TEST test_string_to_time(void)
 
         ARRAY_SAME_LENGTH(inputs, results);
 
-        char buf[50];
+        static char buf[50];
         for (int i = 0; i < G_N_ELEMENTS(inputs); i++) {
                 sprintf(buf, "Failed in round %i", i);
                 ASSERTm(buf, set_from_string(&val, s, inputs[i]));
@@ -495,7 +495,7 @@ TEST test_string_to_time_invalid(void)
                 "s",
         };
 
-        char buf[50];
+        static char buf[50];
         for (int i = 0; i < G_N_ELEMENTS(invalid_inputs); i++) {
                 sprintf(buf, "Failed in round %i", i);
                 ASSERT_FALSEm(buf, set_from_string(&val, s, invalid_inputs[i]));
@@ -554,7 +554,7 @@ TEST test_string_to_path(void)
         ARRAY_SAME_LENGTH(inputs, results);
         ARRAY_SAME_LENGTH(inputs, results2);
 
-        char buf[256];
+        static char buf[256];
         for (int i = 0; i < G_N_ELEMENTS(inputs); i++) {
                 sprintf(buf, "Failed in round %i", i);
                 ASSERTm(buf, set_from_string(&val, s, inputs[i]));
@@ -602,7 +602,7 @@ TEST test_string_to_sepcolor(void)
 
         ARRAY_SAME_LENGTH(inputs, results);
 
-        char buf[50];
+        static char buf[50];
         for (int i = 0; i < G_N_ELEMENTS(inputs); i++) {
                 sprintf(buf, "Failed in round %i. Expected %i, got %i", i, results[i].type, val.type);
                 ASSERTm(buf, set_from_string(&val, s, inputs[i]));
@@ -638,7 +638,7 @@ TEST test_string_to_sepcolor_invalid(void)
                 /* "#AB123C123212", */
         };
 
-        char buf[50];
+        static char buf[50];
         for (int i = 0; i < G_N_ELEMENTS(inputs); i++) {
                 sprintf(buf, "Failed in round %i.", i);
                 ASSERT_FALSEm(buf, set_from_string(&val, s, inputs[i]));
@@ -682,7 +682,7 @@ TEST test_string_to_length(void)
 
         ARRAY_SAME_LENGTH(inputs, results);
 
-        char buf[500];
+        static char buf[500];
         for (int i = 0; i < G_N_ELEMENTS(inputs); i++) {
                 sprintf(buf, "Failed in round %i.", i);
                 ASSERTm(buf, set_from_string(&val, s, inputs[i]));
@@ -726,7 +726,7 @@ TEST test_string_to_length_invalid(void)
                 "(123, 122)", // invalid order
         };
 
-        char buf[50];
+        static char buf[50];
         for (int i = 0; i < G_N_ELEMENTS(inputs); i++) {
                 sprintf(buf, "Failed in round %i.", i);
                 ASSERT_FALSEm(buf, set_from_string(&val, s, inputs[i]));

--- a/test/queues.c
+++ b/test/queues.c
@@ -1061,7 +1061,7 @@ TEST test_queue_get_history(void)
 }
 
 
-void print_queues() {
+void print_queues(void) {
         printf("\nQueues:\n");
         for (GList *iter = g_queue_peek_head_link(QUEUE_WAIT); iter;
                         iter = iter->next) {


### PR DESCRIPTION
As noted in #1229 the code does not compile cleanly on recent compilers.

* I increased the standard to use mainly to silence the clang warnings about `_Static_assert`.
* I'm not sure whether wayland allows for `NULL` in callbacks and couldn't find any information. So, I decided to just implement all needed handlers as empty methods to get rid of the `noop` functions.
* I rewrote all functions having warnings about dangling pointers to use a suite to set up a real test. This way, the message is `const` within the scope of the function and the warning is suppressed.

At the moment, this builds without warnings on GCC 13.2.1 and clang 16.0.6.

Fixes #1229