### PR TITLE
makefile: add version variable quotes in git case

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ include config.mk
 
 VERSION := "1.13.0-non-git"
 ifneq ($(wildcard ./.git/),)
-VERSION := $(shell ${GIT} describe --tags 2>/dev/null || echo ${VERSION})
+VERSION := "$(shell ${GIT} describe --tags 2>/dev/null || echo ${VERSION})"
 endif
 
 SYSTEMD ?= $(shell $(PKG_CONFIG) --silence-errors ${SYSTEMDAEMON} || echo 0)


### PR DESCRIPTION
Add quotes to the VERSION variable, when they are determined by invoking git. git describe doesn't seem to output spaces. But the fallback case of just echoing the VERSION variable may contain spaces, as every release includes a space separated release date in the version variable.

This fixes the issue that if the .git directory is present on a release, but the git command isn't available or fails, the VERSION variable isn't escaped anymore and the release date contained causes a build failure.