### PR TITLE
Add instructions to reload the .dunstrc file without restarting.

### DIFF
--- a/docs/dunst.5.pod
+++ b/docs/dunst.5.pod
@@ -24,7 +24,7 @@ All experimental settings are marked with I<Experimental>
 
 To Reload C<.dunstrc>, run this command in your terminal :
  
-        $ killall dunst;notify-send foo
+        $ killall dunst
 
 =head2 Global section
 

--- a/docs/dunst.5.pod
+++ b/docs/dunst.5.pod
@@ -22,6 +22,10 @@ See RULES for more details.
 
 All experimental settings are marked with I<Experimental>
 
+To Reload C<.dunstrc>, run this command in your terminal :
+ 
+        $ killall dunst;notify-send foo
+
 =head2 Global section
 
 =over 4


### PR DESCRIPTION
Since dunst does not have a reload feature, added instructions in the docs to reload `.dunstrc` after making changes,
**without** needing to restart the window manager every time a change is made during configuration.