### PR TITLE
Suppress alpine allocation issue

### DIFF
--- a/.valgrind.suppressions
+++ b/.valgrind.suppressions
@@ -19,6 +19,16 @@
    obj:*
 }
 
+# Ignore yet another musls' weird error
+{
+   musl_alpine_libc
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:realloc
+   fun:getdelim
+   ...
+}
+
 # rsvg_error_handle_close got fixed in
 # - GNOME/librsvg@7bf1014
 # (2018-11-12, first tags: v2.45.0, v2.44.9)

--- a/src/wayland/wl.c
+++ b/src/wayland/wl.c
@@ -150,13 +150,13 @@ static void output_handle_name(void *data, struct wl_output *wl_output,
         output->name = g_strdup(name);
         LOG_D("Output global %" PRIu32 " name %s", output->global_name, name);
 }
+
+static void output_handle_description(void *data, struct wl_output *output, const char* description) {
+        // do nothing
+}
 #endif
 
 static void output_listener_done_handler(void *data, struct wl_output *output) {
-        // do nothing
-}
-
-static void output_handle_description(void *data, struct wl_output *output, const char* description) {
         // do nothing
 }
 


### PR DESCRIPTION
This is related to the introduction of `wordexp` in e9a27c0 but did go unnoticed as it seems to be detected just by newer versions of valgrind (I would rule out musl here as the `wordexp` code was not touched in ages and `getdelim` was last mentioned in the 1.1.22 version while the old alpine image already shipped 1.1.24).

This isn't an issue with the current images but newer versions of alpine fail to complete without it (see [this comment](https://github.com/dunst-project/docker-images/pull/8#issuecomment-1948756512)).