### PR TITLE
Allow compilation without X11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,15 +32,18 @@ SYSCONF_FORCE_NEW ?= $(shell [ -f ${DESTDIR}${SYSCONFFILE} ] || echo 1)
 CFLAGS  := ${DEFAULT_CPPFLAGS} ${CPPFLAGS} ${DEFAULT_CFLAGS} ${CFLAGS} ${INCS} -MMD -MP
 LDFLAGS := ${DEFAULT_LDFLAGS} ${LDFLAGS} ${LIBS}
 
+SRC := $(sort $(shell ${FIND} src/ -not \( -path src/wayland -prune -o -path src/x11 -prune \) -name '*.c'))
 
-ifeq (0,${WAYLAND})
-# without wayland support
-SRC := $(sort $(shell ${FIND} src/ -not \( -path src/wayland -prune \) -name '*.c'))
-else
+ifneq (0,${WAYLAND})
 # with Wayland support
 CFLAGS += -DHAVE_WL_CURSOR_SHAPE -DHAVE_WL_EXT_IDLE_NOTIFY
-SRC := $(sort $(shell ${FIND} src/ -name '*.c'))
+SRC += $(sort $(shell ${FIND} src/wayland -name '*.c'))
 endif
+
+ifneq (0,${X11})
+SRC += $(sort $(shell ${FIND} src/x11 -name '*.c'))
+endif
+
 OBJ := ${SRC:.c=.o}
 TEST_SRC := $(sort $(shell ${FIND} test/ -name '*.c'))
 TEST_OBJ := $(TEST_SRC:.c=.o)

--- a/README.md
+++ b/README.md
@@ -118,12 +118,15 @@ sudo make install
 - `MANDIR=<PATH>`: Set the prefix of the manpage. (Default: `${DATADIR}/man`)
 - `SYSTEMD=(0|1)`: Disable/Enable the systemd unit. (Default: autodetect systemd)
 - `WAYLAND=(0|1)`: Disable/Enable wayland support. (Default: 1 (enabled))
+- `X11=(0|1)`: Disable/Enable X11 support. (Default: 1 (enabled))
 - `DUNSTIFY=(0|1)`: Disable/Enable the libnotify dunstctl utility. (Default: 1 (enabled))
 - `SERVICEDIR_SYSTEMD=<PATH>`: The path to put the systemd user service file. Unused, if `SYSTEMD=0`. (Default: `${PREFIX}/lib/systemd/user`)
 - `SERVICEDIR_DBUS=<PATH>`: The path to put the dbus service file. (Default: `${DATADIR}/dbus-1/services`)
 - `EXTRA_CFLAGS=<FLAGS>`: Additional flags for the compiler.
 
 **Make sure to run all make calls with the same parameter set. So when building with `make PREFIX=/usr`, you have to install it with `make PREFIX=/usr install`, too.**
+
+**Either X11 or WAYLAND should be set, otherwise dunst will not compile.**
 
 **Notes on default of XDG_CONFIG_DIRS**
 

--- a/config.mk
+++ b/config.mk
@@ -40,9 +40,13 @@ ifneq (0, ${WAYLAND})
 ENABLE_WAYLAND= -DENABLE_WAYLAND
 endif
 
+ifneq (0, ${X11})
+ENABLE_X11= -DENABLE_X11
+endif
+
 # flags
 DEFAULT_CPPFLAGS = -Wno-gnu-zero-variadic-macro-arguments -D_DEFAULT_SOURCE -DVERSION=\"${VERSION}\" -DSYSCONFDIR=\"${SYSCONFDIR}\"
-DEFAULT_CFLAGS   = -g -std=gnu11 -pedantic -Wall -Wno-overlength-strings -Os ${ENABLE_WAYLAND} ${EXTRA_CFLAGS}
+DEFAULT_CFLAGS   = -g -std=gnu11 -pedantic -Wall -Wno-overlength-strings -Os ${ENABLE_WAYLAND} ${ENABLE_X11} ${EXTRA_CFLAGS}
 DEFAULT_LDFLAGS  = -lm -lrt
 
 CPPFLAGS_DEBUG := -DDEBUG_BUILD
@@ -53,11 +57,6 @@ pkg_config_packs := gio-2.0 \
                     gdk-pixbuf-2.0 \
                     "glib-2.0 >= 2.44" \
                     pangocairo \
-                    x11 \
-                    xinerama \
-                    xext \
-                    "xrandr >= 1.5" \
-                    xscrnsaver \
 
 
 ifneq (0,${DUNSTIFY})
@@ -68,4 +67,12 @@ endif
 ifneq (0,${WAYLAND})
 pkg_config_packs += wayland-client
 pkg_config_packs += wayland-cursor
+endif
+
+ifneq (0,${X11})
+pkg_config_packs += x11
+pkg_config_packs += xinerama
+pkg_config_packs += xext
+pkg_config_packs += "xrandr >= 1.5"
+pkg_config_packs += xscrnsaver
 endif

--- a/docs/dunst.5.pod
+++ b/docs/dunst.5.pod
@@ -332,6 +332,8 @@ Default: overlay
 Force the use of X11 output, even on a wayland compositor. This setting
 has no effect when not using a Wayland compositor.
 
+This setting will be ignored if dunst was compiled without X11 support.
+
 =item B<font> (default: "Monospace 8")
 
 Defines the font or font set used. Optionally set the size as a decimal number

--- a/src/option_parser.c
+++ b/src/option_parser.c
@@ -9,7 +9,6 @@
 #include <string.h>
 #include <errno.h>
 
-#include "x11/x.h"
 #include "dunst.h"
 #include "log.h"
 #include "utils.h"

--- a/src/output.c
+++ b/src/output.c
@@ -1,8 +1,10 @@
 #include "output.h"
-
 #include "log.h"
+
+#ifdef ENABLE_X11
 #include "x11/x.h"
 #include "x11/screen.h"
+#endif
 
 #ifdef ENABLE_WAYLAND
 #include "wayland/wl.h"
@@ -13,6 +15,7 @@ bool is_running_wayland(void) {
         return !(wayland_display == NULL);
 }
 
+#ifdef ENABLE_X11
 const struct output output_x11 = {
         x_setup,
         x_free,
@@ -33,6 +36,7 @@ const struct output output_x11 = {
 
         x_get_scale,
 };
+#endif
 
 #ifdef ENABLE_WAYLAND
 const struct output output_wl = {
@@ -57,6 +61,7 @@ const struct output output_wl = {
 };
 #endif
 
+#ifdef ENABLE_X11
 const struct output* get_x11_output(void) {
         const struct output* output = &output_x11;
         if (output->init()) {
@@ -65,6 +70,7 @@ const struct output* get_x11_output(void) {
                 LOG_E("Couldn't initialize X11 output. Aborting...");
         }
 }
+#endif
 
 #ifdef ENABLE_WAYLAND
 const struct output* get_wl_output(void) {
@@ -72,9 +78,13 @@ const struct output* get_wl_output(void) {
         if (output->init()) {
                 return output;
         } else {
+#ifdef ENABLE_X11
                 LOG_W("Couldn't initialize wayland output. Falling back to X11 output.");
                 output->deinit();
                 return get_x11_output();
+#else
+                DIE("Couldn't initialize wayland output");
+#endif
         }
 }
 #endif
@@ -82,15 +92,19 @@ const struct output* get_wl_output(void) {
 const struct output* output_create(bool force_xwayland)
 {
 #ifdef ENABLE_WAYLAND
-        if (!force_xwayland && is_running_wayland()) {
+        if ((!force_xwayland || WAYLAND_ONLY) && is_running_wayland()) {
                 LOG_I("Using Wayland output");
+                if (force_xwayland)
+                        LOG_W("Ignoring force_xwayland setting because X11 output was not compiled");
                 return get_wl_output();
-        } else {
-                LOG_I("Using X11 output");
-                return get_x11_output();
         }
-#else
+#endif
+
+#ifdef ENABLE_X11
+        LOG_I("Using X11 output");
         return get_x11_output();
 #endif
+
+        DIE("No applicable ouput was found (X11, Wayland)");
 }
 /* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/output.h
+++ b/src/output.h
@@ -53,12 +53,11 @@ struct output {
 
 #ifndef ENABLE_X11
 #define WAYLAND_ONLY 1
+#ifndef ENABLE_WAYLAND
+#error "You have to compile at least one output (X11, Wayland)"
+#endif
 #else
 #define WAYLAND_ONLY 0
-#endif
-
-#if !defined(ENABLE_X11) && !defined(ENABLE_WAYLAND)
-#error "You have to compile at least one output (X11, Wayland)"
 #endif
 
 /**

--- a/src/output.h
+++ b/src/output.h
@@ -51,6 +51,16 @@ struct output {
         double (*get_scale)(void);
 };
 
+#ifndef ENABLE_X11
+#define WAYLAND_ONLY 1
+#else
+#define WAYLAND_ONLY 0
+#endif
+
+#if !defined(ENABLE_X11) && !defined(ENABLE_WAYLAND)
+#error "You have to compile at least one output (X11, Wayland)"
+#endif
+
 /**
  * return an initialized output, selecting the correct output type from either
  * wayland or X11 according to the settings and environment.

--- a/src/settings.c
+++ b/src/settings.c
@@ -20,7 +20,6 @@
 #include "ini.h"
 #include "rules.h"
 #include "utils.h"
-#include "x11/x.h"
 #include "output.h"
 
 #ifndef SYSCONFDIR

--- a/src/settings.h
+++ b/src/settings.h
@@ -12,7 +12,7 @@
 #include "x11/x.h"
 #endif
 
-// TODO: Make keyboard_shortcut work also for wayland
+// Note: Wayland doesn't support hotkeys
 struct keyboard_shortcut {
         const char *str;
 #ifdef ENABLE_X11

--- a/src/settings.h
+++ b/src/settings.h
@@ -8,8 +8,22 @@
 #include "wayland/protocols/wlr-layer-shell-unstable-v1-client-header.h"
 #endif
 
-#include "notification.h"
+#ifdef ENABLE_X11
 #include "x11/x.h"
+#endif
+
+// TODO: Make keyboard_shortcut work also for wayland
+struct keyboard_shortcut {
+        const char *str;
+#ifdef ENABLE_X11
+        KeyCode code;
+        KeySym sym;
+        KeySym mask;
+        bool is_valid;
+#endif
+};
+
+#include "notification.h"
 
 #define LIST_END (-1)
 

--- a/src/x11/x.h
+++ b/src/x11/x.h
@@ -15,17 +15,6 @@
 
 #include "screen.h"
 
-struct keyboard_shortcut {
-        const char *str;
-        KeyCode code;
-        KeySym sym;
-        KeySym mask;
-        bool is_valid;
-};
-
-// Cyclical dependency
-#include "../settings.h"
-
 struct x_context {
         Display *dpy;
         XScreenSaverInfo *screensaver_info;


### PR DESCRIPTION
With these changes you can compile dunst with only wayland support.

Important note: At the moment I don't have a working wayland setup so I can't test if everything is ok. I guess so since the changes are minimal, but if someone with wayland could test this it would be great.

Update: Narrat reviewed the changes. Somewhere in the near future this will be merged hopefully

Closes #1008 