### PR TITLE
filter prefix maps from the embedded build flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ else
 endif
 src/dunst.o: src/dunst.c
 	${CC} -o $@ -c $< ${CPPFLAGS} ${CFLAGS} \
-		-D_CCDATE="${BUILD_DATE}" -D_CFLAGS="$(filter-out $(filter -I%,${INCS}),${CFLAGS})" -D_LDFLAGS="${LDFLAGS}"
+		-D_CCDATE="${BUILD_DATE}" -D_CFLAGS="$(filter-out $(filter -I%,${INCS}) -fdebug-prefix-map% -fmacro-prefix-map% -ffile-prefix-map%,${CFLAGS})" -D_LDFLAGS="$(filter-out -fdebug-prefix-map% -fmacro-prefix-map% -ffile-prefix-map%,${LDFLAGS})"
 
 %.o: %.c
 	${CC} -o $@ -c $< ${CPPFLAGS} ${CFLAGS}


### PR DESCRIPTION
To aid reproducible compilation there exist three compiler/linker commands to map build time dependent paths to generic paths: -fdebug-prefix-map, -fmacro-prefix-map and -ffile-prefix-map These allow compilations from different paths to generate the same paths in the resulting executable.

Including these flags in the executable defeats the purpose of leaking build paths into the executable. Therefore just filter them out.