### PR TITLE
Ensure PropertiesChanged signal is sent when handling SIGUSR*

### DIFF
--- a/src/dbus.c
+++ b/src/dbus.c
@@ -113,9 +113,17 @@ static const char *introspection_xml =
     "            <annotation name=\"org.freedesktop.DBus.Property.EmitsChangedSignal\" value=\"true\"/>"
     "        </property>"
 
-    "        <property name=\"displayedLength\" type=\"u\" access=\"read\" />"
-    "        <property name=\"historyLength\" type=\"u\" access=\"read\" />"
-    "        <property name=\"waitingLength\" type=\"u\" access=\"read\" />"
+    "        <property name=\"displayedLength\" type=\"u\" access=\"read\">"
+    "            <annotation name=\"org.freedesktop.DBus.Property.EmitsChangedSignal\" value=\"true\"/>"
+    "        </property>"
+    "        <property name=\"historyLength\" type=\"u\" access=\"read\">"
+    "            <annotation name=\"org.freedesktop.DBus.Property.EmitsChangedSignal\" value=\"true\"/>"
+    "        </property>"
+
+    "        <property name=\"waitingLength\" type=\"u\" access=\"read\">"
+    "            <annotation name=\"org.freedesktop.DBus.Property.EmitsChangedSignal\" value=\"true\"/>"
+    "        </property>"
+
 
     "        <signal name=\"NotificationHistoryRemoved\">"
     "            <arg name=\"id\"         type=\"u\"/>"

--- a/src/dbus.h
+++ b/src/dbus.h
@@ -21,6 +21,7 @@ void dbus_teardown(int id);
 void signal_notification_closed(struct notification *n, enum reason reason);
 void signal_action_invoked(const struct notification *n, const char *identifier);
 void signal_length_propertieschanged(void);
+void signal_paused_propertieschanged(void);
 void signal_history_removed(guint id);
 void signal_history_cleared(guint n);
 void signal_config_reloaded(char **const configs);

--- a/src/dunst.c
+++ b/src/dunst.c
@@ -184,6 +184,8 @@ gboolean pause_signal(gpointer data)
         dunst_status_int(S_PAUSE_LEVEL, MAX_PAUSE_LEVEL);
         wake_up();
 
+        signal_paused_propertieschanged();
+
         return G_SOURCE_CONTINUE;
 }
 
@@ -193,6 +195,8 @@ gboolean unpause_signal(gpointer data)
 
         dunst_status_int(S_PAUSE_LEVEL, 0);
         wake_up();
+
+        signal_paused_propertieschanged();
 
         return G_SOURCE_CONTINUE;
 }

--- a/src/dunst.h
+++ b/src/dunst.h
@@ -47,6 +47,8 @@ int dunst_main(int argc, char *argv[]);
 void usage(int exit_status);
 void print_version(void);
 
+gboolean pause_signal(gpointer data);
+gboolean unpause_signal(gpointer data);
 gboolean quit_signal(gpointer data);
 
 #endif

--- a/test/dbus.c
+++ b/test/dbus.c
@@ -1382,6 +1382,74 @@ TEST test_signal_length_propertieschanged(void)
         PASS();
 }
 
+TEST test_signal_paused_propertieschanged_pause(void)
+{
+        struct signal_propertieschanged sig = {NULL, NULL, NULL, -1};
+
+        dbus_signal_subscribe_propertieschanged(&sig);
+
+        pause_signal(NULL);
+
+        uint waiting = 0;
+
+        while(!sig.interface && waiting < 2000) {
+                usleep(500);
+                waiting++;
+        }
+
+        ASSERT_STR_EQ(sig.interface, DUNST_IFAC);
+
+        gboolean paused;
+        g_variant_lookup(sig.array_dict_sv_data, "paused", "b", &paused);
+
+        ASSERT_EQ(paused, TRUE);
+
+        guint32 pause_level;
+        g_variant_lookup(sig.array_dict_sv_data, "pauseLevel", "u", &pause_level);
+
+        ASSERT_EQ(pause_level, 100);
+
+        g_free(sig.interface);
+        g_variant_unref(sig.array_dict_sv_data);
+        g_variant_unref(sig.array_s_data);
+        dbus_signal_unsubscribe_propertieschanged(&sig);
+        PASS();
+}
+
+TEST test_signal_paused_propertieschanged_unpause(void)
+{
+        struct signal_propertieschanged sig = {NULL, NULL, NULL, -1};
+
+        dbus_signal_subscribe_propertieschanged(&sig);
+
+        unpause_signal(NULL);
+
+        uint waiting = 0;
+
+        while(!sig.interface && waiting < 2000) {
+                usleep(500);
+                waiting++;
+        }
+
+        ASSERT_STR_EQ(sig.interface, DUNST_IFAC);
+
+        gboolean paused;
+        g_variant_lookup(sig.array_dict_sv_data, "paused", "b", &paused);
+
+        ASSERT_EQ(paused, FALSE);
+
+        guint32 pause_level;
+        g_variant_lookup(sig.array_dict_sv_data, "pauseLevel", "u", &pause_level);
+
+        ASSERT_EQ(pause_level, 0);
+
+        g_free(sig.interface);
+        g_variant_unref(sig.array_dict_sv_data);
+        g_variant_unref(sig.array_s_data);
+        dbus_signal_unsubscribe_propertieschanged(&sig);
+        PASS();
+}
+
 TEST test_close_and_signal(void)
 {
         GVariant *data, *ret;
@@ -1660,6 +1728,8 @@ gpointer run_threaded_tests(gpointer data)
         RUN_TEST(test_close_and_signal);
         RUN_TEST(test_signal_actioninvoked);
         RUN_TEST(test_signal_length_propertieschanged);
+        RUN_TEST(test_signal_paused_propertieschanged_pause);
+        RUN_TEST(test_signal_paused_propertieschanged_unpause);
         RUN_TEST(test_timeout_overflow);
         RUN_TEST(test_override_dbus_timeout);
         RUN_TEST(test_match_dbus_timeout);


### PR DESCRIPTION
This PR fixes #832 , ensuring any applications listening to the pause state properties will always receive proper updates.

The introspection XML is also modified to advertise the changed signals for the *Length properties, which was missing before, and mentioned in the same issue.