### PR TITLE
Re-enable coverage for all pushes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,7 +67,6 @@ jobs:
 
   coverage:
     needs: build
-    if: github.event_name == 'pull_request'
     env:
       CC: gcc
 


### PR DESCRIPTION
There should be a valid token now and thus the restriction for pull requests should not be needed anymore.