### PR TITLE
Fix a Use-After-Free issue

### DIFF
--- a/src/dbus.c
+++ b/src/dbus.c
@@ -628,16 +628,16 @@ static void dbus_cb_dunst_RuleEnable(GDBusConnection *connection,
         }
 
         struct rule *target_rule = get_rule(name);
-        g_free(name);
-
         if (target_rule == NULL) {
                 g_dbus_method_invocation_return_error(invocation,
                         G_DBUS_ERROR,
                         G_DBUS_ERROR_INVALID_ARGS,
                         "There is no rule named \"%s\"",
                         name);
+                g_free(name);
                 return;
         }
+        g_free(name);
 
         if (state == 0)
                 target_rule->enabled = false;


### PR DESCRIPTION
Hello!

We are casually auditing some open-source projects we are using and we found this straightforward use-after-free vulnerability.

When a `get_rule` fails and returns `NULL`, the `name` is free()-ed (line 631) but soon reused for logging (line 638), which is dangerous. This patch fixes this by always free-ing the variable only if it is no longer used.  Even if `get_rule` will unlikely fail at this moment, this patch enhances the code to avoid potential misuse in the future.

Thanks for the brilliant project anyway!