### PR TITLE
Place dunst.service in session.slice

### DIFF
--- a/dunst.systemd.service.in
+++ b/dunst.systemd.service.in
@@ -7,3 +7,4 @@ PartOf=graphical-session.target
 Type=dbus
 BusName=org.freedesktop.Notifications
 ExecStart=##PREFIX##/bin/dunst
+Slice=session.slice


### PR DESCRIPTION
By default, systemd would place it in `app.slice` which doesn't make sense; that's where apps go, not daemons that are part of the desktop session.

`session.slice` makes a lot more sense for a daemon that's part of the desktop session.

Related: https://github.com/flatpak/xdg-desktop-portal-gtk/pull/504