### PR TITLE
Fix a typo and add periods to end all hints consistently.

### DIFF
--- a/docs/dunst.5.pod
+++ b/docs/dunst.5.pod
@@ -1115,16 +1115,16 @@ See RULES for more detailed explanations for some options.
 =over 4
 
 =item B<fgcolor>:
-Foreground cololor
+Foreground color.
 
 =item B<bgcolor>:
-Background color
+Background color.
 
 =item B<frcolor>:
-Frame color
+Frame color.
 
 =item B<hlcolor>:
-Highlight color
+Highlight color.
 
 =item B<value>:
 Progress value.


### PR DESCRIPTION
I came across the typo while reading the man page and then the first four entries ending without periods and all others ending in a period seemed strange, so I changed that as well.