### PR TITLE
Rewrite github action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,16 +11,14 @@ jobs:
   enforce-g_malloc:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-      with:
-        # Clone the whole branch, we have to fetch tags later
-        fetch-depth: 0
+      - uses: actions/checkout@v4
 
-    - name: enforce-g_malloc
-      run: "! git grep -P '(?<!g_)malloc' ':!.valgrind.suppressions' ':!.github/workflows/main.yml'"
+      - name: enforce-g_malloc
+        run: "! git grep -P '(?<!g_)malloc' ':!.valgrind.suppressions' ':!.github/workflows/main.yml'"
 
   build:
     strategy:
+      fail-fast: false
       matrix:
         CC:
           - clang
@@ -28,86 +26,88 @@ jobs:
         distro:
           - alpine
           - archlinux
-          - debian-stretch
+          - debian-bookworm
+          - debian-bullseye
           - debian-buster
           - fedora
-          - ubuntu-xenial
-          - ubuntu-bionic
           - ubuntu-focal
+          - ubuntu-jammy
 
     env:
       CC: ${{ matrix.CC }}
-      EXTRA_CFLAGS: "-Werror"
+      EXTRA_CFLAGS: "-Werror ${{ (matrix.distro == 'debian-bookworm' || matrix.distro == 'ubuntu-jammy') && matrix.CC == 'clang' && '-gdwarf-4' || ' '}}"
+
     steps:
-    - uses: actions/checkout@v2
-      with:
-        # Clone the whole branch, we have to fetch tags later
-        fetch-depth: 0
+      - uses: actions/checkout@v4
+        with:
+          # Clone the whole history including tags.
+          fetch-depth: 0
 
-    # Fetch tags to determine proper version number inside git
-    - name: fetch tags
-      run: git fetch --tags
-      # We cannot pull tags with old distros, since there is no `.git`. See below.
-      if: "! (matrix.distro == 'ubuntu-bionic' || matrix.distro == 'ubuntu-xenial' || matrix.distro == 'debian-stretch')"
+      - name: setup $HOME for git
+        run: echo "HOME=${RUNNER_TEMP}" >> ${GITHUB_ENV}
 
-    # The Github checkout Action doesn't support distros with git older than 2.18
-    # With git<2.18 it downloads the code via API and does not clone it via git :facepalm:
-    # To succeed the tests, we have to manually replace the VERSION macro
-    - name: fix version number for old distros
-      run: 'sed -i "s/-non-git/-ci-oldgit-$GITHUB_SHA/" Makefile'
-      if: "  (matrix.distro == 'ubuntu-bionic' || matrix.distro == 'ubuntu-xenial' || matrix.distro == 'debian-stretch')"
+      - name: configure safe directory for git
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
 
-    - name: build
-      run: make -j all dunstify test/test
+      - name: build
+        run: make -j all dunstify test/test
 
-    - name: test
-      run: make -j test
+      - name: test
+        run: make -j test
 
-    - name: installation
-      run: ./test/test-install.sh
+      - name: installation
+        run: ./test/test-install.sh
 
-    - name: valgrind memleaks
-      run: |
-        make clean
-        make -j test-valgrind
-
-    - name: coverage
-      run: |
-        make clean
-        make -j test-coverage
-
-    - name: Generate coverage report
-      run: lcov -c -d . -o lcov.info
-      if: "matrix.CC == 'gcc'"
-
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        flags: unittests
-        name: ${{ matrix.distro }}-${{ matrix.CC }}
-        fail_ci_if_error: true
-      if: "matrix.CC == 'gcc'"
+      - name: valgrind memleaks
+        run: make -j clean test-valgrind
 
     runs-on: ubuntu-latest
     container:
-      image: dunst/ci:${{ matrix.distro }}
+      image: ghcr.io/dunst-project/docker-images:${{ matrix.distro }}
+
+  coverage:
+    needs: build
+    if: github.repository == 'dunst-project/dunst'
+    env:
+      CC: gcc
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Clone the whole history including tags.
+          fetch-depth: 0
+
+      - name: setup $HOME for git
+        run: echo "HOME=${RUNNER_TEMP}" >> ${GITHUB_ENV}
+
+      - name: configure safe directory for git
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
+
+      - name: coverage
+        run: make clean test-coverage
+
+      - name: Generate coverage report
+        run: lcov -c -d . -o lcov.info
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: unittests
+          name: fedora-gcc
+          fail_ci_if_error: true
+
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/dunst-project/docker-images:fedora
 
   doxygen:
-    strategy:
-      matrix:
-        distro:
-          - misc-doxygen
-
     steps:
-    - uses: actions/checkout@v2
-      with:
-        # Clone the whole branch, we have to fetch tags later
-        fetch-depth: 0
+      - uses: actions/checkout@v4
 
-    - name: doxygen
-      run: make -j doc-doxygen
+      - name: doxygen
+        run: make -j doc-doxygen
 
     runs-on: ubuntu-latest
     container:
-      image: dunst/ci:${{ matrix.distro }}
+      image: ghcr.io/dunst-project/docker-images:misc-doxygen

--- a/.valgrind.suppressions
+++ b/.valgrind.suppressions
@@ -135,3 +135,47 @@
    obj:*pango*
    ...
 }
+
+{
+   rsvg_conditional_jump
+   Memcheck:Cond
+   obj:/usr/lib*/librsvg-2.so.2.48.0
+   ...
+   fun:rsvg_handle_get_pixbuf
+   obj:/usr/lib*/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-svg.so
+   obj:/usr/lib*/libgdk_pixbuf-2.0.so.0.4200.10
+   fun:gdk_pixbuf_new_from_file
+   fun:notification_setup_raw_image
+   fun:notification_load_icon_with_scaling
+   ...
+}
+
+{
+   # Basically the same as above, but just for Debian
+   rsvg_conditional_jump-debian
+   Memcheck:Cond
+   obj:/usr/lib/*/librsvg-2.so.2.48.0
+   ...
+   fun:rsvg_handle_get_pixbuf
+   obj:/usr/lib/*/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-svg.so
+   obj:/usr/lib/*/libgdk_pixbuf-2.0.so.0.4200.8
+   fun:gdk_pixbuf_new_from_file
+   fun:notification_setup_raw_image
+   fun:notification_load_icon_with_scaling
+   ...
+}
+
+{
+   # Basically the same as above, but just for Ubuntu Focal
+   rsvg_conditional_jump-ubuntu_focal
+   Memcheck:Cond
+   obj:/usr/lib/*/librsvg-2.so.2.47.0
+   ...
+   fun:rsvg_rust_handle_close
+   obj:/usr/lib/*/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-svg.so
+   obj:/usr/lib/*/libgdk_pixbuf-2.0.so.0.4000.0
+   fun:gdk_pixbuf_new_from_file
+   fun:notification_setup_raw_image
+   fun:notification_load_icon_with_scaling
+   ...
+}


### PR DESCRIPTION
Yet another try of getting the pipelines to work. This continues/replaces #1303.

Notable changes:
* update to use latest images from `dunst-project/docker-images`
* updated the images for Debian bookworm and Alpine (see the other repository) to add some more missing dependencies
* `make test-coverage` has issues running in parallel ⇒ `-j` should not be used
* don't kill matrix jobs when one fails in order to see which targets are really broken
* update actions where possible
* `misc-doxygen` doesn't need to be a matrix, if it is a `1x1` matrix

TODO:
* [x] why generate coverage data for clang, when it's discarded anyhow (just gcc is uploaded); why upload coverage data for each distro? shouldn't one suffice?
* [ ] `codecov/codecov-action@v3` is outdated, but `v4` doesn't work an all images
* [x] uploading coverage report fails on forks, this could be fixed in `codecov/codecov-action@v4` (at least the description seems to imply this)
* [x] creating coverage reports on forks could be disabled altogether as it's done anyhow when the PR is created
