### PR TITLE
Reference override_pause_level in RULES modify section

### DIFF
--- a/docs/dunst.5.pod
+++ b/docs/dunst.5.pod
@@ -1021,6 +1021,10 @@ B<IMPORTANT NOTE>: This currently DOES NOT re-apply the attributes from the
 urgency_* sections. The changed urgency will only be visible in rules defined
 later. Use C<msg_urgency> to match it.
 
+=item C<override_pause_level>
+
+See B<override_pause_level>.
+
 =item C<skip_display>
 
 Setting this to true will prevent the notification from being displayed


### PR DESCRIPTION
The RULES section says

    The following attributes can be overridden:

which I interpret as meaning that _only_ the attributes listed in this section can be modified by a rule, but override_pause_level can also be set.

This adds a reference to the documentation of `override_pause_level` that exists in the General section.