### PR TITLE
Make recursive icon lookup work with size == 0

### DIFF
--- a/src/icon-lookup.c
+++ b/src/icon-lookup.c
@@ -253,7 +253,7 @@ char *find_icon_in_theme(const char *name, int theme_index, int size) {
                                 break;
 
                         case THEME_DIR_SCALABLE:
-                                match_size = dir.min_size <= size && dir.max_size >= size;
+                                match_size = (size == 0 || dir.min_size <= size) && dir.max_size >= size;
                                 break;
 
                         case THEME_DIR_THRESHOLD:


### PR DESCRIPTION
Only works with scalable icons, but at least it works.

@fwsmit do you think this is a good enough solution for #1094?