### PR TITLE
Always check /usr/share/icons in recursive lookup

### DIFF
--- a/src/icon-lookup.c
+++ b/src/icon-lookup.c
@@ -166,8 +166,9 @@ void get_theme_path() {
         add_paths_from_env(theme_path, "XDG_DATA_HOME", "icons", data_home_default);
         g_free(data_home_default);
 
-        add_paths_from_env(theme_path, "XDG_DATA_DIRS", "icons", "/usr/local/share/:/usr/share/");
+        add_paths_from_env(theme_path, "XDG_DATA_DIRS", "icons", "/usr/local/share/");
         g_ptr_array_add(theme_path, g_strdup("/usr/share/pixmaps"));
+        g_ptr_array_add(theme_path, g_strdup("/usr/share/icons"));
         for (int i = 0; i < theme_path->len; i++) {
                 LOG_D("Theme locations: %s\n", (char*)theme_path->pdata[i]);
         }


### PR DESCRIPTION
As the name says. It may be good since /usr/share/icons is so ubiquitous to check it anyway. Especially if `XDG_DATA_DIRS` is changed unknowingly from the user (like it happened to me  #1270).