### PR TITLE
x11: Prevent memory corruption in XrmSetDatabase

### DIFF
--- a/src/x11/x.c
+++ b/src/x11/x.c
@@ -489,6 +489,13 @@ static void XRM_update_db(void)
                         XrmDestroyDatabase(db);
                 }
 
+                // Despite what the XrmSetDatabase docs say, it may try to free
+                // the database, resulting in memory corruption. Prevent that
+                // by making sure it has no db to act on. If it's past the
+                // first run, we will have done XrmDestroyDatabase above
+                // anyway.
+                xctx.dpy->db = NULL;
+
                 db = XrmGetStringDatabase((const char*)prop.value);
                 XrmSetDatabase(xctx.dpy, db);
         }


### PR DESCRIPTION
Despite what the XrmSetDatabase docs say, it may try to free the database, resulting in memory corruption. Prevent that by making sure it has no db to act on. If it's past the first run, we will have done XrmDestroyDatabase above anyway. This causes a segfault, reported in issue #1256.

From the XrmSetDatabase man page:

> The database previously associated with the display (if any) is not
> destroyed.

But this is patently false, from the source in Xlib's src/Xrm.c:

    void XrmSetDatabase(
        Display *display,
        XrmDatabase database)
    {
        LockDisplay(display);
        /* destroy database if set up implicitly by XGetDefault() */
        if (display->db && (display->flags & XlibDisplayDfltRMDB)) {
            XrmDestroyDatabase(display->db);
            display->flags &= ~XlibDisplayDfltRMDB;
        }
        display->db = database;
        UnlockDisplay(display);
    }

This is broken in Xlib since at least 2004[0], so now it's unfortunately a backwards compatibility issue...

Fixes #1256.

0: https://lists.freedesktop.org/archives/xorg-commit-diffs/2004-March/000239.html