### PR TITLE
Assert that notification icon is not null in tests

### DIFF
--- a/test/icon-lookup.c
+++ b/test/icon-lookup.c
@@ -79,9 +79,10 @@ TEST test_new_icon_overrides_raw_icon(void) {
         rule->new_icon = g_strdup("edit");
 
         ASSERT(n->icon);
-
         int old_width = cairo_image_surface_get_width(n->icon);
         rule_apply(rule, n);
+
+        ASSERT(n->icon);
         ASSERT(old_width != cairo_image_surface_get_width(n->icon));
 
         cairo_surface_destroy(n->icon);

--- a/test/notification.c
+++ b/test/notification.c
@@ -151,6 +151,7 @@ TEST test_notification_icon_scaling_toosmall(void)
 {
         struct notification *n = notification_load_icon_with_scaling(20, 100);
 
+        ASSERT(n->icon);
         ASSERT_EQ(get_icon_width(n->icon, 1), 20);
         ASSERT_EQ(get_icon_height(n->icon, 1), 20);
 
@@ -164,6 +165,7 @@ TEST test_notification_icon_scaling_toolarge(void)
 {
         struct notification *n = notification_load_icon_with_scaling(5, 10);
 
+        ASSERT(n->icon);
         ASSERT_EQ(get_icon_width(n->icon, 1), 10);
         ASSERT_EQ(get_icon_height(n->icon, 1), 10);
 
@@ -176,6 +178,7 @@ TEST test_notification_icon_scaling_notconfigured(void)
 {
         struct notification *n = notification_load_icon_with_scaling(0, 0);
 
+        ASSERT(n->icon);
         ASSERT_EQ(get_icon_width(n->icon, 1), 16);
         ASSERT_EQ(get_icon_height(n->icon, 1), 16);
 
@@ -188,6 +191,7 @@ TEST test_notification_icon_scaling_notneeded(void)
 {
         struct notification *n = notification_load_icon_with_scaling(10, 20);
 
+        ASSERT(n->icon);
         ASSERT_EQ(get_icon_width(n->icon, 1), 16);
         ASSERT_EQ(get_icon_height(n->icon, 1), 16);
 


### PR DESCRIPTION
This is a temporary fix to #1228 until we figure out what causes the issue in first place (icons not being loaded). 

This simply adds assertion so that if the icon is null the test suite will not segfault

The ci will fail...