### PR TITLE
Add implementation for systemctl service reloading

### DIFF
--- a/dunst.systemd.service.in
+++ b/dunst.systemd.service.in
@@ -7,4 +7,5 @@ PartOf=graphical-session.target
 Type=dbus
 BusName=org.freedesktop.Notifications
 ExecStart=@bindir@/dunst
+ExecReload=@bindir@/dunstctl reload
 Slice=session.slice


### PR DESCRIPTION
While a reload mechanism is already in place, it has not been hooked up to systemd's service reloading.
With this change, it's possible to reload configs using `systemctl --user reload dunst`.