### PR TITLE
Add test for DBus RuleEnable and fix memory leak

### DIFF
--- a/src/dbus.c
+++ b/src/dbus.c
@@ -434,6 +434,7 @@ static void dbus_cb_dunst_RuleEnable(GDBusConnection *connection,
         }
 
         struct rule *target_rule = get_rule(name);
+        g_free(name);
 
         if (target_rule == NULL) {
                 g_dbus_method_invocation_return_error(invocation,

--- a/test/dbus.c
+++ b/test/dbus.c
@@ -589,6 +589,29 @@ TEST test_dbus_cb_dunst_NotificationListHistory(void)
         PASS();
 }
 
+TEST test_dbus_cb_dunst_RuleEnable(void)
+{
+        struct rule *rule = rule_new("test_rule_enable");
+        ASSERT(rule->enabled);
+
+        GVariant *result = dbus_invoke_ifac("RuleEnable", g_variant_new("(si)", "test_rule_enable", 0), DUNST_IFAC);
+        ASSERT(result != NULL);
+        ASSERT(!rule->enabled);
+        g_variant_unref(result);
+
+        result = dbus_invoke_ifac("RuleEnable", g_variant_new("(si)", "test_rule_enable", 1), DUNST_IFAC);
+        ASSERT(result != NULL);
+        ASSERT(rule->enabled);
+        g_variant_unref(result);
+
+        result = dbus_invoke_ifac("RuleEnable", g_variant_new("(si)", "test_rule_enable", 2), DUNST_IFAC);
+        ASSERT(result != NULL);
+        ASSERT(!rule->enabled);
+        g_variant_unref(result);
+
+        PASS();
+}
+
 TEST test_empty_notification(void)
 {
         struct dbus_notification *n = dbus_notification_new();
@@ -1285,6 +1308,7 @@ gpointer run_threaded_tests(gpointer data)
         RUN_TEST(test_match_dbus_timeout);
         RUN_TEST(test_timeout);
         RUN_TEST(test_dbus_cb_dunst_NotificationListHistory);
+        RUN_TEST(test_dbus_cb_dunst_RuleEnable);
 
         RUN_TEST(assert_methodlists_sorted);
 


### PR DESCRIPTION
This is mainly done to test whether the current pipeline works properly in terms of coverage reporting.

A nice side-effect is, that I could increase the test coverage a bit and fixed a memory leak while doing so.