### PR TITLE
[fix]: zsh completion bug

### DIFF
--- a/completions/_dunstify.zshcomp
+++ b/completions/_dunstify.zshcomp
@@ -33,7 +33,7 @@ case $state in
       {-I,--raw-icon}"[Path to the icon to be sent as raw image data]" \
       {-c,--category}"[The category of this notification]" \
       {-h,--hint}"[User specified hints]" \
-      {--stack-tag}"[Dunst specific stack tag]" \
+      --stack-tag"[Dunst specific stack tag]" \
       {-r,--replace-id}"[Set id of this notification]" \
       {-A,--action}"[Actions the user can invoke]" \
       {-C,--close}"[Close the notification with the specified ID]"
@@ -41,7 +41,7 @@ case $state in
 
   (params)
     case $line[1] in
-      -u)
+      -u|--urgency)
         local -a urgency;
         urgency=(
           "low"


### PR DESCRIPTION
{--stack-tag} --> --stack-tag
           (you can't but {} braces around a single item in zsh)
-u) --> -u|--urgency) 
         (to also give completion to the long form)

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have read the contribution guidelines in [CONTRIBUTING](https://github.com/dunst-project/dunst/blob/master/CONTRIBUTING.md) guide.
- [ ] I have added documentation for new features (if applicable).
- [ ] I have added tests for new features (if applicable).
- [ ] I have used the assistance of AI/LLM tools (not forbidden, but please disclose).
- [x] The new code successfully builds locally (`make all` shows no error).
- [x] The new code successfully passes the test suite (`make test` shows no error).
