### PR TITLE
CI: Add AppImage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,3 +111,28 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/dunst-project/docker-images:misc-doxygen
+
+  appimage:
+    runs-on: ubuntu-22.04
+    container: alpine:latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: build appimage
+      if: always()
+      run: |
+        apk add wget git build-base patchelf libxscrnsaver-dev libxinerama-dev \
+          libxrandr-dev libnotify-dev dbus-dev wayland-dev perl pango-dev \
+          wayland-protocols dbus librsvg desktop-file-utils
+
+        chmod +x ./AppImage/make-appimage.sh
+        ./AppImage/make-appimage.sh
+
+        mkdir dist
+        mv *.AppImage dist/
+
+    - name: Upload appimage artifact
+      uses: actions/upload-artifact@v4.4.0
+      with:
+        name: AppImage
+        path: 'dist'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,7 +113,7 @@ jobs:
       image: ghcr.io/dunst-project/docker-images:misc-doxygen
 
   appimage:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container: alpine:latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,9 +121,23 @@ jobs:
     - name: build appimage
       if: always()
       run: |
-        apk add wget git build-base patchelf libxscrnsaver-dev libxinerama-dev \
-          libxrandr-dev libnotify-dev dbus-dev wayland-dev perl pango-dev \
-          wayland-protocols dbus librsvg desktop-file-utils
+        apk add \
+          build-base \
+          dbus \
+          dbus-dev \
+          desktop-file-utils \
+          git \
+          libnotify-dev \
+          librsvg \
+          libxinerama-dev \
+          libxrandr-dev \
+          libxscrnsaver-dev \
+          pango-dev \
+          patchelf \
+          perl \
+          wayland-dev \
+          wayland-protocols \
+          wget
 
         chmod +x ./AppImage/make-appimage.sh
         ./AppImage/make-appimage.sh

--- a/AppImage/make-appimage.sh
+++ b/AppImage/make-appimage.sh
@@ -26,31 +26,36 @@ export PATH="$CURRENTDIR/usr/bin:$PATH"
 [ -z "$APPIMAGE" ] && APPIMAGE="$0"
 BIN="${ARGV0#./}"
 unset ARGV0
-case in "${BIN}" in
-    dunst|dunstify)
-        exec "$CURRENTDIR/ld-musl-${ARCH}.so.1" "$CURRENTDIR/usr/bin/$BIN" "$@"
-        ;;
-    dunstctl)
-        exec "$CURRENTDIR/usr/bin/$BIN" "$@"
-        ;;
-    "")
-        echo "AppImage commands:"
-        echo " \"$APPIMAGE dunst\"      runs dunst"
-        echo " \"$APPIMAGE dunstify\"   runs dunstify"
-        echo " \"$APPIMAGE dunstctl\"   runs dunstctl"
-        echo "You can also make and run symlinks to the AppImage with the names"
-        echo "dunstify and dunstctl to launch them automatically without extra args"
-        echo "running dunst..."
-        "${APPIMAGE}" dunst
-        ;;
-    *)
-        echo "AppImage commands:"
-        echo " \"$APPIMAGE dunst\"      runs dunst"
-        echo " \"$APPIMAGE dunstify\"   runs dunstify"
-        echo " \"$APPIMAGE dunstctl\"   runs dunstctl"
-        echo "You can also make and run symlinks to the AppImage with the names"
-        echo "dunstify and dunstctl to launch them automatically without extra args"
-        ;;
+
+case "${BIN}" in
+	dunst|dunstify)
+		exec "$CURRENTDIR/ld-musl-${ARCH}.so.1" "$CURRENTDIR/usr/bin/$BIN" "$@"
+		;;
+	dunstctl)
+		exec "$CURRENTDIR/usr/bin/$BIN" "$@"
+		;;
+	""|*)
+		BIN="$1"
+		case "${BIN}" in
+			dunst|dunstify)
+				shift
+				exec "$CURRENTDIR/ld-musl-${ARCH}.so.1" "$CURRENTDIR/usr/bin/$BIN" "$@"
+				;;
+			dunstctl)
+				shift
+				exec "$CURRENTDIR/usr/bin/$BIN" "$@"
+				;;
+			""|*)
+				echo "AppImage commands:"
+				echo " \"$APPIMAGE dunst\"      runs dunst"
+				echo " \"$APPIMAGE dunstify\"   runs dunstify"
+				echo " \"$APPIMAGE dunstctl\"   runs dunstctl"
+				echo "You can also make and run symlinks to the AppImage with the names"
+				echo "dunstify and dunstctl to launch them automatically without extra args"
+				echo "running dunst..."
+				exec "$CURRENTDIR/ld-musl-${ARCH}.so.1" "$CURRENTDIR/usr/bin/dunst" "$@"
+				;;
+		esac
 esac
 EOF
 chmod +x ./AppRun

--- a/AppImage/make-appimage.sh
+++ b/AppImage/make-appimage.sh
@@ -88,12 +88,12 @@ find ./usr/lib ./usr/bin -type f -exec strip -s -R .comment --strip-unneeded {} 
 
 # Do the thing!
 echo "Generating AppImage..."
-#export VERSION="$(./AppRun --version | awk '{print $(NF-1)}')" # This breaks for some reason?
+export VERSION="$(./AppRun dunst --version | awk 'FNR==1 {print $NF}')" 
 cd ..
 wget -q "$APPIMAGETOOL" -O appimagetool
 chmod +x ./appimagetool
 ./appimagetool --comp zstd \
 	--mksquashfs-opt -Xcompression-level --mksquashfs-opt 22 \
-	-n ./AppDir ./dunst-"$ARCH".AppImage
+	-n ./AppDir ./dunst-"$VERSION"-"$ARCH".AppImage
 ls
 echo "All Done!"

--- a/AppImage/make-appimage.sh
+++ b/AppImage/make-appimage.sh
@@ -7,7 +7,7 @@
 set -e
 export ARCH="$(uname -m)"
 export APPIMAGE_EXTRACT_AND_RUN=1
-APPIMAGETOOL="https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage"
+APPIMAGETOOL="https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-$ARCH.AppImage"
 export COMPLETIONS=0
 
 # BUILD DUNST
@@ -21,6 +21,7 @@ echo "Creating AppRun..."
 cat >> ./AppRun << 'EOF'
 #!/bin/sh
 CURRENTDIR="$(dirname "$(readlink -f "$0")")"
+ARCH="$(uname -m)"
 export PATH="$CURRENTDIR/usr/bin:$PATH"
 [ -z "$APPIMAGE" ] && APPIMAGE="$0"
 BIN="${ARGV0#./}"
@@ -71,10 +72,10 @@ EOF
 echo "Deploying dependencies..."
 mkdir -p ./usr/lib
 ldd ./usr/bin/* | awk -F"[> ]" '{print $4}' | xargs -I {} cp -vf {} ./usr/lib
-if [ -f ./usr/lib/ld-musl-x86_64.so.1 ]; then
-	mv ./usr/lib/ld-musl-x86_64.so.1 ./
+if [ -f ./usr/lib/ld-musl-"$ARCH".so.1 ]; then
+	mv ./usr/lib/ld-musl-"$ARCH".so.1 ./
 else
-	cp /lib/ld-musl-x86_64.so.1 ./
+	cp /lib/ld-musl-"$ARCH".so.1 ./
 fi
 find ./usr/bin -type f -exec patchelf --set-rpath '$ORIGIN/../lib' {} ';'
 find ./usr/lib -type f -exec patchelf --set-rpath '$ORIGIN' {} ';'

--- a/AppImage/make-appimage.sh
+++ b/AppImage/make-appimage.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+
+# This script is meant to be ran on alpine linux, dependencies:
+# wget build-base patchelf libxscrnsaver-dev libxinerama-dev libxrandr-dev libnotify-dev
+# dbus-dev wayland-dev perl pango-dev wayland-protocols dbus librsvg desktop-file-utils
+
+set -e
+export ARCH="$(uname -m)"
+export APPIMAGE_EXTRACT_AND_RUN=1
+APPIMAGETOOL="https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage"
+export COMPLETIONS=0
+
+# BUILD DUNST
+mkdir -p ./AppDir
+make -j$(nproc) PREFIX="$PWD"/AppDir/usr
+make install PREFIX="$PWD"/AppDir/usr
+cd ./AppDir
+
+# AppRun
+echo "Creating AppRun..."
+cat >> ./AppRun << 'EOF'
+#!/bin/sh
+CURRENTDIR="$(dirname "$(readlink -f "$0")")"
+export PATH="$CURRENTDIR/usr/bin:$PATH"
+[ -z "$APPIMAGE" ] && APPIMAGE="$0"
+BIN="${ARGV0#./}"
+unset ARGV0
+if [ -f "$CURRENTDIR/usr/bin/$BIN" ]; then
+	if [ "$BIN" = "dunstctl" ]; then
+		exec "$CURRENTDIR/usr/bin/$BIN" "$@"
+	else
+		exec "$CURRENTDIR/ld-musl-x86_64.so.1" "$CURRENTDIR/usr/bin/$BIN" "$@"
+	fi
+elif [ "$1" = "--notify" ]; then
+	shift
+	exec "$CURRENTDIR/ld-musl-x86_64.so.1" "$CURRENTDIR"/usr/bin/dunstify "$@"
+elif [ "$1" = "--ctl" ]; then
+	shift
+	exec "$CURRENTDIR"/usr/bin/dunstctl "$@"
+else
+	if [ -z "$1" ]; then
+		echo "AppImage commands:"
+		echo " \"$APPIMAGE\"            runs dunst"
+		echo " \"$APPIMAGE --notify\"   runs dunstify"
+		echo " \"$APPIMAGE --ctl\"      runs dunstctl"
+		echo "You can also make and run symlinks to the AppImage with the names"
+		echo "dunstify and dunstctl to launch them automatically without extra args"
+		echo "running dunst..."
+	fi
+	exec "$CURRENTDIR/ld-musl-x86_64.so.1" "$CURRENTDIR/usr/bin/dunst" "$@"
+fi
+EOF
+chmod +x ./AppRun
+
+# Dummy Icon & Desktop
+echo "Placing .desktop and icon..."
+touch ./dunst.png && ln -s ./dunst.png ./.DirIcon # No official icon?
+cat >> ./dunst.desktop << 'EOF' # No official .desktop?
+[Desktop Entry]
+Type=Application
+Name=dunst
+Icon=dunst
+Exec=dunst
+Categories=System
+Hidden=true
+EOF
+
+# DEPLOY ALL LIBS
+echo "Deploying dependencies..."
+mkdir -p ./usr/lib
+ldd ./usr/bin/* | awk -F"[> ]" '{print $4}' | xargs -I {} cp -vf {} ./usr/lib
+if [ -f ./usr/lib/ld-musl-x86_64.so.1 ]; then
+	mv ./usr/lib/ld-musl-x86_64.so.1 ./
+else
+	cp /lib/ld-musl-x86_64.so.1 ./
+fi
+find ./usr/bin -type f -exec patchelf --set-rpath '$ORIGIN/../lib' {} ';'
+find ./usr/lib -type f -exec patchelf --set-rpath '$ORIGIN' {} ';'
+find ./usr/lib ./usr/bin -type f -exec strip -s -R .comment --strip-unneeded {} ';'
+
+# Do the thing!
+echo "Generating AppImage..."
+#export VERSION="$(./AppRun --version | awk '{print $(NF-1)}')" # This breaks for some reason?
+cd ..
+wget -q "$APPIMAGETOOL" -O appimagetool
+chmod +x ./appimagetool
+./appimagetool --comp zstd \
+	--mksquashfs-opt -Xcompression-level --mksquashfs-opt 22 \
+	-n ./AppDir ./dunst-"$ARCH".AppImage
+ls
+echo "All Done!"

--- a/AppImage/make-appimage.sh
+++ b/AppImage/make-appimage.sh
@@ -25,30 +25,32 @@ export PATH="$CURRENTDIR/usr/bin:$PATH"
 [ -z "$APPIMAGE" ] && APPIMAGE="$0"
 BIN="${ARGV0#./}"
 unset ARGV0
-if [ -f "$CURRENTDIR/usr/bin/$BIN" ]; then
-	if [ "$BIN" = "dunstctl" ]; then
-		exec "$CURRENTDIR/usr/bin/$BIN" "$@"
-	else
-		exec "$CURRENTDIR/ld-musl-x86_64.so.1" "$CURRENTDIR/usr/bin/$BIN" "$@"
-	fi
-elif [ "$1" = "--notify" ]; then
-	shift
-	exec "$CURRENTDIR/ld-musl-x86_64.so.1" "$CURRENTDIR"/usr/bin/dunstify "$@"
-elif [ "$1" = "--ctl" ]; then
-	shift
-	exec "$CURRENTDIR"/usr/bin/dunstctl "$@"
-else
-	if [ -z "$1" ]; then
-		echo "AppImage commands:"
-		echo " \"$APPIMAGE\"            runs dunst"
-		echo " \"$APPIMAGE --notify\"   runs dunstify"
-		echo " \"$APPIMAGE --ctl\"      runs dunstctl"
-		echo "You can also make and run symlinks to the AppImage with the names"
-		echo "dunstify and dunstctl to launch them automatically without extra args"
-		echo "running dunst..."
-	fi
-	exec "$CURRENTDIR/ld-musl-x86_64.so.1" "$CURRENTDIR/usr/bin/dunst" "$@"
-fi
+case in "${BIN}" in
+    dunst|dunstify)
+        exec "$CURRENTDIR/ld-musl-${ARCH}.so.1" "$CURRENTDIR/usr/bin/$BIN" "$@"
+        ;;
+    dunstctl)
+        exec "$CURRENTDIR/usr/bin/$BIN" "$@"
+        ;;
+    "")
+        echo "AppImage commands:"
+        echo " \"$APPIMAGE dunst\"      runs dunst"
+        echo " \"$APPIMAGE dunstify\"   runs dunstify"
+        echo " \"$APPIMAGE dunstctl\"   runs dunstctl"
+        echo "You can also make and run symlinks to the AppImage with the names"
+        echo "dunstify and dunstctl to launch them automatically without extra args"
+        echo "running dunst..."
+        "${APPIMAGE}" dunst
+        ;;
+    *)
+        echo "AppImage commands:"
+        echo " \"$APPIMAGE dunst\"      runs dunst"
+        echo " \"$APPIMAGE dunstify\"   runs dunstify"
+        echo " \"$APPIMAGE dunstctl\"   runs dunstctl"
+        echo "You can also make and run symlinks to the AppImage with the names"
+        echo "dunstify and dunstctl to launch them automatically without extra args"
+        ;;
+esac
 EOF
 chmod +x ./AppRun
 


### PR DESCRIPTION
This PR introduces the generation of an AppImage.

[Some context here](https://github.com/dunst-project/dunst/issues/432#issuecomment-2451563613)

The produced appimage uses the static appimage runtime and bundles all the libraries and its own ld-musl.so, so it should work on any linux system from the last 15 years.

 Also I'm creating some dummy icon and .desktop entry, it would be nice if dunst gets its official .desktop and icon.
 
 -------------------------------------------
 
 ~~Also while the AppImage that I produce from the [last stable build](https://github.com/Samueru-sama/dunst-AppImage/releases/tag/continuous) works perfectly, I just tested the one produced [here](https://github.com/Samueru-sama/dunst/actions/runs/11643737551/artifacts/2136476536) which is a git build and it does have some issues finding the icons? and also the notification window is bigger for some reason, not sure if this is a known issue or an issue that would only affect the appimage for recent builds?~~ UPDATE: Fixed

