### PR TITLE
Change type of bool to gboolean

### DIFF
--- a/src/rules.h
+++ b/src/rules.h
@@ -56,7 +56,7 @@ struct rule {
         char *format;
         char *script;
         enum behavior_fullscreen fullscreen;
-        bool enabled;
+        gboolean enabled;
         int progress_bar_alignment;
         char *set_stack_tag; // this has to be the last modifying rule
 };

--- a/test/dbus.c
+++ b/test/dbus.c
@@ -639,7 +639,7 @@ TEST test_dbus_cb_dunst_RuleList(void)
         g_variant_dict_init(&d, dict);
 
         char *str;
-        bool boolean;
+        gboolean boolean;
 
         ASSERT(g_variant_dict_lookup(&d, "name", "s", &str));
         ASSERT_STR_EQ("testing RuleList", str);


### PR DESCRIPTION
`bool` and `gboolean` are not exactly the same type, they only evaluate to the same value in C on little endian architectures but evaluate differently on big endian. This causes issues on e.g. s390x as described in #1421

This fixes https://github.com/dunst-project/dunst/issues/1421