### PR TITLE
Use unix timestamp in dbus history

### DIFF
--- a/src/dbus.c
+++ b/src/dbus.c
@@ -404,7 +404,7 @@ static void dbus_cb_dunst_NotificationListHistory(GDBusConnection *connection,
                         g_variant_new_string(default_action_name));
                 g_variant_builder_add(&n_builder, "{sv}", "icon_path", g_variant_new_string(icon_path));
                 g_variant_builder_add(&n_builder, "{sv}", "id", g_variant_new_int32(n->id));
-                g_variant_builder_add(&n_builder, "{sv}", "timestamp", g_variant_new_int64(n->timestamp));
+                g_variant_builder_add(&n_builder, "{sv}", "timestamp", g_variant_new_int64(n->real_timestamp));
                 g_variant_builder_add(&n_builder, "{sv}", "timeout", g_variant_new_int64(n->timeout));
                 g_variant_builder_add(&n_builder, "{sv}", "progress", g_variant_new_int32(n->progress));
                 g_variant_builder_add(&n_builder, "{sv}", "urgency", g_variant_new_string(urgency));

--- a/src/notification.c
+++ b/src/notification.c
@@ -456,6 +456,7 @@ struct notification *notification_create(void)
         n->format = g_strdup(settings.format);
 
         n->timestamp = time_monotonic_now();
+        n->real_timestamp = time_now();
 
         n->urgency = URG_NORM;
         n->timeout = -1;

--- a/src/notification.h
+++ b/src/notification.h
@@ -76,7 +76,8 @@ struct notification {
         bool receiving_raw_icon; /**< Still waiting for raw icon to be received */
 
         gint64 start;      /**< begin of current display (in milliseconds) */
-        gint64 timestamp;  /**< arrival time (in milliseconds) */
+        gint64 timestamp;  /**< monotonic arrival time (in milliseconds) */
+        gint64 real_timestamp;  /**< real arrival time (unix epoch) */
         gint64 timeout;    /**< time to display (in milliseconds) */
         gint64 dbus_timeout; /**< time to display (in milliseconds) (set by dbus) */
         int locked;     /**< If non-zero the notification is locked **/

--- a/test/dbus.c
+++ b/test/dbus.c
@@ -691,7 +691,7 @@ TEST test_dbus_cb_dunst_Properties_Set_pause_level(void)
 TEST test_dbus_cb_dunst_NotificationListHistory(void)
 {
         struct notification *n = notification_create();
-        gint64 timestamp1 = n->timestamp;
+        gint64 timestamp1 = n->real_timestamp;
         n->appname = g_strdup("dunstify");
         n->summary = g_strdup("Testing");
         n->urgency = 2;
@@ -701,7 +701,7 @@ TEST test_dbus_cb_dunst_NotificationListHistory(void)
         queues_history_push(n);
 
         n = notification_create();
-        gint64 timestamp2 = n->timestamp;
+        gint64 timestamp2 = n->real_timestamp;
         n->appname = g_strdup("notify-send");
         n->summary = g_strdup("More testing");
         n->urgency = 0;


### PR DESCRIPTION
As asked in #1526 and  #1019, expose a "sensical" timestamp to users. 
This will break things and I will not pull it as is.
A clearer distinction between monotonic and real timestamp is probably needed