### PR TITLE
Add tests for additions in #1426

### DIFF
--- a/test/dbus.c
+++ b/test/dbus.c
@@ -529,6 +529,7 @@ TEST test_dbus_cb_dunst_NotificationListHistory(void)
         n->appname = g_strdup("dunstify");
         n->summary = g_strdup("Testing");
         n->urgency = 2;
+        n->stack_tag = g_strdup("test-stack-tag");
         const char *urgency1 = notification_urgency_to_string(n->urgency);
         queues_history_push(n);
 
@@ -537,6 +538,7 @@ TEST test_dbus_cb_dunst_NotificationListHistory(void)
         n->appname = g_strdup("notify-send");
         n->summary = g_strdup("More testing");
         n->urgency = 0;
+        n->stack_tag = g_strdup("test-stack-tag");
         const char *urgency2 = notification_urgency_to_string(n->urgency);
         queues_history_push(n);
 
@@ -573,6 +575,10 @@ TEST test_dbus_cb_dunst_NotificationListHistory(void)
         ASSERT_STR_EQ(urgency2, str);
         g_free(str);
 
+        ASSERT(g_variant_dict_lookup(&d, "stack_tag", "s", &str));
+        ASSERT_STR_EQ("test-stack-tag", str);
+        g_free(str);
+
         g_variant_unref(dict);
         dict = g_variant_iter_next_value(&array_iter);
         g_variant_dict_clear(&d);
@@ -591,6 +597,10 @@ TEST test_dbus_cb_dunst_NotificationListHistory(void)
 
         ASSERT(g_variant_dict_lookup(&d, "urgency", "s", &str));
         ASSERT_STR_EQ(urgency1, str);
+        g_free(str);
+
+        ASSERT(g_variant_dict_lookup(&d, "stack_tag", "s", &str));
+        ASSERT_STR_EQ("test-stack-tag", str);
         g_free(str);
 
         g_variant_dict_clear(&d);

--- a/test/dbus.c
+++ b/test/dbus.c
@@ -530,6 +530,7 @@ TEST test_dbus_cb_dunst_NotificationListHistory(void)
         n->summary = g_strdup("Testing");
         n->urgency = 2;
         n->stack_tag = g_strdup("test-stack-tag");
+        n->urls = g_strdup("https://dunst-project.org/");
         const char *urgency1 = notification_urgency_to_string(n->urgency);
         queues_history_push(n);
 
@@ -539,6 +540,7 @@ TEST test_dbus_cb_dunst_NotificationListHistory(void)
         n->summary = g_strdup("More testing");
         n->urgency = 0;
         n->stack_tag = g_strdup("test-stack-tag");
+        n->urls = g_strdup("https://dunst-project.org/");
         const char *urgency2 = notification_urgency_to_string(n->urgency);
         queues_history_push(n);
 
@@ -579,6 +581,10 @@ TEST test_dbus_cb_dunst_NotificationListHistory(void)
         ASSERT_STR_EQ("test-stack-tag", str);
         g_free(str);
 
+        ASSERT(g_variant_dict_lookup(&d, "urls", "s", &str));
+        ASSERT_STR_EQ("https://dunst-project.org/", str);
+        g_free(str);
+
         g_variant_unref(dict);
         dict = g_variant_iter_next_value(&array_iter);
         g_variant_dict_clear(&d);
@@ -601,6 +607,10 @@ TEST test_dbus_cb_dunst_NotificationListHistory(void)
 
         ASSERT(g_variant_dict_lookup(&d, "stack_tag", "s", &str));
         ASSERT_STR_EQ("test-stack-tag", str);
+        g_free(str);
+
+        ASSERT(g_variant_dict_lookup(&d, "urls", "s", &str));
+        ASSERT_STR_EQ("https://dunst-project.org/", str);
         g_free(str);
 
         g_variant_dict_clear(&d);

--- a/test/dbus.c
+++ b/test/dbus.c
@@ -528,12 +528,16 @@ TEST test_dbus_cb_dunst_NotificationListHistory(void)
         gint64 timestamp1 = n->timestamp;
         n->appname = g_strdup("dunstify");
         n->summary = g_strdup("Testing");
+        n->urgency = 2;
+        const char *urgency1 = notification_urgency_to_string(n->urgency);
         queues_history_push(n);
 
         n = notification_create();
         gint64 timestamp2 = n->timestamp;
         n->appname = g_strdup("notify-send");
         n->summary = g_strdup("More testing");
+        n->urgency = 0;
+        const char *urgency2 = notification_urgency_to_string(n->urgency);
         queues_history_push(n);
 
         GVariant *result = dbus_invoke_ifac("NotificationListHistory", NULL, DUNST_IFAC);
@@ -565,6 +569,10 @@ TEST test_dbus_cb_dunst_NotificationListHistory(void)
         ASSERT(g_variant_dict_lookup(&d, "timestamp", "x", &int64));
         ASSERT_EQ(timestamp2, int64);
 
+        ASSERT(g_variant_dict_lookup(&d, "urgency", "s", &str));
+        ASSERT_STR_EQ(urgency2, str);
+        g_free(str);
+
         g_variant_unref(dict);
         dict = g_variant_iter_next_value(&array_iter);
         g_variant_dict_clear(&d);
@@ -580,6 +588,10 @@ TEST test_dbus_cb_dunst_NotificationListHistory(void)
 
         ASSERT(g_variant_dict_lookup(&d, "timestamp", "x", &int64));
         ASSERT_EQ(timestamp1, int64);
+
+        ASSERT(g_variant_dict_lookup(&d, "urgency", "s", &str));
+        ASSERT_STR_EQ(urgency1, str);
+        g_free(str);
 
         g_variant_dict_clear(&d);
         g_variant_unref(dict);


### PR DESCRIPTION
Self-explanatory; added three assertions to test for values for the properties `urgency`, `stack_tag`, and `urls` are being outputted via `dunstctl history`