### PR TITLE
Use brackets consistently in dunstctl usage

### DIFF
--- a/dunstctl
+++ b/dunstctl
@@ -27,13 +27,13 @@ show_help() {
 	  history-pop [ID]                  Pop the latest notification from
 	                                    history or optionally the
 	                                    notification with given ID.
-	  history-rm [ID]                   Remove the notification from
+	  history-rm ID                     Remove the notification from
 	                                    history with given ID.
 	  is-paused                         Check if pause level is > 0
-	  set-paused [true|false|toggle]    Set the pause status
+	  set-paused true|false|toggle      Set the pause status
 	  get-pause-level                   Get the current pause level
-	  set-pause-level [level]           Set the pause level
-	  rule name [enable|disable|toggle] Enable or disable a rule by its name
+	  set-pause-level level             Set the pause level
+	  rule name enable|disable|toggle   Enable or disable a rule by its name
 	  debug                             Print debugging information
 	  help                              Show this help
 	EOH


### PR DESCRIPTION
As noted in [this comment](https://github.com/dunst-project/dunst/pull/1212#discussion_r1389414771) usage of brackets is a bit inconsistent in the usage output of dunstctl.

Just optional argument should be put in `[]`. Required ones are without them.