### PR TITLE
Use only state to check fullscreen when no configured output is set

### DIFF
--- a/src/wayland/wl.c
+++ b/src/wayland/wl.c
@@ -804,10 +804,12 @@ bool wl_have_fullscreen_window(void) {
                                         TOPLEVEL_STATE_ACTIVATED))
                         continue;
 
+                if(output_name == UINT32_MAX)
+                        return true;
+
                 struct toplevel_output *pos;
                 wl_list_for_each(pos, &toplevel->output_list, link) {
-                        if (output_name == UINT32_MAX ||
-                                        pos->dunst_output->global_name ==
+                        if (pos->dunst_output->global_name ==
                                         output_name) {
                                 return true;
                         }


### PR DESCRIPTION
This patch only affects "fullscreen" option under wayland.
It seems that tracking window outputs via```foreign_toplevel.output_enter``` is not appropriate while ```foreign_toplevel.state``` rigorously tracks active(focused)/fullscreen state.
Some compositors (wlroots/sway in my case) consider that a window starting fullscreen does not "become" visible, it already is. So foreign_toplevel.output_enter is not sent if the window starts in fullscreen. 
That's a problem as toplevel->output_list ends up empty and ```wl_have_fulscreen_window``` returns false even if the window is "active" and "fullscreen". 
This patch keeps the behavior if a configured output is set.

Here's an example with "mpv --fullscreen"
```
[3776372.004] {Default Queue} zwlr_foreign_toplevel_manager_v1#3.toplevel(new id zwlr_foreign_toplevel_handle_v1#4278190093)
[3776372.018] {Default Queue} zwlr_foreign_toplevel_handle_v1#4278190093.title("1.mkv - mpv")
[3776372.022] {Default Queue} zwlr_foreign_toplevel_handle_v1#4278190093.state(array[4])       -- mpv active
[3776372.024] {Default Queue} zwlr_foreign_toplevel_handle_v1#4278190094.state(array[0])       -- previous window -> not active
[3776372.027] {Default Queue} zwlr_foreign_toplevel_handle_v1#4278190093.state(array[8])       -- mpv fullscreen
[3776372.029] {Default Queue} zwlr_foreign_toplevel_handle_v1#4278190093.app_id("mpv")
[3776372.031] {Default Queue} zwlr_foreign_toplevel_handle_v1#4278190093.done()
[3776372.052] {Default Queue}  -> wl_display#1.sync(new id wl_callback#19)
[3776372.056] {Default Queue} zwlr_foreign_toplevel_handle_v1#4278190094.done()
[3776372.462] {Display Queue} wl_display#1.delete_id(19)
[3776372.481] {Default Queue} wl_callback#19.done(28834)
 --- toplevel->output_list is empty here, wl_have_fulscreen_window always false before this patch, notification are always displayed :(
 --- Press f to unfullscreen mpv
[3781447.916] {Default Queue} zwlr_foreign_toplevel_handle_v1#4278190093.state(array[4])
[3781447.951] {Default Queue} zwlr_foreign_toplevel_handle_v1#4278190093.done()
[3781448.025] {Default Queue}  -> wl_display#1.sync(new id wl_callback#19)
[3781448.095] {Display Queue} wl_display#1.delete_id(19)
[3781448.106] {Default Queue} wl_callback#19.done(28836)
[3781458.333] {Default Queue} zwlr_foreign_toplevel_handle_v1#4278190093.output_enter(wl_output#10)   -- output_enter finally ! fills toplevel->output_list
[3781458.349] {Default Queue} zwlr_foreign_toplevel_handle_v1#4278190093.done()
 --- Press f to fullscreen mpv
 --- before and after this patch, notification visibility depends on fullscreen option
[3787032.504] {Default Queue} zwlr_foreign_toplevel_handle_v1#4278190093.state(array[8])
[3787032.546] {Default Queue} zwlr_foreign_toplevel_handle_v1#4278190093.done()
[3787032.638] {Default Queue}  -> wl_display#1.sync(new id wl_callback#19)
[3787032.730] {Display Queue} wl_display#1.delete_id(19)
[3787032.742] {Default Queue} wl_callback#19.done(28839)
[3793144.609] {Default Queue} zwlr_foreign_toplevel_handle_v1#4278190093.state(array[4])
[3793144.645] {Default Queue} zwlr_foreign_toplevel_handle_v1#4278190088.state(array[4])
[3793144.656] {Default Queue} zwlr_foreign_toplevel_handle_v1#4278190093.done()
[3793144.729] {Default Queue}  -> wl_display#1.sync(new id wl_callback#19)
[3793144.742] {Default Queue} zwlr_foreign_toplevel_handle_v1#4278190088.done()
[3793144.874] {Display Queue} wl_display#1.delete_id(19)
[3793144.884] {Default Queue} wl_callback#19.done(28844)
[3793777.390] {Default Queue} zwlr_foreign_toplevel_handle_v1#4278190088.state(array[0])
[3793777.428] {Default Queue} zwlr_foreign_toplevel_handle_v1#4278190093.state(array[8])
[3793777.439] {Default Queue} zwlr_foreign_toplevel_handle_v1#4278190088.done()
[3793777.455] {Default Queue} zwlr_foreign_toplevel_handle_v1#4278190093.done()
[3793777.540] {Default Queue}  -> wl_display#1.sync(new id wl_callback#19)
[3793777.872] {Display Queue} wl_display#1.delete_id(19)
[3793777.906] {Default Queue} wl_callback#19.done(28848)
[3793963.593] {Default Queue} zwlr_foreign_toplevel_handle_v1#4278190093.closed()
[3793963.630] {Default Queue}  -> zwlr_foreign_toplevel_handle_v1#4278190093.destroy()
[3810540.442] {Default Queue} zwlr_foreign_toplevel_handle_v1#4278190088.state(array[4])
[3810540.480] {Default Queue} zwlr_foreign_toplevel_handle_v1#4278190088.done()
```