### PR TITLE
Fix broken link to freedesktop's notification specs in man page

### DIFF
--- a/docs/dunst.5.pod
+++ b/docs/dunst.5.pod
@@ -832,7 +832,7 @@ The body of the notification
 =item C<category>
 
 The category of the notification as defined by the notification spec. See
-https://specifications.freedesktop.org/notification-spec/latest/ar01s06.html.
+https://specifications.freedesktop.org/notification-spec/latest/categories.html.
 
 =item C<desktop_entry>
 


### PR DESCRIPTION
Fix the broken link in the `man 5 dunst` page (link to the page describing categories in freedesktop's notification specs)
https://specifications.freedesktop.org/notification-spec/latest/ar01s06.html gives a 404 error.
https://specifications.freedesktop.org/notification-spec/latest/categories.html seems to be the correct link