### PR TITLE
Update codecov-action to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,7 +90,7 @@ jobs:
         run: lcov -c -d . -o lcov.info
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittests


### PR DESCRIPTION
v3 is facing some issues at the moment. v4 should be fine as coverage reports are generated on fedora which should have a recent Node.js version.