### PR TITLE
Add ordering after graphical-session.target

### DIFF
--- a/dunst.systemd.service.in
+++ b/dunst.systemd.service.in
@@ -2,6 +2,7 @@
 Description=Dunst notification daemon
 Documentation=man:dunst(1)
 PartOf=graphical-session.target
+After=graphical-session.target
 
 [Service]
 Type=dbus


### PR DESCRIPTION
Otherwise it just fails before `WAYLAND_DISPLAY` is available.