### PR TITLE
[RFC] DBus add NotificationListDisplayed

### DIFF
--- a/src/dbus.c
+++ b/src/dbus.c
@@ -83,6 +83,9 @@ static const char *introspection_xml =
     "        <method name=\"NotificationClearHistory\"/>"
     "        <method name=\"NotificationCloseLast\" />"
     "        <method name=\"NotificationCloseAll\"  />"
+    "        <method name=\"NotificationListDisplayed\">"
+    "            <arg direction=\"out\" name=\"notifications\"   type=\"aa{sv}\"/>"
+    "        </method>"
     "        <method name=\"NotificationListHistory\">"
     "            <arg direction=\"out\" name=\"notifications\"   type=\"aa{sv}\"/>"
     "        </method>"
@@ -187,6 +190,7 @@ DBUS_METHOD(dunst_NotificationAction);
 DBUS_METHOD(dunst_NotificationClearHistory);
 DBUS_METHOD(dunst_NotificationCloseAll);
 DBUS_METHOD(dunst_NotificationCloseLast);
+DBUS_METHOD(dunst_NotificationListDisplayed);
 DBUS_METHOD(dunst_NotificationListHistory);
 DBUS_METHOD(dunst_NotificationPopHistory);
 DBUS_METHOD(dunst_NotificationRemoveFromHistory);
@@ -200,6 +204,7 @@ static struct dbus_method methods_dunst[] = {
         {"NotificationClearHistory",            dbus_cb_dunst_NotificationClearHistory},
         {"NotificationCloseAll",                dbus_cb_dunst_NotificationCloseAll},
         {"NotificationCloseLast",               dbus_cb_dunst_NotificationCloseLast},
+        {"NotificationListDisplayed",           dbus_cb_dunst_NotificationListDisplayed},
         {"NotificationListHistory",             dbus_cb_dunst_NotificationListHistory},
         {"NotificationPopHistory",              dbus_cb_dunst_NotificationPopHistory},
         {"NotificationRemoveFromHistory",       dbus_cb_dunst_NotificationRemoveFromHistory},
@@ -379,6 +384,15 @@ static void dbus_answer_queue_entries(GDBusConnection *connection,
 
         g_dbus_method_invocation_return_value(invocation, g_variant_new("(aa{sv})", &builder));
         g_dbus_connection_flush(connection, NULL, NULL, NULL);
+}
+
+static void dbus_cb_dunst_NotificationListDisplayed(GDBusConnection *connection,
+                                           const gchar *sender,
+                                           GVariant *parameters,
+                                           GDBusMethodInvocation *invocation)
+{
+        LOG_D("CMD: Listing all currently displayed notifications");
+        dbus_answer_queue_entries(connection, invocation, queues_length_displayed(), queues_get_displayed());
 }
 
 static void dbus_cb_dunst_NotificationListHistory(GDBusConnection *connection,

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -340,8 +340,7 @@ static void dbus_cb_dunst_NotificationShow(GDBusConnection *connection,
 static void dbus_answer_queue_entries(GDBusConnection *connection,
                                       GDBusMethodInvocation *invocation,
                                       int list_length,
-                                      GList *notification_list
-)
+                                      GList *notification_list)
 {
         GVariantBuilder builder;
         g_variant_builder_init(&builder, G_VARIANT_TYPE("aa{sv}"));

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -332,20 +332,17 @@ static void dbus_cb_dunst_NotificationShow(GDBusConnection *connection,
         g_dbus_connection_flush(connection, NULL, NULL, NULL);
 }
 
-static void dbus_cb_dunst_NotificationListHistory(GDBusConnection *connection,
-                                           const gchar *sender,
-                                           GVariant *parameters,
-                                           GDBusMethodInvocation *invocation)
+static void dbus_answer_queue_entries(GDBusConnection *connection,
+                                      GDBusMethodInvocation *invocation,
+                                      int list_length,
+                                      GList *notification_list
+)
 {
-        LOG_D("CMD: Listing all notifications from history");
-
         GVariantBuilder builder;
         g_variant_builder_init(&builder, G_VARIANT_TYPE("aa{sv}"));
 
-        GList *notification_list = queues_get_history();
-
         // reverse chronological list
-        for(int i = queues_length_history(); i > 0; i--) {
+        for(int i = list_length; i > 0; i--) {
                 struct notification *n;
                 n = g_list_nth_data(notification_list, i-1);
 
@@ -382,6 +379,15 @@ static void dbus_cb_dunst_NotificationListHistory(GDBusConnection *connection,
 
         g_dbus_method_invocation_return_value(invocation, g_variant_new("(aa{sv})", &builder));
         g_dbus_connection_flush(connection, NULL, NULL, NULL);
+}
+
+static void dbus_cb_dunst_NotificationListHistory(GDBusConnection *connection,
+                                           const gchar *sender,
+                                           GVariant *parameters,
+                                           GDBusMethodInvocation *invocation)
+{
+        LOG_D("CMD: Listing all notifications from history");
+        dbus_answer_queue_entries(connection, invocation, queues_length_history(), queues_get_history());
 }
 
 static void dbus_cb_dunst_NotificationPopHistory(GDBusConnection *connection,


### PR DESCRIPTION
A possible implementation to fix #1242.

This way one could e.g. use (fish syntax):
```fish
for id in (busctl --user call org.freedesktop.Notifications /org/freedesktop/Notifications org.dunstproject.cmd0 NotificationListDisplayed -j | jq -r '.data[][] | select(.appname.data == "Spotify") | .id.data')
    busctl --user call org.freedesktop.Notifications /org/freedesktop/Notifications org.freedesktop.Notifications CloseNotification u $id
end
```

To close all currently displayed notifications generated by Spotify.

## TODO (if accepted)

- [ ] add tests
- [ ] add subcommand to dunstctl
- [ ] update completions if needed