### PR TITLE
Just create coverage reports for pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,7 +67,7 @@ jobs:
 
   coverage:
     needs: build
-    if: github.repository == 'dunst-project/dunst'
+    if: github.event_name == 'pull_request'
     env:
       CC: gcc
 


### PR DESCRIPTION
No one will read them for master anyhow.

Currently, uploading fails due to a missing token, which I cannot configure as I'm lacking the needed permissions.