### PR TITLE
Update dunst.5.pod

### DIFF
--- a/docs/dunst.5.pod
+++ b/docs/dunst.5.pod
@@ -552,10 +552,23 @@ is set to 0 this option will be ignored.
 Comma-separated list of the corners. The accepted corner values are bottom-right,
 bottom-left, top-right, top-left, top, bottom, left, right or all.
 
-=item B<mouse_left/middle/right_click> (values: [none/do_action/close_current/close_all/context/context_all])
+=item B<mouse_[left/middle/right]_click> (values: [none/do_action/close_current/close_all/context/context_all])
 
 Defines action of mouse click. A touch input in Wayland acts as a mouse left
-click.
+click. A list of values, separated by commas, can be specified for multiple
+actions to be executed in sequence.
+
+B<Defaults:>
+
+=over 12
+
+=item * C<mouse_left_click="close_current">
+
+=item * C<mouse_middle_click="do_action, close_current">
+
+=item * C<mouse_right_click="close_all">
+
+=back
 
 =over 4
 
@@ -563,7 +576,7 @@ click.
 
 Don't do anything.
 
-=item B<do_action> (default for mouse_middle_click)
+=item B<do_action>
 
 Invoke the action determined by the action_name rule. If there is no such
 action, open the context menu.
@@ -573,11 +586,11 @@ action, open the context menu.
 If the notification has exactly one url, open it. If there are multiple
 ones, open the context menu.
 
-=item B<close_current> (default for mouse_left_click)
+=item B<close_current>
 
 Close current notification.
 
-=item B<close_all> (default for mouse_right_click)
+=item B<close_all>
 
 Close all notifications.
 


### PR DESCRIPTION
Clarify mouse_[left/middle/right]_click documentation and fix factual error

1. changed mouse_left/middle/right_click to mouse_[left/middle/right]_click to make it more obvious that it's a fill-in-the-blank
2. the defaults as listed were (slightly) wrong; in src/settings_data.h, the mouse_middle_click behaviour is in fact "do_action, close_current" and not just "do_action" as the current documentation implies. I refactored the documentation slightly to fix this error.