### PR TITLE
fix progress bar rounding at 0% by disabling rounding in these circumstances

### DIFF
--- a/src/draw.c
+++ b/src/draw.c
@@ -749,13 +749,22 @@ static void render_content(cairo_t *c, struct colored_layout *cl, int width, dou
                 */
                 // left side (fill)
                 cairo_set_source_rgba(c, cl->highlight.r, cl->highlight.g, cl->highlight.b, cl->highlight.a);
-                draw_rounded_rect(c, x_bar_1, frame_y, progress_width_1, progress_height, 
-                        settings.progress_bar_corner_radius, scale, true, true);
+                
+                // Stops rounding when progress bar should be empty
+                if (progress_width_1 != 0) {
+                        draw_rounded_rect(c, x_bar_1, frame_y, progress_width_1, progress_height, 
+                                settings.progress_bar_corner_radius, scale, true, true);
+                }
+
                 cairo_fill(c);
                 // right side (background)
                 cairo_set_source_rgba(c, cl->bg.r, cl->bg.g, cl->bg.b, cl->bg.a);
-                draw_rounded_rect(c, x_bar_2, frame_y, progress_width_2, progress_height, 
-                        settings.progress_bar_corner_radius, scale, true, true);
+                
+                // stops rounding when progress bar should be empty
+                if (progress_width_2 != 0) {
+                        draw_rounded_rect(c, x_bar_2, frame_y, progress_width_2, progress_height, 
+                                settings.progress_bar_corner_radius, scale, true, true);
+                }
 
                 cairo_fill(c);
 


### PR DESCRIPTION
Hello dunst-project!!

A very small PR here;

An example of the original issue: 
![image](https://github.com/dunst-project/dunst/assets/18248986/35470a63-e071-4f06-a8cb-227e9671722e)
You can see here with rounding enabled on the progress bar, at 0% the rounding does not render correctly (it technically renders correctly, but not in the way a user would expect)

This PR simply fixes this by making sure the progress width is not 0 before drawing the rounded sides.

Here is how it looks after:
![image](https://github.com/dunst-project/dunst/assets/18248986/26609fb4-4f7b-4e60-a149-e581cae1fabe)

rounding at all other percentage levels is identical to before as expected:
![image](https://github.com/dunst-project/dunst/assets/18248986/8ad0f544-16af-4539-8975-1d2b1ef56941)

Let me know if any changes are required, I'll be happy to help :)