### PR TITLE
Add support for customColor for SVG icons

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -62,6 +62,7 @@ LDFLAGS_DEBUG  :=
 pkg_config_packs := gio-2.0 \
                     gdk-pixbuf-2.0 \
                     "glib-2.0 >= 2.44" \
+                    librsvg-2.0 \
                     pangocairo \
 
 ifneq (0,${WAYLAND})

--- a/docs/dunst.5.pod
+++ b/docs/dunst.5.pod
@@ -516,6 +516,27 @@ to set B<icon_theme> to the name of the theme you want. To enable this new
 behaviour, set B<enable_recursive_icon_lookup> to true in the I<[global]>
 section. See the respective settings for more details.
 
+=item B<svg_icon_stylesheet> (default: "path { fill: @foreground !important; }")
+
+This setting allows you to set a custom CSS stylesheet for SVG icons. This can
+be used to change the color of monochrome SVG icons to match the foreground
+color of the notification. The default stylesheet does exactly that. If you
+don't want any stylesheet to be applied, set this setting to an empty string.
+
+The following variables are available for use in the stylesheet:
+
+=over 4
+
+=item C<@foreground>
+
+The foreground color of the notification.
+
+=item C<@background>
+
+The background color of the notification.
+
+=back
+
 =item B<sticky_history> (values: [true/false], default: true)
 
 If set to true, notifications that have been recalled from history will not

--- a/dunstrc
+++ b/dunstrc
@@ -223,6 +223,9 @@
     # define all lookup paths.
     enable_recursive_icon_lookup = true
 
+    # CSS rules to apply to the SVG icons.
+    svg_icon_stylesheet = "path { fill: @foreground !important; }"
+
     # Set icon theme (only used for recursive icon lookup)
     icon_theme = Adwaita
     # You can also set multiple icon themes, with the leftmost one being used first.

--- a/src/icon.c
+++ b/src/icon.c
@@ -3,12 +3,12 @@
 #include <assert.h>
 #include <cairo.h>
 #include <gdk-pixbuf/gdk-pixbuf.h>
+#include <librsvg/rsvg.h>
 #include <stdbool.h>
 #include <string.h>
 #include <math.h>
 
 #include "log.h"
-#include "notification.h"
 #include "settings.h"
 #include "utils.h"
 #include "icon-lookup.h"
@@ -205,7 +205,7 @@ static char *get_id_from_data(const uint8_t *data_pb, size_t width, size_t heigh
         return id;
 }
 
-GdkPixbuf *get_pixbuf_from_file(const char *filename, char **id, int min_size, int max_size, double scale)
+cairo_surface_t *get_cairo_surface_from_file(const char *filename, char **id, struct color fg_color, int min_size, int max_size, double scale)
 {
         GError *error = NULL;
         gint w, h;
@@ -217,28 +217,74 @@ GdkPixbuf *get_pixbuf_from_file(const char *filename, char **id, int min_size, i
                 LOG_W("Failed to load image info for %s", STR_NN(filename));
                 return NULL;
         }
-        GdkPixbuf *pixbuf = NULL;
+
         // TODO immediately rescale icon upon scale changes
         icon_size_clamp(&w, &h, min_size, max_size);
-        pixbuf = gdk_pixbuf_new_from_file_at_scale(filename,
+        cairo_surface_t *icon_surface = cairo_image_surface_create(
+                        CAIRO_FORMAT_ARGB32,
                         round(w * scale),
-                        round(h * scale),
-                        TRUE,
-                        &error);
+                        round(h * scale)
+                );
+        const char *ext = strrchr(filename, '.');
+        if (ext && !strcmp(ext, ".svg")) {
+                RsvgHandle *handle = rsvg_handle_new_from_file(filename, &error);
+                const guint8 stylesheet[37];
+                const size_t stylesheet_len = sizeof(stylesheet) / sizeof(guint8);
+
+                g_snprintf((char*)stylesheet, stylesheet_len, "path { fill: #%02x%02x%02x%02x !important; }",
+                                (int)(fg_color.r * 255),
+                                (int)(fg_color.g * 255),
+                                (int)(fg_color.b * 255),
+                                (int)(fg_color.a * 255));
+                rsvg_handle_set_stylesheet(handle, stylesheet, stylesheet_len, &error);
+
+                cairo_t *cr = cairo_create(icon_surface);
+                RsvgRectangle viewport = {
+                        0,
+                        0,
+                        cairo_image_surface_get_width(icon_surface),
+                        cairo_image_surface_get_height(icon_surface)
+                };
+                rsvg_handle_render_document(handle, cr, &viewport, &error);
+                cairo_destroy(cr);
+                g_object_unref(handle);
+        } else {
+                GdkPixbuf *pixbuf = gdk_pixbuf_new_from_file_at_scale(filename,
+                                round(w * scale),
+                                round(h * scale),
+                                TRUE,
+                                &error);
+                icon_surface = gdk_pixbuf_to_cairo_surface(pixbuf);
+                g_object_unref(pixbuf);
+        }
 
         if (error) {
                 LOG_W("%s", error->message);
                 g_error_free(error);
         }
 
-        const uint8_t *data = gdk_pixbuf_get_pixels(pixbuf);
-        size_t rowstride = gdk_pixbuf_get_rowstride(pixbuf);
-        size_t n_channels = gdk_pixbuf_get_n_channels(pixbuf);
-        size_t bits_per_sample = gdk_pixbuf_get_bits_per_sample(pixbuf);
-        size_t pixelstride = (n_channels * bits_per_sample + 7)/8;
+        const uint8_t *data = cairo_image_surface_get_data(icon_surface);
+        size_t rowstride = cairo_image_surface_get_stride(icon_surface);
+
+        int pixelstride;
+        switch (cairo_image_surface_get_format(icon_surface)) {
+                case CAIRO_FORMAT_A8:
+                        pixelstride = 1;
+                        break;
+                case CAIRO_FORMAT_RGB24:
+                        pixelstride = 3;
+                        break;
+                case CAIRO_FORMAT_ARGB32:
+                        pixelstride = 4;
+                        break;
+                default:
+                        LOG_W("Unsupported cairo format %d", cairo_image_surface_get_format(icon_surface));
+                        cairo_surface_destroy(icon_surface);
+                        return NULL;
+        }
 
         *id = get_id_from_data(data, w, h, pixelstride, rowstride);
-        return pixbuf;
+        return icon_surface;
 }
 
 char *get_path_from_icon_name(const char *iconname, int size)

--- a/src/icon.h
+++ b/src/icon.h
@@ -13,14 +13,16 @@ cairo_surface_t *gdk_pixbuf_to_cairo_surface(GdkPixbuf *pixbuf);
  * @param filename A string representing a readable file path
  * @param id   (necessary) A unique identifier of the returned pixbuf.
  *             Only filled, if the return value is non-NULL.
+ * @param fg_color A string representing the desired foreground color in hex format.
+ * @param bg_color A string representing the desired background color in hex format.
  * @param min_size An iteger representing the desired minimum unscaled icon size.
  * @param max_size An iteger representing the desired maximum unscaled icon size.
  * @param scale An integer representing the output dpi scaling.
  *
- * @return an instance of `GdkPixbuf`
+ * @return an instance of `cairo_surface_t`
  * @retval NULL: file does not exist, not readable, etc..
  */
-cairo_surface_t *get_cairo_surface_from_file(const char *filename, char **id, struct color fg_color, int min_size, int max_size, double scale);
+cairo_surface_t *get_cairo_surface_from_file(const char *filename, char **id, const char *fg_color, const char *bg_color, int min_size, int max_size, double scale);
 
 
 /**

--- a/src/icon.h
+++ b/src/icon.h
@@ -4,7 +4,7 @@
 #include <cairo.h>
 #include <gdk-pixbuf/gdk-pixbuf.h>
 
-#include "notification.h"
+#include "draw.h"
 
 cairo_surface_t *gdk_pixbuf_to_cairo_surface(GdkPixbuf *pixbuf);
 
@@ -20,7 +20,7 @@ cairo_surface_t *gdk_pixbuf_to_cairo_surface(GdkPixbuf *pixbuf);
  * @return an instance of `GdkPixbuf`
  * @retval NULL: file does not exist, not readable, etc..
  */
-GdkPixbuf *get_pixbuf_from_file(const char *filename, char **id, int min_size, int max_size, double scale);
+cairo_surface_t *get_cairo_surface_from_file(const char *filename, char **id, struct color fg_color, int min_size, int max_size, double scale);
 
 
 /**

--- a/src/notification.c
+++ b/src/notification.c
@@ -15,17 +15,14 @@
 #include <unistd.h>
 
 #include "dbus.h"
-#include "dunst.h"
 #include "icon.h"
 #include "log.h"
 #include "markup.h"
 #include "menu.h"
-#include "queues.h"
 #include "rules.h"
 #include "settings.h"
 #include "utils.h"
 #include "draw.h"
-#include "icon-lookup.h"
 #include "settings_data.h"
 
 static void notification_extract_urls(struct notification *n);
@@ -374,13 +371,12 @@ void notification_icon_replace_path(struct notification *n, const char *new_icon
         g_free(n->icon_path);
         n->icon_path = get_path_from_icon_name(new_icon, n->min_icon_size);
         if (n->icon_path) {
-                GdkPixbuf *pixbuf = get_pixbuf_from_file(n->icon_path, &n->icon_id,
-                                n->min_icon_size, n->max_icon_size,
+                cairo_surface_t *icon_surface = get_cairo_surface_from_file(n->icon_path, &n->icon_id,
+                                n->colors.fg, n->min_icon_size, n->max_icon_size,
                                 draw_get_scale());
-                if (pixbuf) {
-                        n->icon = gdk_pixbuf_to_cairo_surface(pixbuf);
+                if (icon_surface) {
+                        n->icon = icon_surface;
                         n->icon_time = time_now();
-                        g_object_unref(pixbuf);
                 } else {
                         LOG_W("Failed to load icon from path: '%s'", n->icon_path);
                 }

--- a/src/notification.c
+++ b/src/notification.c
@@ -371,9 +371,10 @@ void notification_icon_replace_path(struct notification *n, const char *new_icon
         g_free(n->icon_path);
         n->icon_path = get_path_from_icon_name(new_icon, n->min_icon_size);
         if (n->icon_path) {
+                char fg_color[10], bg_color[10];
                 cairo_surface_t *icon_surface = get_cairo_surface_from_file(n->icon_path, &n->icon_id,
-                                n->colors.fg, n->min_icon_size, n->max_icon_size,
-                                draw_get_scale());
+                                color_to_string(n->colors.fg, fg_color), color_to_string(n->colors.bg, bg_color),
+                                n->min_icon_size, n->max_icon_size, draw_get_scale());
                 if (icon_surface) {
                         n->icon = icon_surface;
                         n->icon_time = time_now();

--- a/src/settings.c
+++ b/src/settings.c
@@ -7,18 +7,15 @@
 #include "settings.h"
 
 #include <dirent.h>
-#include <errno.h>
 #include <fnmatch.h>
 #include <glib.h>
 #include <stdio.h>
 #include <string.h>
 
-#include "dunst.h"
 #include "log.h"
 #include "notification.h"
 #include "option_parser.h"
 #include "ini.h"
-#include "rules.h"
 #include "utils.h"
 #include "output.h"
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -146,6 +146,7 @@ struct settings {
         enum vertical_alignment vertical_alignment;
         char **icon_theme; // experimental
         bool enable_recursive_icon_lookup; // experimental
+        char *svg_icon_stylesheet;
         bool enable_regex; // experimental
         char *icon_path;
         enum follow_mode f_mode;

--- a/src/settings_data.h
+++ b/src/settings_data.h
@@ -1354,6 +1354,16 @@ static const struct setting allowed_settings[] = {
                 .different_default = true,
         },
         {
+                .name = "svg_icon_stylesheet",
+                .section = "global",
+                .description = "CSS stylesheet to use for SVG icons",
+                .type = TYPE_STRING,
+                .default_value = "path { fill: @foreground !important; }",
+                .value = &settings.svg_icon_stylesheet,
+                .parser = NULL,
+                .parser_data = NULL,
+        },
+        {
                 .name = "enable_posix_regex",
                 .section = "global",
                 .description = "Enable POSIX regex for filtering rules",


### PR DESCRIPTION
This commit implements customColor styling for SVG icons using librsvg. This is a rebased version of #1081 as `master` had changed quite a lot from that branch.