### PR TITLE
Add backward compatibility for height + notice

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -479,4 +479,14 @@ void add_paths_from_env(GPtrArray *arr, char *env_name, char *subdir, char *alte
         g_strfreev(xdg_data_dirs_arr);
 }
 
+bool string_is_int(const char *str) {
+        if (str != NULL) {
+                while (isspace(*str)) str++;
+                while (isdigit(*str)) str++;
+                while (isspace(*str)) str++;
+                return *str == '\0';
+        }
+        return true;
+}
+
 /* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/utils.h
+++ b/src/utils.h
@@ -253,5 +253,8 @@ FILE * fopen_verbose(const char * const path);
  * when the environment variable doesn't exits.
  */
 void add_paths_from_env(GPtrArray *arr, char *env_name, char *subdir, char *alternative);
+
+bool string_is_int(const char *str);
+
 #endif
 /* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */


### PR DESCRIPTION
As solicited by @stapelberg in the discussions this will be a (temporary) solution for backward compatibility of `height`.
This will *not* make it into v2, but for now is fine.
I will need to release a 1.12.1 anyway due to the graphical bug #1406 