### PR TITLE
Add support for PCRE

### DIFF
--- a/docs/dunst.5.pod
+++ b/docs/dunst.5.pod
@@ -717,6 +717,12 @@ This setting is currently implemented only for X11.
 Pause notification timeout when hovering with the mouse pointer.
 This setting is currently implemented only for Wayland.
 
+=item B<enable_pcre_regex> (default: false)
+
+Use PCRE regular expressions for filtering rules.
+For more information see https://en.wikipedia.org/wiki/Perl_Compatible_Regular_Expressions.
+This setting overrides B<enable_posix_regex>.
+
 =back
 
 =head1 DUNSTCTL

--- a/docs/dunst.5.pod
+++ b/docs/dunst.5.pod
@@ -815,6 +815,7 @@ For filtering rules that filter based on strings you can use regular
 expressions. It's recommended to set B<enable_posix_regex> to true. You can then
 use the POSIX Extended Regular Expression syntax:
 https://en.m.wikibooks.org/wiki/Regular_Expressions/POSIX-Extended_Regular_Expressions.
+Eventually B<enable_posix_regex> will be enabled by default.
 
 A matching rule is made by assigning a filter attribute to the value you want to match.
 Shell-like globbing is supported when matching values.

--- a/dunstrc
+++ b/dunstrc
@@ -217,6 +217,13 @@
     # Display indicators for URLs (U) and actions (A).
     show_indicators = yes
 
+    # When set to true (recommended), you can use POSIX regular expressions for filtering rules.
+    # If this is set to false (not recommended), dunst will use fnmatch(3) for matching strings.
+    # Dunst doesn't pass any flags to fnmatch, so you cannot make use of extended patterns.
+    #
+    # Note that this will eventually be true by default.
+    enable_posix_regex = false
+
     ### Icons ###
 
     # Recursive icon lookup. You can set a single theme, instead of having to
@@ -346,6 +353,9 @@
     # Only works on Wayland.
     pause_on_mouse_over = false
 
+    # Use PCRE regular expressions for filtering rules.
+    # This setting overrides enable_posix_regex.
+    enable_pcre_regex = false
 
 [urgency_low]
     # IMPORTANT: colors have to be defined in quotation marks.

--- a/src/rules.c
+++ b/src/rules.c
@@ -273,16 +273,35 @@ void rule_free(struct rule *r)
 
 static inline bool rule_field_matches_string(const char *value, const char *pattern)
 {
-        if (settings.enable_regex) {
-                if (!pattern) {
-                        return true;
-                }
-                if (!value) {
+        // Always match empty pattern
+        if (!pattern)
+                return true;
+
+        // Never match null value
+        if (!value)
+                return false;
+
+        // Use GLib wrapper for PCRE
+        if (settings.enable_pcre) {
+                GError *error = NULL;
+
+                // TODO: When caching regex use G_REGEX_OPTIMIZE
+                GRegex *regex = g_regex_new(pattern, 0, 0, &error);
+                if (error) {
+                        LOG_W("Invalid PCRE Regex '%s': %s", pattern, error->message);
+                        g_error_free(error);
                         return false;
                 }
-                regex_t     regex;
 
-                // TODO compile each regex only once
+                bool matched = g_regex_match(regex, value, 0, NULL);
+                g_regex_unref(regex);
+                return matched;
+        }
+
+        if (settings.enable_regex) {
+                regex_t regex;
+
+                // TODO: Compile each regex only once
                 int err = regcomp(&regex, pattern, REG_NEWLINE | REG_EXTENDED | REG_NOSUB);
                 if (err) {
                         size_t err_size = regerror(err, &regex, NULL, 0);
@@ -301,9 +320,10 @@ static inline bool rule_field_matches_string(const char *value, const char *patt
                 }
                 regfree(&regex);
                 return false;
-        } else {
-                return !pattern || (value && !fnmatch(pattern, value, 0));
         }
+
+        // Fallback to fnmatch if no regex is enabled
+        return !fnmatch(pattern, value, 0);
 }
 
 /*

--- a/src/settings.h
+++ b/src/settings.h
@@ -103,7 +103,7 @@ struct position {
 
 struct settings {
         bool print_notifications;
-        bool per_monitor_dpi;
+        bool per_monitor_dpi; // experimental
         bool stack_duplicates;
         bool hide_duplicate_count;
         char *font;
@@ -146,7 +146,8 @@ struct settings {
         enum vertical_alignment vertical_alignment;
         char **icon_theme; // experimental
         bool enable_recursive_icon_lookup; // experimental
-        bool enable_regex; // experimental
+        bool enable_regex;
+        bool enable_pcre; // experimental
         char *icon_path;
         enum follow_mode f_mode;
         bool always_run_script;

--- a/src/settings_data.h
+++ b/src/settings_data.h
@@ -1374,6 +1374,16 @@ static const struct setting allowed_settings[] = {
                 .parser_data = boolean_enum_data,
         },
         {
+                .name = "enable_pcre_regex",
+                .section = "experimental",
+                .description = "Use PCRE regex for filtering rules (overrides enable_posix_regex)",
+                .type = TYPE_CUSTOM,
+                .default_value = "false",
+                .value = &settings.enable_pcre,
+                .parser = string_parse_bool,
+                .parser_data = boolean_enum_data,
+        },
+        {
                 .name = "frame_width",
                 .section = "global",
                 .description = "Width of frame around the window",


### PR DESCRIPTION
Glib exposes PCRE with GRegex. Since we already have the library lying around we might as well use it