### PR TITLE
Add wayland layer shell namespace reference to config man page

### DIFF
--- a/docs/dunst.5.pod
+++ b/docs/dunst.5.pod
@@ -777,7 +777,8 @@ do anything about that behavior.
 
 Note that dunst creates a "desktop layer" using the layer shell protocol and not
 a regular Wayland window. This has some limitations like stated above.
-For example you can't set a window title/class.
+For example you can't set a window title/class. Some compositors can access the
+layer through its namespace "notifications".
 
 =head1 RULES
 


### PR DESCRIPTION
Added a reference to the layer shell namespace name for Wayland.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have read the contribution guidelines in [CONTRIBUTING](https://github.com/dunst-project/dunst/blob/master/CONTRIBUTING.md) guide.
- [x] I have added documentation for new features (if applicable).
- [x] I have added tests for new features (if applicable).
- [ ] I have used the assistance of AI/LLM tools (not forbidden, but please disclose).
- [x] The new code successfully builds locally (`make all` shows no error).
- [x] The new code successfully passes the test suite (`make test` shows no error).
