### PR TITLE
Fix bash completion

### DIFF
--- a/completions/dunst.bashcomp
+++ b/completions/dunst.bashcomp
@@ -5,7 +5,7 @@ _dunst() {
     opts='-v -version --version -verbosity -conf -config -print --print -startup_notification --startup_notification -h -help --help' 
 
     case "$prev" in
-        -verbosity) COMPREPLY=("crit" "warn" "mesg" "info" "debug") 
+        -verbosity) COMPREPLY=( $( compgen -W 'crit warn mesg info debug' -- "$cur") ) 
             return ;;
         -conf|--config) _filedir
             return ;;

--- a/completions/dunstctl.bashcomp
+++ b/completions/dunstctl.bashcomp
@@ -1,28 +1,27 @@
 _dunstctl() {
-    local opts cur prev split=false
+    local opts cur prev
     _get_comp_words_by_ref cur prev
     COMPREPLY=()
     opts='action close close-all context count debug help history history-clear history-pop history-rm is-paused rule rules set-paused'
 
     case "$prev" in
-        count) COMPREPLY=('displayed' 'history' 'waiting')
+        count) COMPREPLY=( $( compgen -W 'displayed history waiting' -- "$cur" ) )
             return ;;
-        set-paused) COMPREPLY=('true' 'false' 'toggle')
+        set-paused) COMPREPLY=( $( compgen -W 'true false toggle' -- "$cur" ) )
             return ;;
         history-pop|history-rm)
-            COMPREPLY=( $(dunstctl history | grep -A2 '"id" :' |
-                          awk '/"data" :/{print $3}' | sort -u) )
+            COMPREPLY=( $( compgen -W "$(dunstctl history | jq -r '.data[][].id.data')" -- "$cur" ) )
             return ;;
         rule)
-            COMPREPLY=( $( compgen -W "$(dunstctl rules --json | jq -r '.data[][].name.data')" -- $cur ) )
+            COMPREPLY=( $( compgen -W "$(dunstctl rules --json | jq -r '.data[][].name.data')" -- "$cur" ) )
             return ;;
         rules)
-            COMPREPLY=( $( compgen -W "--json" ) )
+            COMPREPLY=( $( compgen -W "--json" -- "$cur" ) )
             return ;;
     esac
 
     case "${COMP_WORDS[1]}" in
-        rule) COMPREPLY=('enabled' 'disable' 'toggle')
+        rule) COMPREPLY=( $( compgen -W 'enable disable toggle' -- "$cur" ) )
             return ;;
     esac
 


### PR DESCRIPTION
A completion was not selected even if the match was unique as `compgen -W` has to be used for this.

Also, fix enabling a rule which would've been completed to `enabled`, which is invalid.