### PR TITLE
Fix settings initialization

### DIFF
--- a/src/dunst.c
+++ b/src/dunst.c
@@ -178,6 +178,8 @@ int dunst_main(int argc, char *argv[])
         dunst_status_int(S_PAUSE_LEVEL, 0);
         dunst_status(S_IDLE, false);
 
+        settings_init();
+
         queues_init();
 
         cmdline_load(argc, argv);
@@ -197,9 +199,7 @@ int dunst_main(int argc, char *argv[])
             cmdline_get_string("-conf/-config", NULL,
                                "Path to configuration file");
 
-        if (cmdline_get_bool("-print/--print", false, "Print notifications to stdout")) {
-                settings.print_notifications = true;
-        }
+        settings.print_notifications = cmdline_get_bool("-print/--print", false, "Print notifications to stdout");
 
         settings.startup_notification = cmdline_get_bool("-startup_notification/--startup_notification",
                         false, "Display a notification on startup.");

--- a/src/queues.c
+++ b/src/queues.c
@@ -375,7 +375,7 @@ void queues_history_pop_by_id(unsigned int id)
         if (g_queue_is_empty(history))
                 return;
 
-        // search through the history buffer 
+        // search through the history buffer
         for (GList *iter = g_queue_peek_head_link(history); iter;
                 iter = iter->next) {
                 struct notification *cur = iter->data;

--- a/src/settings.c
+++ b/src/settings.c
@@ -260,7 +260,10 @@ static void process_conf_file(const gpointer conf_fname, gpointer n_success) {
         ++(*(int *) n_success);
 }
 
-void load_settings(const char * const path) {
+void load_settings(const char *const path) {
+        // NOTE: settings_init should be called before if some settings are changed
+        //       But having it here is useful for tests
+        //       Potentially, we could update the settings code and move this somewhere else
         settings_init();
         LOG_D("Setting defaults");
         set_defaults();

--- a/src/settings.h
+++ b/src/settings.h
@@ -181,7 +181,9 @@ struct settings {
 
 extern struct settings settings;
 
-void load_settings(const char * const path);
+void settings_init(void);
+
+void load_settings(const char *const path);
 
 #endif
 /* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */


### PR DESCRIPTION
settings.print_notifications and settings.startup_notification were always set to zero by load_settings