### PR TITLE
Fix `dunstctl rule` error when not providing rule state

### DIFF
--- a/dunstctl
+++ b/dunstctl
@@ -126,12 +126,20 @@ case "${1:-}" in
 	"rule")
 		[ "${2:-}" ] \
 			|| die "No rule name parameter specified. Please give the rule name"
-		state=nope
-		[ "${3:-}" = "disable" ] && state=0
-		[ "${3:-}" = "enable" ]  && state=1
-		[ "${3:-}" = "toggle" ]  && state=2
-		[ "${state}" = "nope" ] \
-			&& die "No valid rule state parameter specified. Please give either 'enable', 'disable' or 'toggle'"
+		case "${3:-}" in
+			"disable")
+				state=0
+				;;
+			"enable")
+				state=1
+				;;
+			"toggle")
+				state=2
+				;;
+			*)
+				die "No valid rule state parameter specified. Please give either 'enable', 'disable' or 'toggle'"
+				;;
+		esac
 		method_call "${DBUS_IFAC_DUNST}.RuleEnable" "string:${2:-1}" "int32:${state}" >/dev/null
 		;;
 	"get-pause-level")
@@ -178,3 +186,4 @@ case "${1:-}" in
 		;;
 esac
 # vim: noexpandtab
+

--- a/dunstctl
+++ b/dunstctl
@@ -127,9 +127,9 @@ case "${1:-}" in
 		[ "${2:-}" ] \
 			|| die "No rule name parameter specified. Please give the rule name"
 		state=nope
-		[ "${3}" = "disable" ] && state=0
-		[ "${3}" = "enable" ]  && state=1
-		[ "${3}" = "toggle" ]  && state=2
+		[ "${3:-}" = "disable" ] && state=0
+		[ "${3:-}" = "enable" ]  && state=1
+		[ "${3:-}" = "toggle" ]  && state=2
 		[ "${state}" = "nope" ] \
 			&& die "No valid rule state parameter specified. Please give either 'enable', 'disable' or 'toggle'"
 		method_call "${DBUS_IFAC_DUNST}.RuleEnable" "string:${2:-1}" "int32:${state}" >/dev/null


### PR DESCRIPTION
Previously showed "line 130: 3: unbound variable" instead of the pretty error message.