### PR TITLE
Fix compiler warning/error on master

### DIFF
--- a/src/wayland/wl.c
+++ b/src/wayland/wl.c
@@ -150,13 +150,13 @@ static void output_handle_name(void *data, struct wl_output *wl_output,
         output->name = g_strdup(name);
         LOG_D("Output global %" PRIu32 " name %s", output->global_name, name);
 }
+
+static void output_handle_description(void *data, struct wl_output *output, const char* description) {
+        // do nothing
+}
 #endif
 
 static void output_listener_done_handler(void *data, struct wl_output *output) {
-        // do nothing
-}
-
-static void output_handle_description(void *data, struct wl_output *output, const char* description) {
         // do nothing
 }
 


### PR DESCRIPTION
The callback `output_handle_description` is just used when `WL_OUTPUT_NAME_SINCE_VERSION` is defined and so, this function should defined only then as well as it otherwise is flagged as being unused which breaks the build.