### PR TITLE
Do not resolve paths in get_pixbuf_from_file

### DIFF
--- a/src/icon.c
+++ b/src/icon.c
@@ -185,19 +185,17 @@ static GdkPixbuf *icon_pixbuf_scale_to_size(GdkPixbuf *pixbuf, double dpi_scale,
 
 GdkPixbuf *get_pixbuf_from_file(const char *filename, int min_size, int max_size, double scale)
 {
-        char *path = string_to_path(g_strdup(filename));
         GError *error = NULL;
         gint w, h;
 
-        if (!gdk_pixbuf_get_file_info (path, &w, &h)) {
+        if (!gdk_pixbuf_get_file_info (filename, &w, &h)) {
                 LOG_W("Failed to load image info for %s", STR_NN(filename));
-                g_free(path);
                 return NULL;
         }
         GdkPixbuf *pixbuf = NULL;
         // TODO immediately rescale icon upon scale changes
         icon_size_clamp(&w, &h, min_size, max_size);
-        pixbuf = gdk_pixbuf_new_from_file_at_scale(path,
+        pixbuf = gdk_pixbuf_new_from_file_at_scale(filename,
                         round(w * scale),
                         round(h * scale),
                         TRUE,
@@ -208,7 +206,6 @@ GdkPixbuf *get_pixbuf_from_file(const char *filename, int min_size, int max_size
                 g_error_free(error);
         }
 
-        g_free(path);
         return pixbuf;
 }
 


### PR DESCRIPTION
The arguments should be already resolved:
* if it's either `new_icon` or `default_icon` it should be done while parsing the configuration
* if it's coming from DBus whoever sent the message should give a fully resolved path

This fixes #1307.