### PR TITLE
minor typo in docs

### DIFF
--- a/docs/dunst.5.pod
+++ b/docs/dunst.5.pod
@@ -1114,7 +1114,7 @@ When the script is called details of the notification that triggered it will be
 passed via environment variables. The following variables are available:
 B<DUNST_APP_NAME>, B<DUNST_SUMMARY>, B<DUNST_BODY>, B<DUNST_ICON_PATH>,
 B<DUNST_URGENCY>, B<DUNST_ID>, B<DUNST_PROGRESS>, B<DUNST_CATEGORY>,
-B<DUNST_STACK_TAG>, B<DUNST_URLS>, B<DUNST_TIMEOUT>, B<DUNST_TIMESTAMP>, 
+B<DUNST_STACK_TAG>, B<DUNST_URLS>, B<DUNST_TIMEOUT>, B<DUNST_TIMESTAMP>,
 and B<DUNST_DESKTOP_ENTRY>.
 
 Another, less recommended way to get notifcations details from a script is via


### PR DESCRIPTION
Upon scripting inside my dunstrc I did encounter a little typo where this word was listed twice.