### PR TITLE
output: die instead of dumping core with no X11 output

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -67,7 +67,7 @@ const struct output* get_x11_output(void) {
         if (output->init()) {
                 return output;
         } else {
-                LOG_E("Couldn't initialize X11 output. Aborting...");
+                DIE("Couldn't initialize X11 output. Aborting...");
         }
 }
 #endif


### PR DESCRIPTION
Fixes #1134. Makes it consistent with the wayland output (which will also die when it can't be found) and removes the noise caused by dumping core.