### PR TITLE
Print compile-time options in `dunst --version`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,8 @@ debug: all
 ${OBJ} ${TEST_OBJ}: Makefile config.mk
 
 src/dunst.o: src/dunst.c
-	${CC} -o $@ -c $< ${CPPFLAGS} ${CFLAGS} -D_CFLAGS="$(filter-out $(filter -I%,${INCS}),${CFLAGS})" -D_LDFLAGS="${LDFLAGS}"
+	${CC} -o $@ -c $< ${CPPFLAGS} ${CFLAGS} \
+		-D_CCDATE="$(shell date '+%Y-%m-%d')" -D_CFLAGS="$(filter-out $(filter -I%,${INCS}),${CFLAGS})" -D_LDFLAGS="${LDFLAGS}"
 
 %.o: %.c
 	${CC} -o $@ -c $< ${CPPFLAGS} ${CFLAGS}

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,11 @@ endif
 
 SYSCONF_FORCE_NEW ?= $(shell [ -f ${DESTDIR}${SYSCONFFILE} ] || echo 1)
 
+ifneq (0,${DUNSTIFY})
+DUNSTIFY_CFLAGS  := ${DEFAULT_CFLAGS} ${CFLAGS} ${CPPFLAGS} $(shell $(PKG_CONFIG) --cflags libnotify)
+DUNSTIFY_LDFLAGS := ${DEFAULT_LDFLAGS} ${LDFLAGS} $(shell $(PKG_CONFIG) --libs libnotify)
+endif
+
 CPPFLAGS := ${DEFAULT_CPPFLAGS} ${CPPFLAGS}
 CFLAGS   := ${DEFAULT_CFLAGS} ${CFLAGS} ${INCS} -MMD -MP
 LDFLAGS  := ${DEFAULT_LDFLAGS} ${LDFLAGS} ${LIBS}
@@ -81,7 +86,7 @@ dunst: ${OBJ} main.o
 ifneq (0,${DUNSTIFY})
 all: dunstify
 dunstify: dunstify.o
-	${CC} -o ${@} dunstify.o ${CPPFLAGS} ${CFLAGS} ${LDFLAGS}
+	${CC} -o ${@} dunstify.o ${DUNSTIFY_CFLAGS} ${DUNSTIFY_LDFLAGS}
 endif
 
 .PHONY: test test-valgrind test-coverage

--- a/config.mk
+++ b/config.mk
@@ -51,8 +51,8 @@ ENABLE_X11= -DENABLE_X11
 endif
 
 # flags
-DEFAULT_CPPFLAGS = -Wno-gnu-zero-variadic-macro-arguments -D_DEFAULT_SOURCE -DVERSION=\"${VERSION}\" -DSYSCONFDIR=\"${SYSCONFDIR}\"
-DEFAULT_CFLAGS   = -g -std=gnu11 -pedantic -Wall -Wno-overlength-strings -Os ${ENABLE_WAYLAND} ${ENABLE_X11} ${EXTRA_CFLAGS}
+DEFAULT_CPPFLAGS = -Wno-gnu-zero-variadic-macro-arguments -D_DEFAULT_SOURCE -DVERSION=\"${VERSION}\" -D_CCDATE="$(shell date '+%h %d %Y')" -DSYSCONFDIR=\"${SYSCONFDIR}\" ${ENABLE_WAYLAND} ${ENABLE_X11}
+DEFAULT_CFLAGS   = -g -std=gnu11 -pedantic -Wall -Wno-overlength-strings -Os ${EXTRA_CFLAGS}
 DEFAULT_LDFLAGS  = -lm -lrt
 
 CPPFLAGS_DEBUG := -DDEBUG_BUILD

--- a/config.mk
+++ b/config.mk
@@ -64,12 +64,6 @@ pkg_config_packs := gio-2.0 \
                     "glib-2.0 >= 2.44" \
                     pangocairo \
 
-
-ifneq (0,${DUNSTIFY})
-# dunstify also needs libnotify
-pkg_config_packs += libnotify
-endif
-
 ifneq (0,${WAYLAND})
 pkg_config_packs += wayland-client
 pkg_config_packs += wayland-cursor

--- a/config.mk
+++ b/config.mk
@@ -51,7 +51,7 @@ ENABLE_X11= -DENABLE_X11
 endif
 
 # flags
-DEFAULT_CPPFLAGS = -Wno-gnu-zero-variadic-macro-arguments -D_DEFAULT_SOURCE -DVERSION=\"${VERSION}\" -D_CCDATE="$(shell date '+%h %d %Y')" -DSYSCONFDIR=\"${SYSCONFDIR}\" ${ENABLE_WAYLAND} ${ENABLE_X11}
+DEFAULT_CPPFLAGS = -Wno-gnu-zero-variadic-macro-arguments -D_DEFAULT_SOURCE -DVERSION=\"${VERSION}\" -DSYSCONFDIR=\"${SYSCONFDIR}\" ${ENABLE_WAYLAND} ${ENABLE_X11}
 DEFAULT_CFLAGS   = -g -std=gnu11 -pedantic -Wall -Wno-overlength-strings -Os ${EXTRA_CFLAGS}
 DEFAULT_LDFLAGS  = -lm -lrt
 

--- a/src/dunst.c
+++ b/src/dunst.c
@@ -305,21 +305,11 @@ void print_version(void)
         printf("Dunst - A customizable and lightweight notification-daemon %s\n", VERSION);
         printf("Compiled on %s with the following options:\n", STR_TO(_CCDATE));
 
-        printf("X11 support %s\nWayland support %s\n",
-#ifdef ENABLE_X11
-                        "enabled",
-#else
-                        "disabled",
-#endif
-#ifdef ENABLE_WAYLAND
-                        "enabled"
-#else
-                        "disabled"
-#endif
-              );
+        printf("X11 support: %s\n", X11_SUPPORT ? "enabled" : "disabled");
+        printf("Wayland support: %s\n", WAYLAND_SUPPORT ? "enabled" : "disabled");
+        printf("SYSCONFDIR set to: %s\n", SYSCONFDIR);
 
-        printf("SYSCONFDIR set to %s\n", SYSCONFDIR);
-        printf("Compile flags: %s\n", STR_TO(_CFLAGS));
+        printf("Compiler flags: %s\n", STR_TO(_CFLAGS));
         printf("Linker flags: %s\n", STR_TO(_LDFLAGS));
         exit(EXIT_SUCCESS);
 }

--- a/src/dunst.c
+++ b/src/dunst.c
@@ -302,9 +302,25 @@ void usage(int exit_status)
 
 void print_version(void)
 {
-        printf
-            ("Dunst - A customizable and lightweight notification-daemon %s\n",
-             VERSION);
+        printf("Dunst - A customizable and lightweight notification-daemon %s\n", VERSION);
+        printf("Compiled on %s with the following options:\n", STR_TO(_CCDATE));
+
+        printf("X11 support %s\nWayland support %s\n",
+#ifdef ENABLE_X11
+                        "enabled",
+#else
+                        "disabled",
+#endif
+#ifdef ENABLE_WAYLAND
+                        "enabled"
+#else
+                        "disabled"
+#endif
+              );
+
+        printf("SYSCONFDIR set to %s\n", SYSCONFDIR);
+        printf("Compile flags: %s\n", STR_TO(_CFLAGS));
+        printf("Linker flags: %s\n", STR_TO(_LDFLAGS));
         exit(EXIT_SUCCESS);
 }
 

--- a/src/output.c
+++ b/src/output.c
@@ -92,7 +92,7 @@ const struct output* get_wl_output(void) {
 const struct output* output_create(bool force_xwayland)
 {
 #ifdef ENABLE_WAYLAND
-        if ((!force_xwayland || WAYLAND_ONLY) && is_running_wayland()) {
+        if ((!force_xwayland || !X11_SUPPORT) && is_running_wayland()) {
                 LOG_I("Using Wayland output");
                 if (force_xwayland)
                         LOG_W("Ignoring force_xwayland setting because X11 output was not compiled");

--- a/src/output.h
+++ b/src/output.h
@@ -51,19 +51,28 @@ struct output {
         double (*get_scale)(void);
 };
 
-#ifndef ENABLE_X11
-#define WAYLAND_ONLY 1
-#ifndef ENABLE_WAYLAND
-#error "You have to compile at least one output (X11, Wayland)"
-#endif
+#ifdef ENABLE_X11
+#define X11_SUPPORT 1
 #else
-#define WAYLAND_ONLY 0
+#define X11_SUPPORT 0
+#endif
+
+#ifdef ENABLE_WAYLAND
+#define WAYLAND_SUPPORT 1
+#else
+#define WAYLAND_SUPPORT 0
+#endif
+
+#if !WAYLAND_SUPPORT && !X11_SUPPORT
+#error "You have to compile at least one output (X11, Wayland)"
 #endif
 
 /**
  * return an initialized output, selecting the correct output type from either
  * wayland or X11 according to the settings and environment.
  * When the wayland output fails to initilize, it falls back to X11 output.
+ *
+ * Either output is skipped if it was not compiled.
  */
 const struct output* output_create(bool force_xwayland);
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -20,6 +20,11 @@
 //! Get a non null string from a possibly null one
 #define STR_NN(s) (s == NULL ? "(null)" : s)
 
+//! Stringify the given expression or macro
+#define STR_TO(...) _STR_TO(__VA_ARGS__)
+#define _STR_TO(...) "" # __VA_ARGS__
+
+
 //! Assert that expr evaluates to true, if not return with val
 #define ASSERT_OR_RET(expr, val) if (!(expr)) return val;
 

--- a/test/draw.c
+++ b/test/draw.c
@@ -19,7 +19,7 @@ const struct screen_info* noop_screen(void) {
 }
 
 const struct output dummy_output = {
-#if WAYLAND_ONLY
+#if !X11_SUPPORT
         wl_init,
         wl_deinit,
 


### PR DESCRIPTION
In retrospect this should have been added before the release, but better later than never...