### PR TITLE
Add an .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,55 @@
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 8
+tab_width = 8
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[docs/*.pod]
+indent_size = 4
+
+[*.awk]
+indent_size = 4
+
+[{test/greatest.h,test/functional-tests/test.sh,contrib/notification-history.sh,contrib/dunst_xr_theme_changer.sh}]
+indent_size = 4
+
+[dunstrc*]
+indent_size = 4
+
+# Just for historical purposes to avoid
+# manually reformatting whole files
+[src/wayland/pool-buffer.*]
+indent_style = tab
+
+# looks to be external code
+[src/wayland/libgwater-wayland.*]
+indent_size = 4
+
+[completions/*]
+indent_size = 4
+
+[.valgrind.suppressions]
+indent_size = 3
+
+[*.yml]
+indent_size = 2
+
+[completions/*.zshcomp]
+indent_size = 2
+
+[{Makefile,dunstctl,test/data/test-ini}]
+indent_style = tab
+
+[test/functional-tests/dunstrc.vertical_align]
+indent_style =
+
+# Contains external or generated files
+[src/wayland/protocols/**]
+indent_style =
+trim_trailing_whitespace = false

--- a/.editorconfig-checker.json
+++ b/.editorconfig-checker.json
@@ -1,0 +1,6 @@
+{
+        "SpacesAfterTabs": true,
+        "Disable": {
+                "IndentSize": true
+        }
+}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,3 +112,14 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/dunst-project/docker-images:misc-doxygen
+
+  editorconfig:
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: editorconfig-checker/action-editorconfig-checker@main
+
+      - name: Check code matching .editorconfig rules with editorconfig-checker
+        run: editorconfig-checker
+
+    runs-on: ubuntu-latest

--- a/HACKING.md
+++ b/HACKING.md
@@ -77,11 +77,11 @@ documentation for this can be found at https://github.com/dunst-project/docker-i
 # Comments
 
 - Comment system is held similar to JavaDoc
-    - Use `@param` to describe all input parameters
-    - Use `@return` to describe the output value
-    - Use `@retval` to describe special return values (like `NULL`)
-    - Documentation comments should start with a double star (`/**`)
-    - Append `()` to function names and prepend variables with `#` to properly reference them in the docs
+        - Use `@param` to describe all input parameters
+        - Use `@return` to describe the output value
+        - Use `@retval` to describe special return values (like `NULL`)
+        - Documentation comments should start with a double star (`/**`)
+        - Append `()` to function names and prepend variables with `#` to properly reference them in the docs
 - Add comments to all functions and methods
 - Markdown inside the comments is allowed and also desired
 - Add the comments to the prototype. Doxygen will merge the protoype and implementation documentation anyways.
@@ -104,21 +104,21 @@ documentation for this can be found at https://github.com/dunst-project/docker-i
 For logging, there are printf-like macros `LOG_(E|C|W|M|I|D)`.
 
 - `LOG_E` (ERROR):
-    - All messages, which lead to immediate abort and are caused by a programming error. The program needs patching and the error is not user recoverable.
-    - e.g.: Switching over an enum, `LOG_E` would go into the default case.
+        - All messages, which lead to immediate abort and are caused by a programming error. The program needs patching and the error is not user recoverable.
+        - e.g.: Switching over an enum, `LOG_E` would go into the default case.
 - `LOG_C` (CRITICAL):
-    - The program cannot continue to work. It is used in the wrong manner or some outer conditions are not met.
-    - e.g.: `-config` parameter value is unreadable file
+        - The program cannot continue to work. It is used in the wrong manner or some outer conditions are not met.
+        - e.g.: `-config` parameter value is unreadable file
 - `DIE` (CRITICAL):
-    - A shorthand for `LOG_C` and terminating the program after. This does not dump the core (unlike `LOG_E`).
+        - A shorthand for `LOG_C` and terminating the program after. This does not dump the core (unlike `LOG_E`).
 - `LOG_W` (WARNING):
-    - Something is not in shape, but it's recoverable.
-    - e.g.: A value is not parsable in the config file, which will default.
+        - Something is not in shape, but it's recoverable.
+        - e.g.: A value is not parsable in the config file, which will default.
 - `LOG_M` (MESSAGE):
-    - Important info, which informs about the state.
-    - e.g.: An empty notification does get removed immediately.
+        - Important info, which informs about the state.
+        - e.g.: An empty notification does get removed immediately.
 - `LOG_I` (INFO):
-    - Mostly unneccessary info, but important to debug (as the user) some use cases.
-    - e.g.: print the notification contents after arriving
+        - Mostly unneccessary info, but important to debug (as the user) some use cases.
+        - e.g.: print the notification contents after arriving
 - `LOG_D` (DEBUG):
-    - Only important during development or tracing some bugs (as the developer).
+        - Only important during development or tracing some bugs (as the developer).

--- a/Makefile
+++ b/Makefile
@@ -76,9 +76,9 @@ ${OBJ} ${TEST_OBJ}: Makefile config.mk
 
 DATE_FMT = +%Y-%m-%d
 ifdef SOURCE_DATE_EPOCH
-    BUILD_DATE ?= $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u "$(DATE_FMT)")
+	BUILD_DATE ?= $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u "$(DATE_FMT)")
 else
-    BUILD_DATE ?= $(shell date "$(DATE_FMT)")
+	BUILD_DATE ?= $(shell date "$(DATE_FMT)")
 endif
 src/dunst.o: src/dunst.c
 	${CC} -o $@ -c $< ${CPPFLAGS} ${CFLAGS} \
@@ -224,10 +224,10 @@ clean-wayland-protocols:
 	rm -f src/wayland/protocols/*.h
 
 .PHONY: install install-dunst install-dunstctl install-dunstrc \
-        install-service install-service-dbus install-service-systemd \
-        uninstall uninstall-dunstctl uninstall-dunstrc \
-        uninstall-service uninstall-service-dbus uninstall-service-systemd \
-        uninstall-keepconf uninstall-purge
+	install-service install-service-dbus install-service-systemd \
+	uninstall uninstall-dunstctl uninstall-dunstrc \
+	uninstall-service uninstall-service-dbus uninstall-service-systemd \
+	uninstall-keepconf uninstall-purge
 install: install-dunst install-dunstctl install-dunstrc install-service
 
 install-dunst: dunst doc

--- a/completions/_dunstctl.zshcomp
+++ b/completions/_dunstctl.zshcomp
@@ -71,10 +71,10 @@ case $state in
         ;;
 
       history-pop)
-         local -a history_ids;
-         history_ids=(
-           `dunstctl history | jq -M '.data[0][].id.data'`
-         )
+        local -a history_ids;
+        history_ids=(
+          `dunstctl history | jq -M '.data[0][].id.data'`
+        )
         _describe history_ids history_ids && ret=0
         ;;
 

--- a/completions/dunst.bashcomp
+++ b/completions/dunst.bashcomp
@@ -2,10 +2,10 @@ _dunst() {
     local opts cur prev split=false
     _get_comp_words_by_ref cur prev
     COMPREPLY=()
-    opts='-v -version --version -verbosity -conf -config -print --print -startup_notification --startup_notification -h -help --help' 
+    opts='-v -version --version -verbosity -conf -config -print --print -startup_notification --startup_notification -h -help --help'
 
     case "$prev" in
-        -verbosity) COMPREPLY=( $( compgen -W 'crit warn mesg info debug' -- "$cur") ) 
+        -verbosity) COMPREPLY=( $( compgen -W 'crit warn mesg info debug' -- "$cur") )
             return ;;
         -conf|--config) _filedir
             return ;;

--- a/contrib/notification-history.sh
+++ b/contrib/notification-history.sh
@@ -10,7 +10,7 @@ tests() {
 history_json="$(dunstctl history)"
 history_items="$(printf '%s' "$history_json" | jq -r '.data[0][] | .appname.data , (.timestamp.data | tostring) , .summary.data | gsub("[\\n]"; "\\n")')" # the gsub is to really ensure no escaped new lines in the data lead us to print new lines. New lines in data have to be escaped. (Because) Actual newlines are the field separator essential to the logic of the while loop below, and rofi further down.
 
-#history_items ends up looking like arrays with an order with this meaning: 
+#history_items ends up looking like arrays with an order with this meaning:
 #appname (newline) timestamp (newline) summary (newline)
 #
 #NetworkManager

--- a/docs/dunst.1.pod.in
+++ b/docs/dunst.1.pod.in
@@ -111,11 +111,11 @@ See dunst(5) for the list of accepted hints.
 
 Some examples:
 
-	notify-send -h string:fgcolor:#ff4444
+    notify-send -h string:fgcolor:#ff4444
 
-	notify-send -h string:bgcolor:#4444ff -h string:fgcolor:#ff4444 -h string:frcolor:#44ff44
+    notify-send -h string:bgcolor:#4444ff -h string:fgcolor:#ff4444 -h string:frcolor:#44ff44
 
-	notify-send -h int:value:42 "Working ..."
+    notify-send -h int:value:42 "Working ..."
 
 =head1 MISCELLANEOUS
 

--- a/docs/dunst.5.pod
+++ b/docs/dunst.5.pod
@@ -1122,7 +1122,7 @@ You may also specify a transparency component by using the format #RGBA or #RRGG
 B<NOTE>: '#' is interpreted as a comment, to use it the entire value needs to be quoted.
 For example:
 
-	separator_color="#123456"
+    separator_color="#123456"
 
 =head1 NOTIFY-SEND HINTS
 
@@ -1183,11 +1183,11 @@ The transient value.
 
 Some examples:
 
-	notify-send -h string:fgcolor:#ff4444
+    notify-send -h string:fgcolor:#ff4444
 
-	notify-send -h string:bgcolor:#4444ff -h string:fgcolor:#ff4444 -h string:frcolor:#44ff44
+    notify-send -h string:bgcolor:#4444ff -h string:fgcolor:#ff4444 -h string:frcolor:#44ff44
 
-	notify-send -h int:value:42 "Working ..."
+    notify-send -h int:value:42 "Working ..."
 
 =head1 ACTIONS
 

--- a/src/input.h
+++ b/src/input.h
@@ -5,7 +5,7 @@
 
 /**
  * Handle incoming mouse click events
- * 
+ *
  * @param button code, A linux input event code
  * @param button_down State of the button
  * @param mouse_x X-position of the mouse, relative to the window
@@ -13,6 +13,6 @@
  *
  */
 void input_handle_click(unsigned int button, bool button_down, int mouse_x, int mouse_y);
-        
+
 #endif
 /* vim: set ft=c tabstop=8 shiftwidth=8 expandtab textwidth=0: */

--- a/src/settings.h
+++ b/src/settings.h
@@ -40,32 +40,32 @@ enum mouse_action { MOUSE_NONE, MOUSE_DO_ACTION, MOUSE_CLOSE_CURRENT,
 #define ZWLR_LAYER_SHELL_V1_LAYER_ENUM
 // Needed for compiling without wayland dependency
 enum zwlr_layer_shell_v1_layer {
-	ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND = 0,
-	ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM = 1,
-	ZWLR_LAYER_SHELL_V1_LAYER_TOP = 2,
-	ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY = 3,
+        ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND = 0,
+        ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM = 1,
+        ZWLR_LAYER_SHELL_V1_LAYER_TOP = 2,
+        ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY = 3,
 };
 #endif /* ZWLR_LAYER_SHELL_V1_LAYER_ENUM */
 
 #ifndef ZWLR_LAYER_SURFACE_V1_ANCHOR_ENUM
 #define ZWLR_LAYER_SURFACE_V1_ANCHOR_ENUM
 enum zwlr_layer_surface_v1_anchor {
-	/**
-	 * the top edge of the anchor rectangle
-	 */
-	ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP = 1,
-	/**
-	 * the bottom edge of the anchor rectangle
-	 */
-	ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM = 2,
-	/**
-	 * the left edge of the anchor rectangle
-	 */
-	ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT = 4,
-	/**
-	 * the right edge of the anchor rectangle
-	 */
-	ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT = 8,
+        /**
+         * the top edge of the anchor rectangle
+         */
+        ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP = 1,
+        /**
+         * the bottom edge of the anchor rectangle
+         */
+        ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM = 2,
+        /**
+         * the left edge of the anchor rectangle
+         */
+        ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT = 4,
+        /**
+         * the right edge of the anchor rectangle
+         */
+        ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT = 8,
 };
 #endif /* ZWLR_LAYER_SURFACE_V1_ANCHOR_ENUM */
 

--- a/src/wayland/wl.c
+++ b/src/wayland/wl.c
@@ -684,7 +684,7 @@ bool wl_have_fullscreen_window(void) {
                 output_name = current_output->global_name;
 
         struct toplevel_v1 *toplevel;
-	wl_list_for_each(toplevel, &toplevel_list, link) {
+        wl_list_for_each(toplevel, &toplevel_list, link) {
                 if (!(toplevel->current.state & TOPLEVEL_STATE_FULLSCREEN &&
                                         toplevel->current.state &
                                         TOPLEVEL_STATE_ACTIVATED))

--- a/test/draw.c
+++ b/test/draw.c
@@ -77,8 +77,8 @@ struct length get_small_max_height(void)
         // by notification content
         // future tests targeting dynamic sizing logic could be added
         // to address this limitation
-		struct length height = { 0, 10 };
-		return height;
+        struct length height = { 0, 10 };
+        return height;
 }
 
 int get_expected_dimension_height(int layout_count, int height)
@@ -293,7 +293,7 @@ TEST test_calculate_dimensions_height_min(void)
 {
         struct length original_height = settings.height;
         bool orginal_gap_size = settings.gap_size;
-		// NOTE: Should be big enough to fit the notification nicely
+        // NOTE: Should be big enough to fit the notification nicely
         settings.height.min = 100;
         settings.height.max = 200;
         settings.gap_size = 0;

--- a/test/functional-tests/test.sh
+++ b/test/functional-tests/test.sh
@@ -16,8 +16,8 @@ function keypress {
 }
 
 function tmp_dunstrc {
-        cp "$TESTDIR/$1" "$TESTDIR/dunstrc.tmp"
-        echo -e "\n$2" >> "$TESTDIR/dunstrc.tmp"
+    cp "$TESTDIR/$1" "$TESTDIR/dunstrc.tmp"
+    echo -e "\n$2" >> "$TESTDIR/dunstrc.tmp"
 }
 
 function tmp_clean {
@@ -25,9 +25,9 @@ function tmp_clean {
 }
 
 function start_dunst {
-        killall dunst 2>/dev/null
-        $DUNST -config "$TESTDIR/$1" &
-        sleep 0.05
+    killall dunst 2>/dev/null
+    $DUNST -config "$TESTDIR/$1" &
+    sleep 0.05
 }
 
 function basic_notifications {

--- a/test/test-install.sh
+++ b/test/test-install.sh
@@ -14,12 +14,12 @@ export SERVICEDIR_SYSTEMD="/systemd"
 export SERVICEDIR_DBUS="/dbus"
 
 do_make() {  # for convenience/conciseness
-	make -C "${BASE}" "$@"
+        make -C "${BASE}" "$@"
 }
 
 check_dest() {
-	# Check file list given on stdin and see if all are actually present
-	diff -u <(find "${DESTDIR}" -type f -printf "%P\n" | sort) <(sort -)
+        # Check file list given on stdin and see if all are actually present
+        diff -u <(find "${DESTDIR}" -type f -printf "%P\n" | sort) <(sort -)
 }
 
 do_make install


### PR DESCRIPTION
Add an `.editorconfig` mostly trying to match the current styles used in the repository. Consistently indented inconsistent files and moved relevant source files to use spaces instead of tabs. Added necessary checking to the CI using `editorconfig-checker`. As it doesn't support "fancy indentations" (e.g. align arguments), the indentation check was disabled.

Fixes #1455 