### PR TITLE
Wayland: suport GTK/CSS cursor names

### DIFF
--- a/src/wayland/wl.c
+++ b/src/wayland/wl.c
@@ -750,9 +750,14 @@ bool wl_init(void) {
                 LOG_W("couldn't find a cursor theme");
                 return true;
         }
-        struct wl_cursor *cursor = wl_cursor_theme_get_cursor(ctx.cursor_theme, "left_ptr");
+        // Try cursor spec (CSS) name first
+        struct wl_cursor *cursor = wl_cursor_theme_get_cursor(ctx.cursor_theme, "default");
         if (cursor == NULL) {
-                LOG_W("couldn't find cursor icon \"left_ptr\"");
+                // Try legacy Xcursor name
+                cursor = wl_cursor_theme_get_cursor(ctx.cursor_theme, "left_ptr");
+        }
+        if (cursor == NULL) {
+                LOG_W("couldn't find cursor icons \"default\" or \"left_ptr\"");
                 wl_cursor_theme_destroy(ctx.cursor_theme);
                 // Set to NULL so it doesn't get free'd again
                 ctx.cursor_theme = NULL;


### PR DESCRIPTION
Adwaita, the default icon theme for many distributions, decided to stop providing legacy Xcursor icons in favor of the GTK/CSS names[1]. This requires us to probe for "default" instead of the "left_ptr", as the latter is no longer available in Adwaita.
Keep the fallback to "left_ptr" for more conservative themes.

[1]: https://gitlab.gnome.org/GNOME/adwaita-icon-theme/-/commit/74e9b79471236320d2af4925d6c5bb7df22380ce