### PR TITLE
Run script for duplicate notifications

### DIFF
--- a/src/queues.c
+++ b/src/queues.c
@@ -240,7 +240,7 @@ static bool queues_stack_duplicate(struct notification *new)
 
                                 /* If the progress differs, probably notify-send was used to update the notification
                                  * So only count it as a duplicate, if the progress was the same.
-                                 * */
+                                 */
                                 if (old->progress == new->progress) {
                                         old->dup_count++;
                                 } else {
@@ -251,8 +251,11 @@ static bool queues_stack_duplicate(struct notification *new)
                                 new->dup_count = old->dup_count;
                                 signal_notification_closed(old, 1);
 
-                                if (allqueues[i] == displayed)
+                                /* Run script if the duplicate notification is already displayed */
+                                if (allqueues[i] == displayed) {
                                         new->start = time_monotonic_now();
+                                        notification_run_script(new);
+                                }
 
                                 notification_unref(old);
                                 return true;
@@ -300,6 +303,7 @@ static bool queues_stack_by_tag(struct notification *new)
 
                                 signal_notification_closed(old, 1);
 
+                                /* Run script if the stacked notification is already displayed */
                                 if (allqueues[i] == displayed) {
                                         new->start = time_monotonic_now();
                                         notification_run_script(new);


### PR DESCRIPTION
Update `queues_stack_duplicate` to run scripts. Closes #1115

Basically the same as `queues_stack_by_tag` line 305.
```c
                                if (allqueues[i] == displayed) {
                                        new->start = time_monotonic_now();
                                        notification_run_script(new);
                                }
```

TODO: Add some way to test if a script was run or not 

---

Please check all the boxes that apply:

- [ ] I have read the contribution guidelines in [CONTRIBUTING](https://github.com/dunst-project/dunst/blob/master/CONTRIBUTING.md) guide.
- [ ] I have added documentation for new features (if applicable).
- [ ] I have added tests for new features (if applicable).
- [ ] I have used the assistance of AI/LLM tools (not forbidden, but please disclose).
- [ ] The new code successfully builds locally (`make all` shows no error).
- [ ] The new code successfully passes the test suite (`make test` shows no error).
